### PR TITLE
fix: email template override for dokan vendor completed order

### DIFF
--- a/includes/Emails/Manager.php
+++ b/includes/Emails/Manager.php
@@ -119,6 +119,7 @@ class Manager {
                 'withdraw-cancel.php',
                 'withdraw-approve.php',
                 'vendor-new-order.php',
+                'vendor-completed-order.php',
             )
         );
 


### PR DESCRIPTION
This PR adds some email templates to `dokan_email_list` filter list.

Fix: https://github.com/weDevsOfficial/dokan/issues/1181
