### PR TITLE
fix: time format with forward slash (\) wasn't parsing correctly on store open/close time dropdown

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -3189,8 +3189,8 @@ function dokan_is_store_open( $user_id ) {
             return true;
         }
 
-        $open  = $current_time->modify( $schedule['opening_time'] );
-        $close = $current_time->modify( $schedule['closing_time'] );
+        $open  = DateTimeImmutable::createFromFormat( esc_attr( get_option( 'time_format' ) ), $schedule['opening_time'], new DateTimeZone( dokan_wp_timezone_string() ) );
+        $close = DateTimeImmutable::createFromFormat( esc_attr( get_option( 'time_format' ) ), $schedule['closing_time'], new DateTimeZone( dokan_wp_timezone_string() ) );
 
         if ( $open <= $current_time && $close >= $current_time ) {
             return true;

--- a/templates/settings/store-form.php
+++ b/templates/settings/store-form.php
@@ -349,7 +349,7 @@
         } );
         $( '.time .dokan-form-control' ).timepicker({
             scrollDefault: 'now',
-            timeFormat: '<?php echo esc_attr( get_option( 'time_format' ) ); ?>',
+            timeFormat: '<?php echo addcslashes( esc_attr( get_option( 'time_format' ) ), '\\' ); ?>',
             step: <?php echo 'h' === strtolower( get_option( 'time_format' ) ) ? '60' : '30'; ?>
         });
         // dokan store open close scripts end //


### PR DESCRIPTION
fixes https://github.com/weDevsOfficial/dokan-pro/issues/1167