### PR TITLE
fix(total_sales_count): the total sales for each product calculates twice when purchased from multiple vendor is fixed #249

### DIFF
--- a/includes/class-order-manager.php
+++ b/includes/class-order-manager.php
@@ -209,6 +209,9 @@ class Dokan_Order_Manager {
 
         if ( $order_id && !is_wp_error( $order_id ) ) {
 
+            // update total_sales count for sub-order
+            wc_update_total_sales_counts( $order_id );
+
             // update author as vendor
             wp_update_post( array(
                 'post_author' => $seller_id,


### PR DESCRIPTION
The issue was when a sub order is created the total_sales count is increased by twice and when the order status is changed to on-hold, processing or completed, the total_sales count again increased by twice.

Reason: When there is a change of order status WooCommerce does update 'total_sales' post meta by order quantity and also keep track whether it has been recorded into database or not by using '_recorded_sales' post meta.

In dokan when an order is placed with products from multi-vendors it creates sub-orders. WooCommerce updates the 'total_sales' post meta for the parent order only and when there is a change of order status of sub order it does update 'total_sales' post meta again cause it didn't update 'total_sales' and '_recorded_sales' post meta.