### PR TITLE
refactor(core): Refactor admin settings saving process

### DIFF
--- a/assets/js/vue-admin.js
+++ b/assets/js/vue-admin.js
@@ -1805,16 +1805,23 @@ let Loading = dokan_get_lib('Loading');
                 section: section
             };
             self.showLoading = true;
-            jQuery.post(dokan.ajaxurl, data, function (resp) {
-                if (resp.success) {
-                    self.isSaved = true;
-                    self.isUpdated = true;
-                    self.message = resp.data;
-                } else {
-                    self.isSaved = true;
-                    self.isUpdated = false;
-                    self.message = resp.data;
-                }
+
+            jQuery.post(dokan.ajaxurl, data).done(function (response) {
+                var settings = response.data.settings;
+
+                self.isSaved = true;
+                self.isUpdated = true;
+
+                self.message = response.data.message;
+
+                self.settingValues[settings.name] = settings.value;
+            }).fail(function (jqXHR) {
+                var messages = jqXHR.responseJSON.data.map(function (error) {
+                    return error.message;
+                });
+
+                alert(messages.join(' '));
+            }).always(function () {
                 self.showLoading = false;
             });
         }

--- a/includes/admin/class-settings.php
+++ b/includes/admin/class-settings.php
@@ -53,29 +53,44 @@ class Dokan_Settings {
      * @return void
      */
     public function save_settings_value() {
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( __( 'You have no permission to get settings value', 'dokan-lite' ) );
+        try {
+            if ( ! current_user_can( 'manage_options' ) ) {
+                throw new Exception( __( 'You are not authorized to perform this action.', 'dokan-lite' ), 401 );
+            }
+
+            if ( ! wp_verify_nonce( $_POST['nonce'], 'dokan_admin' ) ) {
+                throw new Exception( __( 'Invalid nonce', 'dokan-lite' ), 403 );
+            }
+
+            $option_name = $_POST['section'];
+
+            if ( empty( $option_name ) ) {
+                throw new Exception( __( 'Setting not saved properly', 'dokan-lite' ), 400 );
+            }
+
+            $option_value = $this->sanitize_options( $_POST['settingsData'] );
+
+            $option_value = apply_filters( 'dokan_save_settings_value', $option_value );
+
+            do_action( 'dokan_before_saving_settings', $option_name, $option_value );
+
+            update_option( $option_name, $option_value );
+
+            do_action( 'dokan_after_saving_settings', $option_name, $option_value );
+
+            wp_send_json_success( array(
+                'settings' => array(
+                    'name'    => $option_name,
+                    'value'   => $option_value,
+                ),
+                'message' => __( 'Setting has been saved successfully.', 'dokan-lite' ),
+            ) );
+
+        } catch ( Exception $e ) {
+            $error_code = $e->getCode() ? $e->getCode() : 422;
+
+            wp_send_json_error( new WP_Error( 'error_saving_dokan_settings', $e->getMessage() ), $error_code );
         }
-
-        if ( ! wp_verify_nonce( $_POST['nonce'], 'dokan_admin' ) ) {
-            wp_send_json_error( __( 'Invalid nonce', 'dokan-lite' ) );
-        }
-
-        $option_key = $_POST['section'];
-
-        if ( empty( $option_key ) ) {
-            wp_send_json_error( __( 'Setting not saved properly', 'dokan-lite' ) );
-        }
-
-        $option_values = $this->sanitize_options( $_POST['settingsData'] );
-
-        $option_values = apply_filters( 'dokan_save_settings_value', $option_values );
-
-        update_option( $option_key, $option_values );
-
-        do_action( 'dokan_after_saving_settings', $option_key, $option_values );
-
-        wp_send_json_success( __( 'Setting Saved', 'dokan-lite' ) );
     }
 
     /**

--- a/src/admin/pages/Settings.vue
+++ b/src/admin/pages/Settings.vue
@@ -157,18 +157,28 @@
                         section: section
                     };
                 self.showLoading = true;
-                jQuery.post( dokan.ajaxurl, data, function(resp) {
-                    if ( resp.success ) {
+
+                jQuery.post( dokan.ajaxurl, data )
+                    .done( function ( response ) {
+                        var settings = response.data.settings;
+
                         self.isSaved = true;
                         self.isUpdated = true;
-                        self.message = resp.data;
-                    } else {
-                        self.isSaved = true;
-                        self.isUpdated = false;
-                        self.message = resp.data;
-                    }
-                    self.showLoading = false;
-                })
+
+                        self.message = response.data.message;
+
+                        self.settingValues[ settings.name ] = settings.value;
+                    } )
+                    .fail( function ( jqXHR ) {
+                        var messages = jqXHR.responseJSON.data.map( function ( error ) {
+                            return error.message;
+                        } );
+
+                        alert( messages.join( ' ' ) );
+                    } )
+                    .always( function () {
+                        self.showLoading = false;
+                    } );
             }
         },
 


### PR DESCRIPTION
With this changes you can,
1. Validate and throw errors from Dokan Pro using `dokan_after_saving_settings` hook.
2. From now on Vue will update the form field value found from the response. So, for example, if your option has `sanitize_callback => 'absint'` and you're trying to save `-10`, then Vue will set the value to `10` found from the ajax response.

@sabbir1991 @saimonh3 