### PR TITLE
fix: filtered order export on vendor dashboard

### DIFF
--- a/includes/Order/functions.php
+++ b/includes/Order/functions.php
@@ -70,7 +70,7 @@ function dokan_get_seller_orders( $seller_id, $status = 'all', $order_date = nul
     $where = $customer_id ? sprintf( "pm.meta_key = '_customer_user' AND pm.meta_value = %d AND", $customer_id ) : '';
 
     if ( $orders === false ) {
-        $status_where = ( $status === 'all' ) ? '' : $wpdb->prepare( ' AND order_status = %s', 'wc-' . $status );
+        $status_where = ( $status === 'all' ) ? '' : $wpdb->prepare( ' AND order_status = %s', $status );
         $date_query   = ( $order_date ) ? $wpdb->prepare( ' AND DATE( p.post_date ) = %s', $order_date ) : '';
 
         $orders = $wpdb->get_results(


### PR DESCRIPTION
Issue Description:
Vendors are unable to export orders for specific order status. Vendors can see orders from different order statuses from their dashboard but there is no way to export those. The export filtered button only works for the date and customer filter.

How to reproduce:

Navigate to vendor dashboard > orders page
Click on any of the order statuses
Click on export filtered
A blank CSV is exported
Expected behavior:
The export filtered button should export all orders which are available under that certain order status - https://prnt.sc/y6o4w8

Versions:
WP - 5.6
WC - 4.9.2
Dokan Lite - 3.2
Dokan Pro - 3.2