### PR TITLE
fix: admin is unable to see the setup wizard on new dokan installation is fixed #783

### DIFF
--- a/includes/Admin/SetupWizard.php
+++ b/includes/Admin/SetupWizard.php
@@ -26,6 +26,8 @@ class SetupWizard {
      * Hook in tabs.
      */
     public function __construct() {
+        add_filter( 'user_has_cap', [ $this, 'set_user_cap' ] );
+
         if ( current_user_can( 'manage_woocommerce' ) ) {
             add_action( 'admin_menu', array( $this, 'admin_menus' ) );
             add_action( 'admin_init', array( $this, 'setup_wizard' ), 99 );
@@ -39,6 +41,21 @@ class SetupWizard {
                 add_action( 'dokan_admin_setup_wizard_save_step_store', array( SetupWizardNoWC::class, 'save_wc_store_setup_data' ) );
             }
         }
+    }
+
+    /**
+     * Give manage_woocommerce cap to admin if not there.
+     *
+     * @param array $caps
+     *
+     * @return array
+     */
+    public function set_user_cap( $caps ) {
+        if ( ! empty( $caps[ 'manage_options' ] ) && empty( $caps[ 'manage_woocommerce' ] ) ) {
+            $caps[ 'manage_woocommerce' ] = true;
+        }
+
+        return $caps;
     }
 
     /**

--- a/includes/Admin/SetupWizard.php
+++ b/includes/Admin/SetupWizard.php
@@ -26,7 +26,9 @@ class SetupWizard {
      * Hook in tabs.
      */
     public function __construct() {
-        add_filter( 'user_has_cap', [ $this, 'set_user_cap' ] );
+        if ( ! dokan()->has_woocommerce() ) {
+            add_filter( 'user_has_cap', [ $this, 'set_user_cap' ] );
+        }
 
         if ( current_user_can( 'manage_woocommerce' ) ) {
             add_action( 'admin_menu', array( $this, 'admin_menus' ) );
@@ -51,7 +53,7 @@ class SetupWizard {
      * @return array
      */
     public function set_user_cap( $caps ) {
-        if ( ! empty( $caps[ 'manage_options' ] ) && empty( $caps[ 'manage_woocommerce' ] ) ) {
+        if ( ! empty( $caps[ 'manage_options' ] ) ) {
             $caps[ 'manage_woocommerce' ] = true;
         }
 


### PR DESCRIPTION
Both admin and shop manager wants to see the setup wizard. The dokan-setup page has been registered like this.

```php
add_submenu_page( null, '', '', 'manage_woocommerce', 'dokan-setup', '' );
```
So admin can't see the page if WooCommerce has't been installed before and if we change the cap to `manage_options` then shop manager can't see the setup wizard.
