### PR TITLE
fix: Store and store TOC template make high priority

### DIFF
--- a/includes/Rewrites.php
+++ b/includes/Rewrites.php
@@ -22,9 +22,9 @@ class Rewrites {
         add_action( 'pre_get_posts', [ $this, 'store_query_filter' ] );
 
         add_filter( 'woocommerce_get_query_vars', [ $this, 'resolve_wc_query_conflict' ] );
-        add_filter( 'template_include', [ $this, 'store_template' ] );
+        add_filter( 'template_include', [ $this, 'store_template' ], 99 );
         add_filter( 'template_include', [ $this, 'product_edit_template' ], 99 );
-        add_filter( 'template_include', [ $this, 'store_toc_template' ] );
+        add_filter( 'template_include', [ $this, 'store_toc_template' ], 99 );
         add_filter( 'query_vars', [ $this, 'register_query_var' ] );
         add_filter( 'woocommerce_get_breadcrumb', [ $this, 'store_page_breadcrumb' ] );
     }


### PR DESCRIPTION
It conflicting with Divi theme when use custom Divi builder templates and then happen template_include filter hook priority issue