### PR TITLE
fix: on save store settings error fix

### DIFF
--- a/includes/Dashboard/Templates/Settings.php
+++ b/includes/Dashboard/Templates/Settings.php
@@ -500,6 +500,15 @@ class Settings {
         } elseif ( wp_verify_nonce( sanitize_key( $post_data['_wpnonce'] ), 'dokan_store_settings_nonce' ) ) {
 
             $default_locations = dokan_get_option( 'location', 'dokan_geolocation' );
+
+            if ( ! is_array( $default_locations ) || empty( $default_locations ) ) {
+                $default_locations = array(
+                    'latitude'  => '',
+                    'longitude' => '',
+                    'address'   => '',
+                );
+            }
+
             $find_address      = ! empty( $post_data['find_address'] ) ? sanitize_text_field( $post_data['find_address'] ) : $default_locations['address'];
             $default_location  = $default_locations['latitude'] . ',' . $default_locations['longitude'];
             $location          = ! empty( $post_data['find_address'] ) ? sanitize_text_field( $post_data['location'] ) : $default_location;


### PR DESCRIPTION
Hi,

This PR solves the "Vendor Dashboard Store" settings save error. code extracted from #1098 

The error is below.
```
2021-02-19T10:24:36+00:00 CRITICAL Uncaught TypeError: Cannot access offset of type string on string in /Users/shohag/Sites/wd/wp-content/plugins/dokan-lite/includes/Dashboard/Templates/Settings.php:504
Stack trace:
#0 /Users/shohag/Sites/wd/wp-content/plugins/dokan-lite/includes/Dashboard/Templates/Settings.php(267): WeDevs\Dokan\Dashboard\Templates\Settings->insert_settings_info()
#1 /Users/shohag/Sites/wd/wp-includes/class-wp-hook.php(287): WeDevs\Dokan\Dashboard\Templates\Settings->ajax_settings('')
#2 /Users/shohag/Sites/wd/wp-includes/class-wp-hook.php(311): WP_Hook->apply_filters('', Array)
#3 /Users/shohag/Sites/wd/wp-includes/plugin.php(484): WP_Hook->do_action(Array)
#4 /Users/shohag/Sites/wd/wp-admin/admin-ajax.php(184): do_action('wp_ajax_dokan_s...')
#5 /Users/shohag/.composer/vendor/laravel/valet/server.php(219): require('/Users/shohag/S...')
#6 {main}
  thrown in /Users/shohag/Sites/wd/wp-content/plugins/dokan-lite/includes/Dashboard/Templates/Settings.php on line 504
```