### PR TITLE
fix: dokan_product_gallery_image_count action added

### DIFF
--- a/templates/products/new-product.php
+++ b/templates/products/new-product.php
@@ -145,6 +145,7 @@ use WeDevs\Dokan\Walkers\TaxonomyDropdown;
                                             </div>
                                         </div>
                                     </div> <!-- .product-gallery -->
+                                    <?php do_action( 'dokan_product_gallery_image_count' ); ?>
                                 </div>
 
                                 <div class="content-half-part dokan-product-meta">


### PR DESCRIPTION
`dokan_product_gallery_image_count` action hook added to give support for Product Gallery image set restriction in **Add new Product** page.
The hook is already present in Product edit page and add new product popup
for more info please check [this PM task](https://lounge.wedevs.com/wp-admin/admin.php?page=pm_projects#/projects/39/task-lists/1754/tasks/54310)