### PR TITLE
fix: different edit url for different product status

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -983,17 +983,15 @@ function dokan_edit_product_url( $product ) {
         return false;
     }
 
-    if ( 'publish' === $product->get_status() ) {
-        $url = trailingslashit( get_permalink( $product->get_id() ) ) . 'edit/';
-    } else {
-        $url = add_query_arg(
-            [
-                'product_id' => $product->get_id(),
-                'action'     => 'edit',
-            ],
-            dokan_get_navigation_url( 'products' )
-        );
-    }
+
+    $url = add_query_arg(
+        [
+            'product_id' => $product->get_id(),
+            'action'     => 'edit',
+        ],
+        dokan_get_navigation_url( 'products' )
+    );
+
 
     return apply_filters( 'dokan_get_edit_product_url', $url, $product );
 }


### PR DESCRIPTION
There is a different edit URL for the product that has the status of published.

Removed the status check and set the URL with the vendor dashboard prefix.


fix #1114 