### PR TITLE
Add system to refresh options for select fields in admin settings

### DIFF
--- a/src/admin/components/Fields.vue
+++ b/src/admin/components/Fields.vue
@@ -141,6 +141,13 @@
                     </optgroup>
                 </select>
 
+                <RefreshSettingOptions
+                    v-if="fieldData.refresh_options"
+                    :section="sectionId"
+                    :field="fieldData"
+                    :toggle-loading-state="toggleLoadingState"
+                />
+
                 <p class="description" v-html="fieldData.desc"></p>
             </td>
         </template>
@@ -286,6 +293,7 @@
     let TextEditor = dokan_get_lib('TextEditor');
     let GoogleMaps = dokan_get_lib('GoogleMaps');
     let Mapbox = dokan_get_lib('Mapbox');
+    let RefreshSettingOptions = dokan_get_lib('RefreshSettingOptions');
 
     export default {
         name: 'Fields',
@@ -295,9 +303,10 @@
             TextEditor,
             GoogleMaps,
             Mapbox,
+            RefreshSettingOptions,
         },
 
-        props: ['id', 'fieldData', 'sectionId', 'fieldValue', 'allSettingsValues', 'errors'],
+        props: ['id', 'fieldData', 'sectionId', 'fieldValue', 'allSettingsValues', 'errors', 'toggleLoadingState'],
 
         data() {
             return {

--- a/src/admin/components/RefreshSettingOptions.vue
+++ b/src/admin/components/RefreshSettingOptions.vue
@@ -1,0 +1,136 @@
+<template>
+    <button
+        type="button"
+        class="button button-link"
+        @click.prevent="refreshSettings"
+        :disabled="isRefreshing || showRefreshedMsg"
+    >
+        <span v-if="! isRefreshing && ! showRefreshedMsg" class="dashicons dashicons-image-rotate"></span>
+        <span v-if="isRefreshing" class="refreshing-message">{{ messages.refreshing }}...</span>
+        <span v-if="showRefreshedMsg" class="refresh-message-success">✓ {{ messages.refreshed }}</span>
+    </button>
+</template>
+
+<script>
+    export default {
+        props: {
+            section: {
+                type: String,
+                required: true,
+            },
+            field: {
+                type: Object,
+                required: true,
+            },
+            toggleLoadingState: {
+                type: Function,
+                required: true,
+            },
+        },
+
+        data() {
+            return {
+                isRefreshing: false,
+                showRefreshedMsg: false,
+            };
+        },
+
+        computed: {
+            messages() {
+                return {
+                    refreshing: this.field.refresh_options?.messages?.refreshing || this.__( 'Refreshing options', 'dokan-lite' ),
+                    refreshed: this.field.refresh_options?.messages?.refreshed || this.__( 'Option refreshed!', 'dokan-lite' ),
+                }
+            },
+        },
+
+        methods: {
+            refreshSettings() {
+                this.toggleLoadingState();
+                this.isRefreshing = true;
+
+                jQuery.ajax( {
+                    url: dokan.ajaxurl,
+                    method: 'post',
+                    dataType: 'json',
+                    data: {
+                        action: 'dokan_refresh_admin_settings_field_options',
+                        _wpnonce: dokan.admin_settings_nonce,
+                        section: this.section,
+                        field: this.field.name,
+                    }
+                } ).done( ( response ) => {
+                    response?.data?.[0] && this.setSettingOptions( response.data );
+                } ).always( () => {
+                    this.toggleLoadingState();
+                    this.isRefreshing = false;
+                } ).fail( ( jqXHR ) => {
+                    jqXHR?.responseJSON?.data && alert( jqXHR.responseJSON.data );
+                } );
+            },
+
+            setSettingOptions( options ) {
+                this.field.options = options;
+                this.showRefreshedMsg = true;
+                setTimeout( () => ( this.showRefreshedMsg = false ), 3000 );
+            },
+        }
+    };
+</script>
+
+<style lang="less" scoped>
+    .button {
+
+        &.button-link {
+            padding: 0 4px;
+            text-decoration: none;
+            line-height: 1;
+
+            &:hover {
+                background: none;
+
+                .dashicons {
+                    opacity: 1;
+                }
+            }
+
+            &:active,
+            &:focus {
+                background: none;
+                box-shadow: none;
+            }
+
+            &:active {
+
+                .dashicons {
+                    margin-top: 3px;
+                }
+            }
+
+            &[disabled] {
+                background: none !important;
+                pointer-events: none;
+            }
+
+            .dashicons {
+                font-size: 15px;
+                padding: 0;
+                margin: 0;
+                line-height: 1.3;
+                color: #444;
+                opacity: .7;
+                transition: opacity .4s;
+            }
+
+            .refreshing-message {
+                line-height: 1;
+                color: #444;
+            }
+
+            .refresh-message-success {
+                line-height: 1;
+                color: #46b450;
+            }
+        }
+    }
+</style>

--- a/src/admin/pages/Settings.vue
+++ b/src/admin/pages/Settings.vue
@@ -47,6 +47,7 @@
                                         @openMedia="showMedia"
                                         :key="fieldId"
                                         :errors="errors"
+                                        :toggle-loading-state="toggleLoadingState"
                                     />
                                 </tbody>
                             </table>
@@ -303,7 +304,11 @@
                return array.filter( ( element ) => {
                    return element !== value;
                });
-            }
+            },
+
+            toggleLoadingState() {
+                this.showLoading = ! this.showLoading;
+            },
         },
 
         created() {

--- a/src/utils/Bootstrap.js
+++ b/src/utils/Bootstrap.js
@@ -42,6 +42,7 @@ import GoogleMaps from "admin/components/GoogleMaps.vue"
 import Mapbox from "admin/components/Mapbox.vue"
 import UploadImage from "admin/components/UploadImage.vue"
 import PasswordGenerator from "admin/components/PasswordGenerator.vue"
+import RefreshSettingOptions from "admin/components/RefreshSettingOptions.vue"
 import VendorAccountFields from "admin/pages/VendorAccountFields.vue";
 import VendorAddressFields from "admin/pages/VendorAddressFields.vue";
 import VendorSocialFields from "admin/pages/VendorSocialFields.vue";
@@ -112,6 +113,7 @@ window.dokan.libs['VendorAccountFields'] = VendorAccountFields;
 window.dokan.libs['VendorAddressFields'] = VendorAddressFields;
 window.dokan.libs['VendorSocialFields']  = VendorSocialFields;
 window.dokan.libs['VendorPaymentFields'] = VendorPaymentFields;
+window.dokan.libs['RefreshSettingOptions'] = RefreshSettingOptions;
 
 window.dokan.libs['ContentLoading']  = {
   VclCode,


### PR DESCRIPTION
This feature is introduced to refresh the Profile options in upcoming Vendor Analytics admin settings. If we have any settings that requires data from external API, then we should fetch that data once, save in options table and use that every page refresh. This refresh feature comes handy when we want to refresh/refetch the external data.

### UI: example video: https://www.loom.com/share/8162cb5b9d1d41389454cb6ef6741773

### Example code:
```php
<?php

class MySettings {

    public function __construct() {
        add_filter( 'dokan_settings_sections',  [ $this, 'add_settings_section' ] );
        add_filter( 'dokan_settings_fields',  [ $this, 'add_settings_fields' ] );

        /**
         * @see "dokan_settings_refresh_option_{$section}_{$field}" filter 
         * in \WeDevs\Dokan\Admin\Settings::refresh_admin_settings_field_options()
         */
        add_filter( 'dokan_settings_refresh_option_dokan_SECTION_NAME_FIELD_NAME',  [ $this, 'refresh_admin_settings_options' ] );      
    }

    public function add_settings_section( $sections ) {
        $sections['SECTION_NAME'] = [
            'id'    => 'SECTION_NAME',
            'title' => __( 'Section Title', 'dokan' ),
            'icon'  => 'dashicons-chart-area'
        ];

        return $sections;
    }

    public function add_settings_fields( $settings_fields ) {
        $analytics_fields = [
            'FIELD_NAME'  => [
                'name'        => 'FIELD_NAME',
                'label'       => __( 'Field Label', 'dokan' ),
                'type'        => 'select',
                'placeholder' => __( 'Select an option', 'dokan' ),
                // 'grouped'     => true,
                'options'     => [
                    // options
                ],
                // `refresh_options` is required to show the refresh button
                'refresh_options' => [
                    // `messages` are optional.
                    'messages' => [
                        'refreshing' => __( 'Refreshing profiles', 'dokan' ),
                        'refreshed'  => __( 'Profiles refreshed!', 'dokan' ),
                    ],
                ],
            ],
        ];      
    }

    public function refresh_admin_settings_options() {
        // Always return an array of options
        $options = get_my_options_array();

        // Throw DokanException instead of returning WP_Error for error handling
        if ( is_wp_error( $options ) ) {
            throw new DokanException(
                $options->get_error_code(),
                $options->get_error_message()               
            );
        }

        return $options;
    }
}
```