### PR TITLE
Fix: vendor withdraw balance

### DIFF
--- a/includes/Vendor/Vendor.php
+++ b/includes/Vendor/Vendor.php
@@ -661,7 +661,11 @@ class Vendor {
         }
 
         if ( $formatted ) {
-            return apply_filters( 'dokan_get_formatted_seller_balance', wc_price( $earning ), $this->id );
+            $decimal = ( 0 === wc_get_price_decimals() ) ? 2 : wc_get_price_decimals();
+            return apply_filters( 
+                'dokan_get_formatted_seller_balance', 
+                wc_price( $earning, [ 'decimals' => $decimal ] 
+            ), $this->id );
         }
 
         return apply_filters( 'dokan_get_seller_balance', $earning, $this->id );


### PR DESCRIPTION
If the vendor has a rounded value in their balance then you are unable to request for a withdrawal of the full amount as it shows an error.

Fix: #1030