### PR TITLE
Shortcode is not working is fixed #137

### DIFF
--- a/classes/template-shortcodes.php
+++ b/classes/template-shortcodes.php
@@ -193,6 +193,8 @@ class Dokan_Template_Shortcodes {
      * @return string
      */
     function my_orders_page() {
+        if ( ! is_user_logged_in() ) return;
+        
         return dokan_get_template_part( 'my-orders' );
     }
 }

--- a/dokan.php
+++ b/dokan.php
@@ -334,7 +334,6 @@ final class WeDevs_Dokan {
         $this->container['product']  = new Dokan_Product_Manager();
 
         if ( is_user_logged_in() ) {
-            Dokan_Template_Shortcodes::init();
             Dokan_Template_Main::init();
             Dokan_Template_Dashboard::init();
             Dokan_Template_Products::init();
@@ -343,10 +342,11 @@ final class WeDevs_Dokan {
             Dokan_Template_Settings::init();
         }
 
+        Dokan_Template_Shortcodes::init();
+
         if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
             Dokan_Ajax::init()->init_ajax();
         }
-        // print_r( dokan()->vendor->get_total() );
     }
 
     /**


### PR DESCRIPTION
The shortcode class Dokan_Template_Shortcodes was inside the is_user_logged_in() function that's why the "dokan-best-selling-product" shortcode wasn't working when the user is not logged in.

And also I returned early for this dokan-my-orders shortcode as the main Dokan_Template_Shortcodes class is outside the is_user_logged_in() function.