### PR TITLE
New Rest Route To Get Corresponding Vendors Product Categories Under StoreController

### DIFF
--- a/includes/REST/StoreController.php
+++ b/includes/REST/StoreController.php
@@ -204,6 +204,12 @@ class StoreController extends WP_REST_Controller {
                         'description' => __( 'Unique identifier for the object.', 'dokan-lite' ),
                         'type'        => 'integer',
                     ],
+                    'best_selling' => [
+                        'description' => __( 'Get Best Selling Products Category.', 'dokan-lite' ),
+                        'type'        => 'boolean',
+                        'default'     => false,
+                        'required'    => false,
+                    ],
                 ],
                 [
                     'methods'             => WP_REST_Server::READABLE,
@@ -922,7 +928,8 @@ class StoreController extends WP_REST_Controller {
      * @return WP_Error|\WP_REST_Response
      */
     public function get_store_category( $request ) {
-        $store_id = absint( $request['id'] );
+        $store_id     = absint( $request['id'] );
+        $best_selling = boolval( $request->get_param( 'best_selling' ) );
 
         $store = dokan()->vendor->get( $store_id );
 
@@ -930,7 +937,7 @@ class StoreController extends WP_REST_Controller {
             return new WP_Error( 'no_store_found', __( 'No store found', 'dokan-lite' ), [ 'status' => 404 ] );
         }
 
-        $category_data = $store->get_store_categories();
+        $category_data = $store->get_store_categories( $best_selling );
         $response      = rest_ensure_response( $category_data );
 
         return $response;

--- a/includes/REST/StoreController.php
+++ b/includes/REST/StoreController.php
@@ -196,6 +196,22 @@ class StoreController extends WP_REST_Controller {
                 ],
             ]
         );
+
+        register_rest_route(
+            $this->namespace, '/' . $this->base . '/(?P<id>[\d]+)/categories', [
+                'args' => [
+                    'id' => [
+                        'description' => __( 'Unique identifier for the object.', 'dokan-lite' ),
+                        'type'        => 'integer',
+                    ],
+                ],
+                [
+                    'methods'             => WP_REST_Server::READABLE,
+                    'callback'            => [ $this, 'get_store_category' ],
+                    'permission_callback' => '__return_true',
+                ],
+            ]
+        );
     }
 
     /**
@@ -892,6 +908,30 @@ class StoreController extends WP_REST_Controller {
                 }
             }
         }
+
+        return $response;
+    }
+
+    /**
+     * Get singe store
+     *
+     * @param $request
+     *
+     * @since 3.2.11
+     *
+     * @return WP_Error|\WP_REST_Response
+     */
+    public function get_store_category( $request ) {
+        $store_id = absint( $request['id'] );
+
+        $store = dokan()->vendor->get( $store_id );
+
+        if ( empty( $store->id ) || ! $store instanceof Vendor ) {
+            return new WP_Error( 'no_store_found', __( 'No store found', 'dokan-lite' ), [ 'status' => 404 ] );
+        }
+
+        $category_data = $store->get_store_categories();
+        $response      = rest_ensure_response( $category_data );
 
         return $response;
     }

--- a/includes/Vendor/Vendor.php
+++ b/includes/Vendor/Vendor.php
@@ -575,6 +575,39 @@ class Vendor {
                 if ( $terms && ! is_wp_error( $terms ) ) {
                     foreach ( $terms as $term ) {
                         if ( ! array_key_exists( $term->term_id, $all_categories ) ) {
+                            // get extra information
+                            $display_type            = get_term_meta( $term->term_id, 'display_type', true );
+                            $thumbnail_id            = absint( get_term_meta( $term->term_id, 'thumbnail_id', true ) );
+                            $category_commision_type = get_term_meta( $term->term_id, 'per_category_admin_commission_type', true );
+                            $category_commision      = get_term_meta( $term->term_id, 'per_category_admin_commission', true );
+                            $category_icon           = get_term_meta( $term->term_id, 'dokan_cat_icon', true );
+                            $category_icon_color     = get_term_meta( $term->term_id, 'dokan_cat_icon_color', true );
+
+
+                            // get category image url
+                            if ( $thumbnail_id ) {
+                                $thumbnail = wp_get_attachment_thumb_url( $thumbnail_id );
+                                // get the image URL
+                                $image = wp_get_attachment_url( $thumbnail_id );
+                            } else {
+                                $image = $thumbnail = wc_placeholder_img_src();
+                            }
+
+                            // fix commission
+                            $category_commision = ! empty( $category_commision ) ? wc_format_decimal( $category_commision ) : 0.00;
+
+                            // set extra fields to term object
+                            $term->thumbnail = $thumbnail;
+                            $term->image     = $image;
+                            // set icon and icon color
+                            $term->icon         = $category_icon;
+                            $term->icon_color   = $category_icon_color;
+                            $term->display_type = $display_type;
+                            // set commissions
+                            $term->admin_commission_type = $category_commision_type;
+                            $term->admin_commission      = $category_commision;
+
+                            // finally store category data
                             $all_categories[ $term->term_id ] = $term;
                         }
                     }

--- a/includes/Widgets/StoreCategoryMenu.php
+++ b/includes/Widgets/StoreCategoryMenu.php
@@ -16,7 +16,7 @@ class StoreCategoryMenu extends WP_Widget {
 			'classname' => 'dokan-store-menu',
 			'description' => __( 'Dokan Seller Store Menu', 'dokan-lite' ),
 		);
-        parent::__construct( 'dokan-store-menu', __( 'Dokan: Store Category Menu', 'dokan-lite' ), $widget_ops );
+        parent::__construct( 'dokan-store-menu', __( 'Dokan: Store Product Category Menu', 'dokan-lite' ), $widget_ops );
     }
 
     /**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2742,7 +2742,7 @@ function dokan_get_category_wise_seller_commission( $product_id, $category_id = 
     }
 
     if ( ! empty( $category_commision ) ) {
-        return (float) $category_commision;
+        return wc_format_decimal( $category_commision );
     }
 
     return 0;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -281,7 +281,7 @@ function dokan_count_stock_posts( $post_type, $user_id, $stock_type ) {
         if ( ! $results ) {
             $results = $wpdb->get_results(
                 $wpdb->prepare(
-                    "SELECT p.post_status, COUNT( * ) AS num_posts 
+                    "SELECT p.post_status, COUNT( * ) AS num_posts
                     FROM {$wpdb->prefix}posts as p INNER JOIN {$wpdb->prefix}postmeta as pm ON p.ID = pm.post_id
                     WHERE p.post_type = %s
                     AND p.post_author = %d
@@ -2822,7 +2822,6 @@ add_action( 'dokan_checkout_update_order_meta', 'dokan_cache_reset_seller_order_
 add_action( 'woocommerce_order_status_changed', 'dokan_cache_reset_order_data_on_status', 10, 4 );
 add_action( 'dokan_new_product_added', 'dokan_cache_clear_seller_product_data', 20, 2 );
 add_action( 'dokan_product_updated', 'dokan_cache_clear_seller_product_data', 20 );
-add_action( 'delete_post', 'dokan_cache_clear_deleted_product', 20 );
 
 /**
  * Reset cache group related to seller orders
@@ -2846,20 +2845,6 @@ function dokan_cache_clear_seller_product_data( $product_id, $post_data = [] ) {
     dokan_cache_clear_group( 'dokan_seller_product_data_' . $seller_id );
     dokan_cache_clear_group( 'dokan_cache_seller_product_data_' . $seller_id );
     dokan_cache_clear_group( 'dokan_cache_seller_product_stock_data_' . $seller_id );
-    delete_transient( 'dokan-store-category-' . $seller_id );
-}
-
-/**
- * Reset the cache group for store category when deleted
- *
- * @param int $post_id
- *
- * @return void
- */
-function dokan_cache_clear_deleted_product( $post_id ) {
-    $seller_id = get_post_field( 'post_author', $post_id );
-
-    delete_transient( 'dokan-store-category-' . $seller_id );
 }
 
 /**

--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -584,41 +584,24 @@ if ( ! function_exists( 'dokan_store_category_menu' ) ) :
      * Store category menu for a store
      *
      * @param  int $seller_id
+     *
+     * @since 3.2.11 rewritten whole function
+     *
      * @return void
      */
     function dokan_store_category_menu( $seller_id, $title = '' ) {
         ?>
     <div id="cat-drop-stack" class="store-cat-stack-dokan">
         <?php
-        $vendor      = dokan()->vendor->get( get_query_var( 'author' ) );
-        $vendor_id   = $vendor->get_id();
-        $products    = $vendor->get_products();
-        $product_ids = [];
-        foreach ( $products->posts as $product ) {
-            array_push( $product_ids, $product->ID );
+        $seller_id = empty( $seller_id ) ? get_query_var( 'author' ) : $seller_id;
+        $vendor    = dokan()->vendor->get( $seller_id );
+        if ( $vendor instanceof \WeDevs\Dokan\Vendor\Vendor ) {
+            $categories = $vendor->get_store_categories();
+            $walker = new \WeDevs\Dokan\Walkers\StoreCategory( $seller_id );
+            echo '<ul>';
+            echo call_user_func_array( array( &$walker, 'walk' ), array( $categories, 0, array() ) ); //phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+            echo '</ul>';
         }
-        // hold all the terms
-        $all_terms = [];
-        foreach ( $product_ids as $product_id ) {
-            $terms = get_the_terms( $product_id, 'product_cat' );
-
-            //allow when there is terms and do not have any wp_errors
-            if ( $terms && ! is_wp_error( $terms ) ) {
-                foreach ( $terms as $term ) {
-                    array_push( $all_terms, $term );
-                }
-            }
-        }
-        // hold unique categoreis
-        $categories = [];
-        foreach ( $all_terms as $term ) {
-            $categories[ serialize( $term ) ] = $term;
-        }
-        $categories = array_values( $categories );
-        $walker = new \WeDevs\Dokan\Walkers\StoreCategory( $seller_id );
-        echo '<ul>';
-        echo call_user_func_array( array( &$walker, 'walk' ), array( $categories, 0, array() ) ); //phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
-        echo '</ul>';
         ?>
     </div>
         <?php

--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -153,7 +153,7 @@ function dokan_product_dashboard_errors() {
             dokan_get_template_part(
                 'global/dokan-success', '', array(
                     'deleted' => true,
-                    'message' => __( 'Product succesfully deleted', 'dokan-lite' ),
+                    'message' => __( 'Product successfully deleted', 'dokan-lite' ),
                 )
             );
             break;

--- a/includes/wc-functions.php
+++ b/includes/wc-functions.php
@@ -1042,6 +1042,7 @@ function dokan_clear_edit_product_category_cache( $term_id ) {
     }
 }
 add_action( 'edit_product_cat', 'dokan_clear_edit_product_category_cache', 10, 1 );
+add_action( 'pre_delete_term', 'dokan_clear_edit_product_category_cache', 10, 1 );
 
 if ( ! function_exists( 'dokan_date_time_format' ) ) {
 

--- a/includes/wc-functions.php
+++ b/includes/wc-functions.php
@@ -956,6 +956,12 @@ function dokan_clear_product_category_cache( $post_id ) {
     $seller_id = get_post_field( 'post_author', $post_id );
 
     delete_transient( 'dokan-store-category-' . $seller_id );
+
+    // delete vendor get_published_products() method transient
+    delete_transient( 'dokan_vendor_get_published_products_' . $seller_id );
+
+    // delete vendor get_store_categories() method transient
+    delete_transient( 'dokan_vendor_get_store_categories_' . $seller_id );
 }
 
 if ( ! function_exists( 'dokan_date_time_format' ) ) {

--- a/includes/wc-functions.php
+++ b/includes/wc-functions.php
@@ -1000,8 +1000,8 @@ function dokan_clear_best_selling_product_category_cache( $order_id ) {
     delete_transient( 'dokan_vendor_get_best_selling_products_' . $seller_id );
     delete_transient( 'dokan_vendor_get_best_selling_categories_' . $seller_id );
 }
-add_action( 'woocommerce_new_order', array( $this, 'dokan_clear_best_selling_product_category_cache' ), 10, 1 );
-add_action( 'woocommerce_update_order', array( $this, 'dokan_clear_best_selling_product_category_cache' ), 10, 1 );
+add_action( 'woocommerce_new_order', 'dokan_clear_best_selling_product_category_cache', 10, 1 );
+add_action( 'woocommerce_update_order', 'dokan_clear_best_selling_product_category_cache', 10, 1 );
 
 /**
  * This method will delete store category cache after a category is updated

--- a/includes/wc-functions.php
+++ b/includes/wc-functions.php
@@ -941,10 +941,10 @@ function dokan_save_account_details() {
 
 add_action( 'template_redirect', 'dokan_save_account_details' );
 
-add_action( 'trashed_post', 'dokan_clear_product_category_cache' );
-add_action( 'deleted_post', 'dokan_clear_product_category_cache' );
-add_action( 'dokan_new_product_added', 'dokan_clear_product_category_cache' );
-add_action( 'dokan_product_updated', 'dokan_clear_product_category_cache' );
+add_action( 'wp_trash_post', 'dokan_clear_product_category_cache' );
+add_action( 'delete_post', 'dokan_clear_product_category_cache' );
+add_action( 'woocommerce_new_product', 'dokan_clear_product_category_cache' );
+add_action( 'woocommerce_update_product', 'dokan_clear_product_category_cache' );
 
 function dokan_clear_product_category_cache( $post_id ) {
     $product = wc_get_product( $post_id );
@@ -1135,24 +1135,6 @@ function dokan_bulk_order_status_change() {
 }
 
 add_action( 'template_redirect', 'dokan_bulk_order_status_change' );
-
-/**
- * Clear transient once a product is saved or deleted
- *
- * @param int $post_id
- *
- * @return void
- */
-function dokan_store_category_delete_transient( $post_id ) {
-    $post_tmp  = get_post( $post_id );
-    $seller_id = $post_tmp->post_author;
-
-    //delete store category transient
-    delete_transient( 'dokan-store-category-' . $seller_id );
-}
-
-add_action( 'delete_post', 'dokan_store_category_delete_transient' );
-add_action( 'save_post', 'dokan_store_category_delete_transient' );
 
 /**
  * Add vendor email on customers note mail replay to


### PR DESCRIPTION
new: added a new method named get_published_products() under Vendor class to get all published products of a vendor
new: added a new method named get_store_categories() under Vendor class to get all published products assigned categories
new: added get_best_selling_products() method under Vendor class
new added best selling products category support under get_store_categories() in Vendor class

update: rewritten store category dokan_store_category_menu() function

REST API:
new: added a new rest route name id/categories under StoreController to get corresponding vendors published product categories (wp-json/dokan/v1/stores/3/categories)
new: added popular category support under StoreController rest API (wp-json/dokan/v1/stores/3/categories?best_selling=1)

