### PR TITLE
Fix #1282 : unable to remove downloadable file

### DIFF
--- a/includes/wc-functions.php
+++ b/includes/wc-functions.php
@@ -362,6 +362,8 @@ function dokan_process_product_meta( $post_id, $data = [] ) {
             do_action( 'dokan_process_file_download', $post_id, 0, $files );
 
             update_post_meta( $post_id, '_downloadable_files', $files );
+        } else {
+            update_post_meta( $post_id, '_downloadable_files', '' );
         }
 
         update_post_meta( $post_id, '_download_limit', $_download_limit );


### PR DESCRIPTION
**Fix:** Downloadable file was unable to be removed when there only one file exists

fixes https://github.com/weDevsOfficial/dokan/issues/1282