### PR TITLE
fix: fixes store/product orderby parameter for query

### DIFF
--- a/includes/Product/Manager.php
+++ b/includes/Product/Manager.php
@@ -26,7 +26,7 @@ class Manager {
             'post_type'      => 'product',
             'post_status'    => $post_statuses,
             'posts_per_page' => -1,
-            'orderby'        => 'post_date',
+            'orderby'        => 'post_date ID',
             'order'          => 'DESC',
             'paged'          => 1,
         ];

--- a/includes/Rewrites.php
+++ b/includes/Rewrites.php
@@ -324,6 +324,9 @@ class Rewrites {
             }
 
             $query->set( 'tax_query', apply_filters( 'dokan_store_tax_query', $tax_query ) );
+
+            // set orderby param
+            $query->set( 'orderby', 'post_date ID' );
         }
     }
 }


### PR DESCRIPTION
If the product post_date field value is the same for a couple of products, orderby parameter is not working and  Some products are showing 2x/3x and some are not showing in the store page and vendor dashboard product page