### PR TITLE
Fix: product count exclude booking product

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -26,7 +26,7 @@ function dokana_admin_menu_capability() {
  *
  * @since 2.7.3
  *
- * @return void
+ * @return int
  */
 function dokan_get_current_user_id() {
     if ( current_user_can( 'vendor_staff' ) ) {
@@ -199,7 +199,16 @@ function dokan_count_posts( $post_type, $user_id ) {
         if ( ! $results ) {
             $results = $wpdb->get_results(
                 $wpdb->prepare(
-                    "SELECT post_status, COUNT( * ) AS num_posts FROM {$wpdb->posts} WHERE post_type = %s AND post_author = %d GROUP BY post_status",
+                    "SELECT post_status, COUNT( * ) AS num_posts FROM {$wpdb->posts} as posts
+                            INNER JOIN {$wpdb->term_relationships} AS term_relationships ON posts.ID = term_relationships.object_id
+                            INNER JOIN {$wpdb->term_taxonomy} AS term_taxonomy ON term_relationships.term_taxonomy_id = term_taxonomy.term_taxonomy_id
+                            INNER JOIN {$wpdb->terms} AS terms ON term_taxonomy.term_id = terms.term_id
+                            WHERE
+                                term_taxonomy.taxonomy = 'product_type'
+                            AND terms.slug != 'booking'
+                            AND posts.post_type = %s
+                            AND posts.post_author = %d
+                                GROUP BY posts.post_status",
                     $post_type,
                     $user_id
                 ),

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -186,7 +186,7 @@ function dokan_redirect_if_not_seller( $redirect = '' ) {
  *
  * @return array
  */
-function dokan_count_posts( $post_type, $user_id ) {
+function dokan_count_posts( $post_type, $user_id, $exclude_product_type = 'booking' ) {
     global $wpdb;
 
     $cache_group = 'dokan_seller_product_data_' . $user_id;
@@ -205,10 +205,11 @@ function dokan_count_posts( $post_type, $user_id ) {
                             INNER JOIN {$wpdb->terms} AS terms ON term_taxonomy.term_id = terms.term_id
                             WHERE
                                 term_taxonomy.taxonomy = 'product_type'
-                            AND terms.slug != 'booking'
+                            AND terms.slug != %s
                             AND posts.post_type = %s
                             AND posts.post_author = %d
                                 GROUP BY posts.post_status",
+                    $exclude_product_type,
                     $post_type,
                     $user_id
                 ),

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -194,8 +194,15 @@ function dokan_count_posts( $post_type, $user_id, $exclude_product_types = array
     $exclude_product_types_text = "'" . implode( "', '", $exclude_product_types ) . "'";
     $exclude_product_types_key  = implode( '-', $exclude_product_types );
     $cache_group                = 'dokan_seller_product_data_' . $user_id;
-    $cache_key                  = 'dokan-count-' . $post_type . '-' . $exclude_product_types_key . '-' . $user_id;
+    $cache_key                  = 'dokan-count-cache-' . $post_type . '-' . $exclude_product_types_key . '-' . $user_id;
     $counts                     = wp_cache_get( $cache_key, $cache_group );
+    $tracked_cache_keys         = get_option( $cache_group, [] );
+
+    if ( ! in_array( $cache_key, $tracked_cache_keys, true ) ) {
+        $tracked_cache_keys[] = $cache_key;
+        update_option( $cache_group, $tracked_cache_keys );
+    }
+
     if ( false === $counts ) {
         $results = apply_filters( 'dokan_count_posts', null, $post_type, $user_id );
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -193,8 +193,8 @@ function dokan_count_posts( $post_type, $user_id, $exclude_product_types = array
     $exclude_product_types      = esc_sql( $exclude_product_types );
     $exclude_product_types_text = "'" . implode( "', '", $exclude_product_types ) . "'";
     $exclude_product_types_key  = implode( '-', $exclude_product_types );
-    $cache_group                = 'dokan_seller_product_data_' . $user_id;
-    $cache_key                  = 'dokan-count-cache-' . $post_type . '-' . $exclude_product_types_key . '-' . $user_id;
+    $cache_group                = 'dokan_cache_seller_product_data_' . $user_id;
+    $cache_key                  = 'dokan-count-' . $post_type . '-' . $exclude_product_types_key . '-' . $user_id;
     $counts                     = wp_cache_get( $cache_key, $cache_group );
     $tracked_cache_keys         = get_option( $cache_group, [] );
 
@@ -2775,6 +2775,7 @@ function dokan_cache_clear_seller_product_data( $product_id, $post_data = [] ) {
 
     dokan_clear_product_caches( $product_id );
     dokan_cache_clear_group( 'dokan_seller_product_data_' . $seller_id );
+    dokan_cache_clear_group( 'dokan_cache_seller_product_data_' . $seller_id );
     delete_transient( 'dokan-store-category-' . $seller_id );
 }
 


### PR DESCRIPTION
Product count is displaying count number including `product_type = booking` in this PR booking product are excluded.

fix: https://github.com/weDevsOfficial/dokan-pro/issues/1229