### PR TITLE
Fix: Dokan.js file not found when store list shortcode use on another …

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -3421,7 +3421,7 @@ function dokan_is_store_listing() {
     if ( ! $found ) {
         $post = get_post( $page_id );
 
-        if ( $post && false !== strpos( $post->post_content, '[dokan-stores]' ) ) {
+        if ( $post && false !== strpos( $post->post_content, '[dokan-stores' ) ) {
             $found = true;
         }
     }


### PR DESCRIPTION
…new page issue fixed

When we use dokan-stores shortcode on new page which one not select from admin area then dokan.js file not found.  

Here have a function "dokan_is_store_listing" where checking "[dokan-stores]" on content but when we use with attribute example: [dokan-stores per_page=12] then it not working properly. That's why i am some changes on this function so without attributes or with attributes both can search short code from content and can add dokan.js script that page.  