### PR TITLE
Update product-tab.php to show store name, not vendor name

### DIFF
--- a/templates/global/product-tab.php
+++ b/templates/global/product-tab.php
@@ -28,7 +28,7 @@
         </span>
 
         <span class="details">
-            <?php printf( '<a href="%s">%s</a>', esc_url( dokan_get_store_url( $author->ID ) ), esc_attr( $author->display_name ) ); ?>
+            <?php printf( '<a href="%s">%s</a>', esc_url( dokan_get_store_url( $author->ID ) ), esc_attr(  $store_info['store_name'] ) ); ?>
         </span>
     </li>
     <?php if ( ! dokan_is_vendor_info_hidden( 'address' ) && ! empty( $store_info['address'] ) ) { ?>


### PR DESCRIPTION
this change will make product-tab in product detail showing store name not vendor name

#981 #980 

# Description

    on the product information page, the page show the owner name instate of showing the shop/merchant name.

# Steps to reproduce

   1. Go to product list page
   2. choose an item
   3. look at the bottom left of the screen, there should be a vendor shop name but it shows the owner name.

# Screenshots/Video

![Untitled](https://user-images.githubusercontent.com/46392719/101136390-d63b9280-363f-11eb-8f3d-c338ad710dd7.png)
![Untitled(1)](https://user-images.githubusercontent.com/46392719/101136416-e18ebe00-363f-11eb-9ce1-45b57685ad68.png)


# after the change implemented

    1. Go to dokan-lite/templates/global/product-tab.php
    2. Changes code in line 31 from $author->display_name to $store_info['store_name']
