### PR TITLE
Update wp-vue-i18n package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dokan",
-  "version": "2.9.10",
+  "version": "2.9.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6141,9 +6141,9 @@
       }
     },
     "gettext-parser": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.3.1.tgz",
-      "integrity": "sha512-W4t55eB/c7WrH0gbCHFiHuaEnJ1WiPJVnbFFiNEoh2QkOmuSLxs0PmJDGAmCQuTJCU740Fmb6D+2D/2xECWZGQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
+      "integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
       "dev": true,
       "requires": {
         "encoding": "0.1.12",
@@ -7058,7 +7058,7 @@
       "dev": true,
       "requires": {
         "grunt": "1.0.3",
-        "wp-vue-i18n": "1.1.1"
+        "wp-vue-i18n": "1.1.4"
       },
       "dependencies": {
         "ansi-styles": {
@@ -8688,6 +8688,12 @@
           "dev": true
         }
       }
+    },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
     },
     "lodash._arraycopy": {
       "version": "3.0.0",
@@ -14578,26 +14584,18 @@
       }
     },
     "wp-vue-i18n": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/wp-vue-i18n/-/wp-vue-i18n-1.1.1.tgz",
-      "integrity": "sha1-h7VFfjSO2a10rntwmIfs9+lIsoM=",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/wp-vue-i18n/-/wp-vue-i18n-1.1.4.tgz",
+      "integrity": "sha512-cLEB5ajWpb5mtIS9c5XoJeBpq8T48+H0HwjNEsJakRtsi2pq5O6uLYLOTNnPPerRBcn74S6wrF/ZKMcqV+Xpkg==",
       "dev": true,
       "requires": {
         "bluebird": "3.5.1",
-        "gettext-parser": "1.3.1",
+        "gettext-parser": "1.4.0",
         "glob": "7.0.6",
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "minimist": "1.2.0",
         "mkdirp": "0.5.1",
         "tmp": "0.0.33"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.10",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-          "dev": true
-        }
       }
     },
     "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,6 @@
     "vue-style-loader": "^3.0.1",
     "vue-template-compiler": "^2.5.13",
     "webpack": "^3.10.0",
-    "wp-vue-i18n": "^1.1.1"
+    "wp-vue-i18n": "^1.1.4"
   }
 }


### PR DESCRIPTION
From now on translation inside attributes in vue templates is possible. For example,
```html
<a href="#" :title="__('Link title', 'dokan')">{{ __('Link Text', 'dokan') }}</a>
```

Before this update `__('Link title', 'dokan')` won't be parsed.