### PR TITLE
fix: capitalize vendor url in add new vendor

### DIFF
--- a/src/admin/pages/VendorAccountFields.vue
+++ b/src/admin/pages/VendorAccountFields.vue
@@ -183,8 +183,8 @@ export default {
         'vendorInfo.user_nicename'( newValue ) {
             if ( typeof newValue !== 'undefined' ) {
                 this.showStoreUrl = false;
-                this.otherStoreUrl = this.defaultUrl + newValue.trim().split(' ').join('-').toLowerCase();
-                this.vendorInfo.user_nicename = newValue.split(' ').join('-').toLowerCase();
+                this.otherStoreUrl = this.defaultUrl + newValue.trim().split(' ').join('-').toLowerCase().replace(/[^\w\s/-]/g, '').replace( /-+/g, '-' );
+                this.vendorInfo.user_nicename = newValue.split(' ').join('-').toLowerCase().replace(/[^\w\s/-]/g, '').replace( /-+/g, '-' );
 
                 // check if the typed url is available
                 this.checkStoreName();
@@ -202,7 +202,7 @@ export default {
 
     computed: {
         storeUrl() {
-            let storeUrl = this.vendorInfo.store_name.trim().split(' ').join('-').toLowerCase();
+            let storeUrl = this.vendorInfo.store_name.trim().split(' ').join('-').toLowerCase().replace(/[^\w\s/-]/g, '').replace( /-+/g, '-' );
             this.vendorInfo.user_nicename = storeUrl;
             this.otherStoreUrl = this.defaultUrl + storeUrl;
             return this.defaultUrl + storeUrl;

--- a/src/admin/pages/VendorAccountFields.vue
+++ b/src/admin/pages/VendorAccountFields.vue
@@ -183,8 +183,8 @@ export default {
         'vendorInfo.user_nicename'( newValue ) {
             if ( typeof newValue !== 'undefined' ) {
                 this.showStoreUrl = false;
-                this.otherStoreUrl = this.defaultUrl + newValue.trim().split(' ').join('-');
-                this.vendorInfo.user_nicename = newValue.split(' ').join('-');
+                this.otherStoreUrl = this.defaultUrl + newValue.trim().split(' ').join('-').toLowerCase();
+                this.vendorInfo.user_nicename = newValue.split(' ').join('-').toLowerCase();
 
                 // check if the typed url is available
                 this.checkStoreName();
@@ -202,10 +202,9 @@ export default {
 
     computed: {
         storeUrl() {
-            let storeUrl = this.vendorInfo.store_name.trim().split(' ').join('-');
+            let storeUrl = this.vendorInfo.store_name.trim().split(' ').join('-').toLowerCase();
             this.vendorInfo.user_nicename = storeUrl;
             this.otherStoreUrl = this.defaultUrl + storeUrl;
-
             return this.defaultUrl + storeUrl;
         }
     },


### PR DESCRIPTION
In the admin area, when the admin tries to add a new vendor using vendor wizard, The store URL shows uppercase letter.

<img width="1440" alt="Screenshot 2021-03-12 at 11 03 42 AM" src="https://user-images.githubusercontent.com/5476784/110894966-0bccd780-8323-11eb-8064-b47efc26524e.png">
