### PR TITLE
Fixed a bug that would allow vendors to change order status even if they don't have permission to do so

### DIFF
--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -192,7 +192,7 @@ class Ajax {
             die();
         }
 
-        if ( ! current_user_can( 'dokandar' ) && 'on' !== dokan_get_option( 'order_status_change', 'dokan_selling', 'on' ) ) {
+        if ( ! current_user_can( 'dokandar' ) || 'on' !== dokan_get_option( 'order_status_change', 'dokan_selling', 'on' ) ) {
             wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'dokan-lite' ) );
         }
 
@@ -290,7 +290,7 @@ class Ajax {
     public function change_order_status() {
         check_ajax_referer( 'dokan_change_status' );
 
-        if ( ! current_user_can( 'dokan_manage_order' ) ) {
+        if ( ! current_user_can( 'dokan_manage_order' ) || 'on' !== dokan_get_option( 'order_status_change', 'dokan_selling', 'on' ) ) {
             wp_send_json_error( __( 'You have no permission to manage this order', 'dokan-lite' ) );
 
             return;

--- a/templates/orders/details.php
+++ b/templates/orders/details.php
@@ -183,7 +183,7 @@ $hide_customer_info = dokan_get_option( 'hide_customer_info', 'dokan_selling', '
                                     <a href="#" class="dokan-edit-status"><small><?php esc_html_e( '&nbsp; Edit', 'dokan-lite' ); ?></small></a>
                                 <?php } ?>
                             </li>
-                            <?php if ( current_user_can( 'dokan_manage_order' ) ): ?>
+                            <?php if ( current_user_can( 'dokan_manage_order' ) && dokan_get_option( 'order_status_change', 'dokan_selling', 'on' ) == 'on' && $order->get_status() !== 'cancelled' && $order->get_status() !== 'refunded' ): ?>
                                 <li class="dokan-hide">
                                     <form id="dokan-order-status-form" action="" method="post">
 


### PR DESCRIPTION
that can be done by show dokan-order-status-form in devtool and change status easily, because "dokan-order-status-form" form always printed even if we change "order_status_change" option to false, that cause to generate a valid nonce too.