### PR TITLE
check if seller can add more product

### DIFF
--- a/includes/product-functions.php
+++ b/includes/product-functions.php
@@ -18,6 +18,11 @@
  */
 function dokan_save_product( $args ) {
 
+    $errors = array();
+    $errors = apply_filters( 'dokan_can_add_product', $errors );
+    
+    if ( ! empty( $errors ) ) return;
+
     $defaults = array(
         'post_title'     => '',
         'post_content'   => '',


### PR DESCRIPTION
As the subscription module has checking whether a seller can add product or not based on dokan_can_add_product filter.. that's why I've applied the same filter in the dokan_save_product function. 

NB. We are doing this cause clicking on create & add new button making an ajax request and template is not redirecting here.. 
This happens when we just click create product button.. handle_all_submit function is called on template_redirect action.. which is not happening for the create& add new button...