### PR TITLE
Updated order functions.php in includes

### DIFF
--- a/includes/Order/functions.php
+++ b/includes/Order/functions.php
@@ -608,8 +608,8 @@ function dokan_get_sellers_by( $order ) {
 
         //New filter hook to modify the seller id at run time.
         $seller_id = apply_filters( 'dokan_get_sellers_by', $seller_id, $item );
-        if(!empty($seller_id)){
-            $sellers[$seller_id][] = $item;
+        if ( ! empty( $seller_id ) ) {
+            $sellers[ $seller_id ][] = $item;
         }
     }
 

--- a/includes/Order/functions.php
+++ b/includes/Order/functions.php
@@ -608,7 +608,9 @@ function dokan_get_sellers_by( $order ) {
 
         //New filter hook to modify the seller id at run time.
         $seller_id = apply_filters( 'dokan_get_sellers_by', $seller_id, $item );
-        $sellers[$seller_id][] = $item;
+        if(!empty($seller_id)){
+            $sellers[$seller_id][] = $item;
+        }
     }
 
     return $sellers;


### PR DESCRIPTION
fix(Order): filter out empty seller ids

Fixes a bug where empty Seller IDs were returned by dokan_get_sellers_by.