### PR TITLE
fix typo - all the instance of Dahsboard to Dashboard

### DIFF
--- a/assets/js/dokan.js
+++ b/assets/js/dokan.js
@@ -688,7 +688,7 @@ jQuery(function($) {
                         $.magnificPopup.close();
                         window.location.href = resp.data;
                     } else {
-                        $('.dokan-dahsboard-product-listing-wrapper').load( window.location.href + ' table.product-listing-table' );
+                        $('.dokan-dashboard-product-listing-wrapper').load( window.location.href + ' table.product-listing-table' );
                         $.magnificPopup.close();
                         Dokan_Editor.openProductPopup();
                     }

--- a/assets/src/js/product-editor.js
+++ b/assets/src/js/product-editor.js
@@ -231,7 +231,7 @@
                         $.magnificPopup.close();
                         window.location.href = resp.data;
                     } else {
-                        $('.dokan-dahsboard-product-listing-wrapper').load( window.location.href + ' table.product-listing-table' );
+                        $('.dokan-dashboard-product-listing-wrapper').load( window.location.href + ' table.product-listing-table' );
                         $.magnificPopup.close();
                         Dokan_Editor.openProductPopup();
                     }

--- a/classes/template-withdraw.php
+++ b/classes/template-withdraw.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Dokan Dahsboard Withdraw class
+ * Dokan Dashboard Withdraw class
  *
  * @author weDevs
  *

--- a/templates/dashboard/dashboard.php
+++ b/templates/dashboard/dashboard.php
@@ -2,7 +2,7 @@
 /**
  *  Dokan Dashboard Template
  *
- *  Dokan Main Dahsboard template for Fron-end
+ *  Dokan Main Dashboard template for Fron-end
  *
  *  @since 2.4
  *

--- a/templates/dashboard/edit-account.php
+++ b/templates/dashboard/edit-account.php
@@ -2,7 +2,7 @@
 /**
  *  Dokan Dashboard Template
  *
- *  Dokan Main Dahsboard template for Front-end
+ *  Dokan Main Dashboard template for Front-end
  *
  *  @since 2.5
  *

--- a/templates/dashboard/orders-widget.php
+++ b/templates/dashboard/orders-widget.php
@@ -1,6 +1,6 @@
 <?php
 /**
- *  Dahsboard Widget Template
+ *  Dashboard Widget Template
  *
  *  Get dokan dashboard widget template
  *

--- a/templates/dashboard/sales-chart-widget.php
+++ b/templates/dashboard/sales-chart-widget.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- *  Dokan Dahsboard Template
+ *  Dokan Dashboard Template
  *
  *  Dokan Dashboard Sales chart report widget
  *

--- a/templates/global/no-permission.php
+++ b/templates/global/no-permission.php
@@ -2,7 +2,7 @@
 /**
  *  Dokan Dashboard Template
  *
- *  Dokan Main Dahsboard template for Fron-end
+ *  Dokan Main Dashboard template for Fron-end
  *
  *  @since 2.4
  *

--- a/templates/orders/orders-status-filter.php
+++ b/templates/orders/orders-status-filter.php
@@ -1,6 +1,6 @@
 <?php
 /**
- *  Dokan Dahsboard Template
+ *  Dokan Dashboard Template
  *
  *  Dokan Dashboard order status filter template
  *

--- a/templates/products/listing-filter.php
+++ b/templates/products/listing-filter.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Dokan Dahsboard Product Listing
+ * Dokan Dashboard Product Listing
  * filter template
  *
  * @since 2.4

--- a/templates/products/listing-status-filter.php
+++ b/templates/products/listing-status-filter.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Dokan Dahsboard Product Listing status filter
+ * Dokan Dashboard Product Listing status filter
  * Template
  *
  * @since 2.4

--- a/templates/products/products-listing.php
+++ b/templates/products/products-listing.php
@@ -56,7 +56,7 @@
                     <?php dokan_product_listing_filter(); ?>
                 </div>
 
-                <div class="dokan-dahsboard-product-listing-wrapper">
+                <div class="dokan-dashboard-product-listing-wrapper">
                     <table class="dokan-table dokan-table-striped product-listing-table">
                         <thead>
                             <tr>

--- a/templates/withdraw/header.php
+++ b/templates/withdraw/header.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Dokan Dahsboard Withdra Header Template
+ * Dokan Dashboard Withdra Header Template
  *
  * @since 2.4
  *


### PR DESCRIPTION
Fixed typos in the files where it was Dahsboard instead of Dashboard.