### PR TITLE
fix: pass order into woocommerce_order_item_{type}_html hook

### DIFF
--- a/templates/orders/details.php
+++ b/templates/orders/details.php
@@ -64,7 +64,7 @@ $hide_customer_info = dokan_get_option( 'hide_customer_info', 'dokan_selling', '
                                                     break;
                                                 }
 
-                                                do_action( 'woocommerce_order_item_' . $item['type'] . '_html', $item_id, $item );
+                                                do_action( 'woocommerce_order_item_' . $item['type'] . '_html', $item_id, $item, $order );
 
                                             }
                                         ?>


### PR DESCRIPTION
This exact hook is used inside WooCommerce with 3 parameters. When WooCommerce Product Addons does something with this hook, it produce fatal error.