### PR TITLE
Fix: REST API order total value gets rounded

### DIFF
--- a/includes/REST/OrderController.php
+++ b/includes/REST/OrderController.php
@@ -235,7 +235,7 @@ class OrderController extends DokanRESTController {
 
         // Format decimal values.
         foreach ( $format_decimal as $key ) {
-            $data[ $key ] = wc_format_decimal( $data[ $key ], $this->request['dp'] );
+            $data[ $key ] = wc_format_decimal( $data[ $key ], wc_get_price_decimals() );
         }
 
         // Format date values.
@@ -259,7 +259,7 @@ class OrderController extends DokanRESTController {
             $data['refunds'][] = array(
                 'id'     => $refund->get_id(),
                 'refund' => $refund->get_reason() ? $refund->get_reason() : '',
-                'total'  => '-' . wc_format_decimal( $refund->get_amount(), $this->request['dp'] ),
+                'total'  => '-' . wc_format_decimal( $refund->get_amount(), wc_get_price_decimals() ),
             );
         }
 
@@ -474,7 +474,7 @@ class OrderController extends DokanRESTController {
         // Format decimal values.
         foreach ( $format_decimal as $key ) {
             if ( isset( $data[ $key ] ) ) {
-                $data[ $key ] = wc_format_decimal( $data[ $key ], $this->request['dp'] );
+                $data[ $key ] = wc_format_decimal( $data[ $key ], wc_get_price_decimals() );
             }
         }
 

--- a/includes/REST/OrderController.php
+++ b/includes/REST/OrderController.php
@@ -235,7 +235,7 @@ class OrderController extends DokanRESTController {
 
         // Format decimal values.
         foreach ( $format_decimal as $key ) {
-            $data[ $key ] = wc_format_decimal( $data[ $key ], wc_get_price_decimals() );
+            $data[ $key ] = wc_format_decimal( $data[ $key ], '' );
         }
 
         // Format date values.
@@ -259,7 +259,7 @@ class OrderController extends DokanRESTController {
             $data['refunds'][] = array(
                 'id'     => $refund->get_id(),
                 'refund' => $refund->get_reason() ? $refund->get_reason() : '',
-                'total'  => '-' . wc_format_decimal( $refund->get_amount(), wc_get_price_decimals() ),
+                'total'  => '-' . wc_format_decimal( $refund->get_amount(), '' ),
             );
         }
 
@@ -474,7 +474,7 @@ class OrderController extends DokanRESTController {
         // Format decimal values.
         foreach ( $format_decimal as $key ) {
             if ( isset( $data[ $key ] ) ) {
-                $data[ $key ] = wc_format_decimal( $data[ $key ], wc_get_price_decimals() );
+                $data[ $key ] = wc_format_decimal( $data[ $key ], '' );
             }
         }
 


### PR DESCRIPTION
When an order data is retrieved using `.../wp-json/dokan/v1/orders/` the "total" order value is rounded. One the other hand, WooCommerce's response shows the correct value.

Fix: #941