### PR TITLE
Added $post_id parameter to dokan_product_edit_after_options action

### DIFF
--- a/templates/products/new-product-single.php
+++ b/templates/products/new-product-single.php
@@ -619,7 +619,7 @@ if ( ! $from_shortcode ) {
                         </div><!-- .dokan-other-options -->
 
                         <?php if ( $post_id ): ?>
-                            <?php do_action( 'dokan_product_edit_after_options' ); ?>
+                            <?php do_action( 'dokan_product_edit_after_options', $post_id ); ?>
                         <?php endif; ?>
 
                         <?php wp_nonce_field( 'dokan_edit_product', 'dokan_edit_product_nonce' ); ?>


### PR DESCRIPTION
Hi,
Without $post_id parameter dokan_product_edit_after_options action is not usable properly.