### PR TITLE
Change avatar modification to use  instead of

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1356,27 +1356,9 @@ function dokan_get_avatar_url( $url, $id_or_email, $args ) {
         return $url;
     }
 
-    try {
-        /**
-         * Trying to get from exact size
-         */
-        if(!isset($args['width']) || !isset($args['height'])){
-            throw new Exception("Image size not provided");
-        }
-
-        $avatar_src = wp_get_attachment_image_src( $gravatar_id, array(
-            'width' => $args['width'],
-            'height' => $args['height'],
-        ) );
-
-        if(isset($avatar_src[0])){
-            throw new Exception("Image url not found from wp_attachment_image_src");
-        }
-        
-        $dokan_avatar_url = $avatar_src[0];
-            
-    } catch (Exception $e) {
-        $dokan_avatar_url = wp_get_attachment_thumb_url( $gravatar_id );
+    $dokan_avatar_url = wp_get_attachment_thumb_url( $gravatar_id );
+    if(empty($dokan_avatar_url)){
+        return $url;
     }
 
     return esc_url( $dokan_avatar_url );


### PR DESCRIPTION
I think better to use `get_avatar_url` hook instead of `get_avatar`, so when a user or theme calls `get_avatar_url()` function that will return our modification url. 
This would work well for `get_avatar()` function.

@see https://github.com/WordPress/WordPress/blob/master/wp-includes/pluggable.php#L2497