### PR TITLE
fix: missing translations for admin dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15969,9 +15969,9 @@
       "dev": true
     },
     "vue-wp-list-table": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/vue-wp-list-table/-/vue-wp-list-table-1.2.0.tgz",
-      "integrity": "sha512-GRB6AYvIgVT3B6qGkJKYJCeQq7m+FT4ipimO6P5s9hkWGDNjjkbQdmvg/fMRjDAxFHYZZzH80+HH/afITDE7sA=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/vue-wp-list-table/-/vue-wp-list-table-1.3.0.tgz",
+      "integrity": "sha512-xkhZ6KbD4i+qVNmIHSCs++ocHWXvtmRvJ7fCSUVU5c1wyYZauiCj++0juXsA+uIXf9+ecdbT15YObOFF8UxYDg=="
     },
     "walkdir": {
       "version": "0.0.11",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "vue-notification": "^1.3.20",
     "vue-router": "^3.4.7",
     "vue-sweetalert2": "^1.6.4",
-    "vue-wp-list-table": "^1.2.0"
+    "vue-wp-list-table": "^1.3.0"
   },
   "devDependencies": {
     "@babel/plugin-proposal-optional-chaining": "^7.12.1",

--- a/src/admin/main.js
+++ b/src/admin/main.js
@@ -15,7 +15,19 @@ new Vue({
         if ( dokan.dokan_pro_i18n ) {
             this.setLocaleData( dokan.dokan_pro_i18n['dokan'] );
         }
-    }
+    },
+
+    methods: {
+        listTableTexts() {
+            return {
+                loading: this.__('Loading', 'dokan-lite'),
+                select_bulk_action: this.__('Select bulk action', 'dokan-lite'),
+                bulk_actions: this.__('Bulk Actions', 'dokan-lite'),
+                items: this.__('items', 'dokan-lite'),
+                apply: this.__('Apply', 'dokan-lite'),
+            }
+        }
+    },
 });
 
 

--- a/src/admin/main.js
+++ b/src/admin/main.js
@@ -20,11 +20,11 @@ new Vue({
     methods: {
         listTableTexts() {
             return {
-                loading: this.__('Loading', 'dokan-lite'),
-                select_bulk_action: this.__('Select bulk action', 'dokan-lite'),
-                bulk_actions: this.__('Bulk Actions', 'dokan-lite'),
-                items: this.__('items', 'dokan-lite'),
-                apply: this.__('Apply', 'dokan-lite'),
+                loading: this.__( 'Loading', 'dokan-lite' ),
+                select_bulk_action: this.__( 'Select bulk action', 'dokan-lite' ),
+                bulk_actions: this.__( 'Bulk Actions', 'dokan-lite' ),
+                items: this.__( 'items', 'dokan-lite' ),
+                apply: this.__( 'Apply', 'dokan-lite' ),
             }
         }
     },

--- a/src/admin/pages/Vendors.vue
+++ b/src/admin/pages/Vendors.vue
@@ -20,7 +20,7 @@
                 <li><router-link :to="{ name: 'Vendors', query: { status: 'pending' }}" active-class="current" exact v-html="sprintf( __( 'Pending <span class=\'count\'>(%s)</span>', 'dokan-lite' ), counts.pending )"></router-link></li>
             </ul>
 
-            <search title="Search Vendors" @searched="doSearch"></search>
+            <search :title="__( 'Search Vendors', 'dokan-lite')" @searched="doSearch"></search>
 
             <list-table
                 :columns="columns"
@@ -40,6 +40,7 @@
 
                 :sort-by="sortBy"
                 :sort-order="sortOrder"
+                :text="$root.listTableTexts()"
                 @sort="sortCallback"
 
                 @pagination="goToPage"

--- a/src/admin/pages/Withdraw.vue
+++ b/src/admin/pages/Withdraw.vue
@@ -38,6 +38,7 @@
                 :total-items="totalItems"
                 :per-page="perPage"
                 :current-page="currentPage"
+                :text="$root.listTableTexts()"
                 @pagination="goToPage"
                 @action:click="onActionClick"
                 @bulk:click="onBulkAction"


### PR DESCRIPTION
* vue wp list table package updated to 1.3.0
* add translation support for list tables
* global method `listTableTexts` for list table texts