### PR TITLE
fix(admin): error loading some admin pages content

### DIFF
--- a/src/utils/Api.js
+++ b/src/utils/Api.js
@@ -28,7 +28,7 @@ class Dokan_API  {
     // jQuery ajax wrapper
     ajax(path, method, headers, data) {
 
-        return $.ajax({
+        return ($ || jQuery).ajax({
             url: this.endpoint() + path,
             beforeSend: function ( xhr ) {
                 xhr.setRequestHeader( 'X-WP-Nonce', window.dokan.rest.nonce );


### PR DESCRIPTION
On Wordpress 4.7 some admin pages like 'Dashboard' and 'Help' can't load content because of jQuery reference '$' is undefined. For example, loading 'Help' page leads to error in browser console:

```
[Error] [Vue warn]: Error in created hook: "TypeError: undefined is not an object (evaluating '$.ajax')"

found in

---> <Help> at src/admin/pages/Help.vue
       <App> at src/admin/App.vue
         <Root>
[Error] TypeError: undefined is not an object (evaluating '$.ajax') — vue-bootstrap.js:554
```

and prevents loading content. Same for other pages using Api.js (vue-bootstrap.js). 

For Wordpress 4.9 current code works fine. But it is not always possible to quick update WP to 4.9 by different reasons. 

This patch allows some admin pages works on 4.7 version of Wordpress too.