### PR TITLE
fix: shipping is not creating for sub orders, for this shipping address is missing in  customer order details, vendor order email

### DIFF
--- a/includes/Order/Manager.php
+++ b/includes/Order/Manager.php
@@ -274,8 +274,8 @@ class Manager {
         if ( $shipping_methods ) {
             foreach ( $shipping_methods as $method_item_id => $shipping_object ) {
                 $shipping_seller_id = wc_get_order_item_meta( $method_item_id, 'seller_id', true );
-
-                if ( $order_seller_id == $shipping_seller_id ) {
+                // In dokan lite, we do not have any dokan shipping methods.
+                if ( ! dokan()->is_pro_exists() || $order_seller_id === $shipping_seller_id ) {
                     $applied_shipping_method = $shipping_object;
                     break;
                 }

--- a/includes/Order/Manager.php
+++ b/includes/Order/Manager.php
@@ -295,14 +295,25 @@ class Manager {
 
             dokan_log( sprintf( '#%d - Adding shipping item.', $order->get_id() ) );
 
-            $item->set_props(
-                array(
-					'method_title' => $shipping_method->get_name(),
-					'method_id'    => $shipping_method->get_method_id(),
-					'total'        => $shipping_method->get_total(),
-					'taxes'        => $shipping_method->get_taxes(),
-                )
-            );
+            if ( ! dokan()->is_pro_exists() ) {
+                $item->set_props(
+                    array(
+                        'method_title' => $shipping_method->get_name(),
+                        'method_id'    => $shipping_method->get_method_id(),
+                        'total'        => 0.00,
+                        'taxes'        => 0.00,
+                    )
+                );
+            } else {
+                $item->set_props(
+                    array(
+                        'method_title' => $shipping_method->get_name(),
+                        'method_id'    => $shipping_method->get_method_id(),
+                        'total'        => $shipping_method->get_total(),
+                        'taxes'        => $shipping_method->get_taxes(),
+                    )
+                );
+            }
 
             $metadata = $shipping_method->get_meta_data();
 

--- a/includes/Order/Manager.php
+++ b/includes/Order/Manager.php
@@ -275,7 +275,7 @@ class Manager {
             foreach ( $shipping_methods as $method_item_id => $shipping_object ) {
                 $shipping_seller_id = wc_get_order_item_meta( $method_item_id, 'seller_id', true );
                 // In dokan lite, we do not have any dokan shipping methods.
-                if ( ! dokan()->is_pro_exists() || $order_seller_id === $shipping_seller_id ) {
+                if ( ! dokan()->is_pro_exists() || $order_seller_id === absint( $shipping_seller_id ) ) {
                     $applied_shipping_method = $shipping_object;
                     break;
                 }


### PR DESCRIPTION
We were checking for shipping methods associated with the seller during creating a suborder shipping.

Currently, we are not associating any shipping methods with any seller in Dokan lite.

Here we are checking if the pro is activated during the comparison for the shipping method associated with the seller.

Fix: #1288 