### PR TITLE
Enhancement: enable downloadable and virtual for subscription product

### DIFF
--- a/includes/Dashboard/Templates/Products.php
+++ b/includes/Dashboard/Templates/Products.php
@@ -90,7 +90,7 @@ class Products {
             'post'            => $post,
             'is_downloadable' => $is_downloadable,
             'is_virtual'      => $is_virtual,
-            'class'           => 'show_if_simple',
+            'class'           => 'show_if_subscription show_if_variable-subscription show_if_simple',
         ) );
     }
 


### PR DESCRIPTION
Dokan’s integration with WC Subscription plugin does not allow the vendor to create downloadable/virtual products in the dashboard.

Fix: https://github.com/weDevsOfficial/dokan-pro/issues/749