### PR TITLE
Fix: Add Filter parameter on functions.php to approve vendor's withdraw from admin for custom payment methods

### DIFF
--- a/includes/Withdraw/functions.php
+++ b/includes/Withdraw/functions.php
@@ -73,7 +73,7 @@ function dokan_get_seller_active_withdraw_methods( $vendor_id = 0 ) {
         }
     }
 
-    return apply_filters( 'dokan_get_seller_active_withdraw_methods', $active_payment_methods );
+    return apply_filters( 'dokan_get_seller_active_withdraw_methods', $active_payment_methods, $vendor_id );
 }
 
 


### PR DESCRIPTION
'$vendor_id' - should be pass on the filter -  'dokan_get_seller_active_withdraw_methods'  on function - dokan_get_seller_active_withdraw_methods().
Otherwise it's not possible to approve vendor's payment from admin panel while using the filter to add additional payment methods.