### PR TITLE
feat(*): Adding filter dokan_get_seller_amount_from_order_array

### DIFF
--- a/includes/order-functions.php
+++ b/includes/order-functions.php
@@ -31,7 +31,7 @@ function dokan_get_seller_amount_from_order( $order_id, $get_array = false ) {
             $amount['tax']      = $order_tax;
         }
 
-        return $amount;
+        return apply_filters( 'dokan_get_seller_amount_from_order_array', $amount, $order, $seller_id );
     }
 
 


### PR DESCRIPTION
feat(*): Adding filter dokan_get_seller_amount_from_order_array

Allow third party plug-ins to correct the individual amount of shipping and tax. Will help correct Dokan Pro's statement table adding shipping twice to the balance as well.