### PR TITLE
Fix malformed dashboard subpage URL when `page_link` is filtered to add a query parameter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
   ],
   "minimum-stability": "dev",
   "require": {
-    "appsero/client": "dev-master"
+    "appsero/client": "dev-master",
+    "jakeasmith/http_build_url": "^1"
   },
   "require-dev": {
     "wp-coding-standards/wpcs": "dev-master",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "52dfeea324b1da26ade14e6c56d5da6f",
+    "content-hash": "67f88946d5e670f70ef405f4c8c637fd",
     "packages": [
         {
             "name": "appsero/client",
@@ -47,6 +47,39 @@
                 "wordpress"
             ],
             "time": "2020-09-10T09:10:28+00:00"
+        },
+        {
+            "name": "jakeasmith/http_build_url",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jakeasmith/http_build_url.git",
+                "reference": "93c273e77cb1edead0cf8bcf8cd2003428e74e37"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jakeasmith/http_build_url/zipball/93c273e77cb1edead0cf8bcf8cd2003428e74e37",
+                "reference": "93c273e77cb1edead0cf8bcf8cd2003428e74e37",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/http_build_url.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jake A. Smith",
+                    "email": "theman@jakeasmith.com"
+                }
+            ],
+            "description": "Provides functionality for http_build_url() to environments without pecl_http.",
+            "time": "2017-05-01T15:36:40+00:00"
         }
     ],
     "packages-dev": [

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2049,10 +2049,12 @@ function dokan_get_navigation_url( $name = '' ) {
         return '';
     }
 
+    $url = get_permalink( $page_id );
+
     if ( ! empty( $name ) ) {
-        $url = get_permalink( $page_id ) . $name . '/';
-    } else {
-        $url = get_permalink( $page_id );
+        $urlParts         = wp_parse_url( $url );
+        $urlParts['path'] = $urlParts['path'] . $name . '/';
+        $url              = http_build_url( '', $urlParts );
     }
 
     return apply_filters( 'dokan_get_navigation_url', esc_url( $url ), $name );


### PR DESCRIPTION
Solves https://github.com/weDevsOfficial/dokan/issues/1172.

I added a preliminary commit to include the [jakeasmith/http_build_url](https://packagist.org/packages/jakeasmith/http_build_url) composer package. This is a very popular package that provides an implementation of `http_build_url` if the function does not already exists. It makes easy and safe to handle URLs.