### PR TITLE
feat(api): Add support to send objects to trash

### DIFF
--- a/includes/Abstracts/DokanRESTController.php
+++ b/includes/Abstracts/DokanRESTController.php
@@ -185,7 +185,9 @@ abstract class DokanRESTController extends WP_REST_Controller {
         $response = rest_ensure_response( $data );
 
         // If we're forcing, then delete permanently.
-        $object->delete( true );
+        $force = ( false !== $request['force'] );
+        $object->delete( $force );
+
         $result = 0 === $object->get_id();
 
         if ( ! $result ) {

--- a/includes/Abstracts/DokanRESTController.php
+++ b/includes/Abstracts/DokanRESTController.php
@@ -185,8 +185,7 @@ abstract class DokanRESTController extends WP_REST_Controller {
         $response = rest_ensure_response( $data );
 
         // If we're forcing, then delete permanently.
-        $force = ( false !== $request['force'] );
-        $object->delete( $force );
+        $object->delete( $request['force'] );
 
         $result = 0 === $object->get_id();
 

--- a/includes/REST/ProductController.php
+++ b/includes/REST/ProductController.php
@@ -103,7 +103,7 @@ class ProductController extends DokanRESTController {
                     'args'                => [
                         'force' => [
                             'type'        => 'boolean',
-                            'default'     => true,
+                            'default'     => false,
                             'description' => __( 'Whether to bypass trash and force deletion.', 'dokan-lite' ),
                         ],
                     ],

--- a/includes/REST/ProductController.php
+++ b/includes/REST/ProductController.php
@@ -103,7 +103,7 @@ class ProductController extends DokanRESTController {
                     'args'                => [
                         'force' => [
                             'type'        => 'boolean',
-                            'default'     => false,
+                            'default'     => true,
                             'description' => __( 'Whether to bypass trash and force deletion.', 'dokan-lite' ),
                         ],
                     ],


### PR DESCRIPTION
Add support to force parameter on API requests.
Use false as default because backward compatibility.

Closes #1202