### PR TITLE
Fix vendor payment settings page available withdraw methods display i…

### DIFF
--- a/templates/settings/payment.php
+++ b/templates/settings/payment.php
@@ -14,17 +14,17 @@ do_action( 'dokan_payment_settings_before_form', $current_user, $profile_info );
 
     <?php foreach ( $methods as $method_key ) {
         $method = dokan_withdraw_get_method( $method_key );
+        if ( is_callable( $method['callback'] ) ) {
         ?>
         <fieldset class="payment-field-<?php echo esc_attr( $method_key ); ?>">
             <div class="dokan-form-group">
                 <label class="dokan-w3 dokan-control-label" for="dokan_setting"><?php echo esc_html( $method['title'] ) ?></label>
                 <div class="dokan-w6">
-                    <?php if ( is_callable( $method['callback'] ) ) {
-                        call_user_func( $method['callback'], $profile_info );
-                    } ?>
+                    <?php call_user_func( $method['callback'], $profile_info ); ?>
                 </div> <!-- .dokan-w6 -->
             </div>
         </fieldset>
+        <?php } ?>
     <?php } ?>
 
     <?php


### PR DESCRIPTION
How to reproduce this issue:

1. Uncheck **Withdraw Methods** from admin Withdraw Options settings page.

![admin withdraw method settings](https://user-images.githubusercontent.com/10962969/68683563-2fe2a200-0591-11ea-913c-5fad3532b2a0.png)

2. Login using vendor account information and check vendor **Payment Settings** page.

![Payment Settings page](https://user-images.githubusercontent.com/10962969/68684086-1857e900-0592-11ea-8ba9-e0075b501f2d.png)