### PR TITLE
fix: product variation pagination display for variable product with type Pending Review

### DIFF
--- a/includes/Product/functions.php
+++ b/includes/Product/functions.php
@@ -161,7 +161,7 @@ function dokan_product_output_variations() {
         }
     }
 
-    $variations_count       = absint( $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(ID) FROM $wpdb->posts WHERE post_parent = %d AND post_type = 'product_variation' AND post_status IN ('publish', 'private')", $post->ID ) ) );
+    $variations_count       = absint( $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(ID) FROM $wpdb->posts WHERE post_parent = %d AND post_type = 'product_variation' AND post_status IN ('publish', 'private', 'pending')", $post->ID ) ) );
     $variations_per_page    = absint( apply_filters( 'woocommerce_admin_meta_boxes_variations_per_page', 15 ) );
     $variations_total_pages = ceil( $variations_count / $variations_per_page ); ?>
     <div id="dokan-variable-product-options" class="">


### PR DESCRIPTION
This pr handles the issue with variation pagination display for the variable product with type Pending Review.

fix: https://github.com/weDevsOfficial/dokan-pro/issues/1244