### PR TITLE
Fix order manager caching

### DIFF
--- a/includes/Order/Manager.php
+++ b/includes/Order/Manager.php
@@ -34,7 +34,7 @@ class Manager {
         $cache_group = 'dokan_seller_data_'.$args['seller_id'];
         
         // Use all arguments to create a hash used as cache key
-        $cache_key = md5(json_encode($args));
+        $cache_key = 'dokan_seller_orders_'.md5(json_encode($args));
         
         $orders      = wp_cache_get( $cache_key, $cache_group );
 

--- a/includes/Order/Manager.php
+++ b/includes/Order/Manager.php
@@ -32,7 +32,10 @@ class Manager {
 
         $offset       = ( $args['paged'] - 1 ) * $args['limit'];
         $cache_group = 'dokan_seller_data_'.$args['seller_id'];
-        $cache_key   = 'dokan-seller-orders-' . $args['status'] . '-' . $args['seller_id'];
+        
+        // Use all arguments to create a hash used as cache key
+        $cache_key = md5(json_encode($args));
+        
         $orders      = wp_cache_get( $cache_key, $cache_group );
 
         $join        = $args['customer_id'] ? "LEFT JOIN $wpdb->postmeta pm ON p.ID = pm.post_id" : '';

--- a/includes/Order/Manager.php
+++ b/includes/Order/Manager.php
@@ -30,11 +30,11 @@ class Manager {
 
         $args = wp_parse_args( $args, $default );
 
-        $offset       = ( $args['paged'] - 1 ) * $args['limit'];
+        $offset      = ( $args['paged'] - 1 ) * $args['limit'];
         $cache_group = 'dokan_seller_data_'.$args['seller_id'];
         
         // Use all arguments to create a hash used as cache key
-        $cache_key = 'dokan_seller_orders_'.md5(json_encode($args));
+        $cache_key   = 'dokan_seller_orders-' . md5(json_encode($args));
         
         $orders      = wp_cache_get( $cache_key, $cache_group );
 


### PR DESCRIPTION
The current order manager cache implementation is not working, as it does not take many of the arguments into account. I have replaced it with a simpler and non-manual cache key generator that will work for any set of parameters. 