### PR TITLE
fix: display shipping widget though virtual checkbox selected

### DIFF
--- a/assets/src/js/product-editor.js
+++ b/assets/src/js/product-editor.js
@@ -1079,10 +1079,10 @@
             };
         }
 
-        if ( $( 'input#_virtual:checked' ).length && $( 'input#_disable_shipping:checked' ).length ) {
-            $( 'input#_disable_shipping' ).click();
-        }
-
+        $( window ).on( "load", function (){
+            if ( $( 'input#_virtual:checked' ).length ) {
+                show_and_hide_panels();
+            }
+        });
     });
-
 })(jQuery);

--- a/assets/src/js/product-editor.js
+++ b/assets/src/js/product-editor.js
@@ -1054,7 +1054,7 @@
         if ( $('#dokan-edit-product-id').val() && $('#post_title').val() && $('#samplepermalinknonce').val() ) {
             $.post(
                 ajaxurl,
-                {   
+                {
                     action: 'sample-permalink',
                     post_id: $('#dokan-edit-product-id').val(),
                     new_slug: $('#edited-post-name-dokan').val(),
@@ -1077,6 +1077,10 @@
                   callback.apply(context, args);
                 }, ms || 0);
             };
+        }
+
+        if ( $( 'input#_virtual:checked' ).length && $( 'input#_disable_shipping:checked' ).length ) {
+            $( 'input#_disable_shipping' ).click();
         }
 
     });


### PR DESCRIPTION
This PR adds a check if **this product need shipping** is checked and virtual check box is also checked, then we are unchecking shipping checkbox.

Please run `grunt` command.

fix: https://github.com/weDevsOfficial/dokan-pro/issues/1179