### PR TITLE
add a filter before return the orders

### DIFF
--- a/includes/Order/Manager.php
+++ b/includes/Order/Manager.php
@@ -69,6 +69,8 @@ class Manager {
                 }, $orders
             );
 
+            $orders = apply_filters('dokan_get_vendor_orders', $orders, $args);
+
             wp_cache_set( $cache_key, $orders, $cache_group );
             dokan_cache_update_group( $cache_key, $cache_group );
         }


### PR DESCRIPTION
add a filter before return the orders to open the way to add custom features such as assigning a worker to monitor specific orders etc.