### PR TITLE
feat: Set limitation for how many product tags that vendor can input

### DIFF
--- a/assets/js/dokan.js
+++ b/assets/js/dokan.js
@@ -785,6 +785,7 @@ jQuery(function($) {
                     if ( ! $found ) data.unshift( tag );
                 },
                 minimumInputLength: 2,
+                maximumSelectionLength: dokan.maximum_tags_select_length !== undefined ? dokan.maximum_tags_select_length : -1,
                 ajax: {
                     url: dokan.ajaxurl,
                     dataType: 'json',

--- a/assets/src/js/product-editor.js
+++ b/assets/src/js/product-editor.js
@@ -182,6 +182,7 @@
                     if ( ! $found ) data.unshift( tag );
                 },
                 minimumInputLength: 2,
+                maximumSelectionLength: dokan.maximum_tags_select_length !== undefined ? dokan.maximum_tags_select_length : -1,
                 ajax: {
                     url: dokan.ajaxurl,
                     dataType: 'json',

--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -430,6 +430,7 @@ class Assets {
             'product_types'      => apply_filters( 'dokan_product_types', [ 'simple' ] ),
             'loading_img'        => DOKAN_PLUGIN_ASSEST . '/images/loading.gif',
             'store_product_search_nonce' => wp_create_nonce( 'dokan_store_product_search_nonce' ),
+            'maximum_tags_select_length' => apply_filters( 'dokan_maximum_tags_select_length', -1 ),  // Filter of maximun a vendor can add tags
         ];
 
         $localize_script     = apply_filters( 'dokan_localized_args', $default_script );

--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -414,23 +414,30 @@ class Assets {
         }
 
         $default_script = [
-            'ajaxurl'            => admin_url( 'admin-ajax.php' ),
-            'nonce'              => wp_create_nonce( 'dokan_reviews' ),
-            'ajax_loader'        => DOKAN_PLUGIN_ASSEST . '/images/ajax-loader.gif',
-            'seller'             => [
+            'ajaxurl'                    => admin_url( 'admin-ajax.php' ),
+            'nonce'                      => wp_create_nonce( 'dokan_reviews' ),
+            'ajax_loader'                => DOKAN_PLUGIN_ASSEST . '/images/ajax-loader.gif',
+            'seller'                     => [
                 'available'     => __( 'Available', 'dokan-lite' ),
                 'notAvailable'  => __( 'Not Available', 'dokan-lite' ),
             ],
-            'delete_confirm'     => __( 'Are you sure?', 'dokan-lite' ),
-            'wrong_message'      => __( 'Something went wrong. Please try again.', 'dokan-lite' ),
-            'vendor_percentage'  => dokan_get_seller_percentage( dokan_get_current_user_id() ),
-            'commission_type'    => dokan_get_commission_type( dokan_get_current_user_id() ),
-            'rounding_precision' => wc_get_rounding_precision(),
-            'mon_decimal_point'  => wc_get_price_decimal_separator(),
-            'product_types'      => apply_filters( 'dokan_product_types', [ 'simple' ] ),
-            'loading_img'        => DOKAN_PLUGIN_ASSEST . '/images/loading.gif',
+            'delete_confirm'             => __( 'Are you sure?', 'dokan-lite' ),
+            'wrong_message'              => __( 'Something went wrong. Please try again.', 'dokan-lite' ),
+            'vendor_percentage'          => dokan_get_seller_percentage( dokan_get_current_user_id() ),
+            'commission_type'            => dokan_get_commission_type( dokan_get_current_user_id() ),
+            'rounding_precision'         => wc_get_rounding_precision(),
+            'mon_decimal_point'          => wc_get_price_decimal_separator(),
+            'product_types'              => apply_filters( 'dokan_product_types', [ 'simple' ] ),
+            'loading_img'                => DOKAN_PLUGIN_ASSEST . '/images/loading.gif',
             'store_product_search_nonce' => wp_create_nonce( 'dokan_store_product_search_nonce' ),
-            'maximum_tags_select_length' => apply_filters( 'dokan_maximum_tags_select_length', -1 ),  // Filter of maximun a vendor can add tags
+            /**
+             * Filter of maximun a vendor can add tags.
+             *
+             * @since 3.3.7
+             *
+             * @param integer default -1
+             */
+            'maximum_tags_select_length' => apply_filters( 'dokan_product_tags_select_max_length', -1 ),  // Filter of maximun a vendor can add tags
         ];
 
         $localize_script     = apply_filters( 'dokan_localized_args', $default_script );

--- a/includes/Dashboard/Templates/Products.php
+++ b/includes/Dashboard/Templates/Products.php
@@ -431,8 +431,8 @@ class Products {
             $maximum_tags_select_length = apply_filters( 'dokan_maximum_tags_select_length', -1 );
 
             // Setting limitation for how many product tags that vendor can input.
-            if ( $maximum_tags_select_length !== 0 && $maximum_tags_select_length !== -1 && count( $postdata['product_tag'] ) !== 0 && count( $postdata['product_tag'] ) > $maximum_tags_select_length ) {
-                $errors[] = sprintf( __( 'You can only select %s items', 'dokan-lite' ), number_format_i18n( $maximum_tags_select_length ) );
+            if ( $maximum_tags_select_length !== -1 && count( $postdata['product_tag'] ) !== 0 && count( $postdata['product_tag'] ) > $maximum_tags_select_length ) {
+                $errors[] = sprintf( __( 'You can only select %s tags', 'dokan-lite' ), number_format_i18n( $maximum_tags_select_length ) );
             }
         }
 

--- a/includes/Dashboard/Templates/Products.php
+++ b/includes/Dashboard/Templates/Products.php
@@ -426,6 +426,16 @@ class Products {
             $errors[] = __( 'I swear this is not your product!', 'dokan-lite' );
         }
 
+        if ( isset( $postdata['product_tag'] ) ) {
+            // Filter of maximun a vendor can add tags
+            $maximum_tags_select_length = apply_filters( 'dokan_maximum_tags_select_length', -1 );
+
+            // Setting limitation for how many product tags that vendor can input.
+            if ( $maximum_tags_select_length !== -1 && count( $postdata['product_tag'] ) !== 0 && count( $postdata['product_tag'] ) > $maximum_tags_select_length ) {
+                $errors[] = sprintf( __( 'You can only select %s items', 'dokan-lite' ), number_format_i18n( $maximum_tags_select_length ) );
+            }
+        }
+
         self::$errors = apply_filters( 'dokan_can_edit_product', $errors );
 
         if ( ! self::$errors ) {
@@ -437,7 +447,7 @@ class Products {
                 'post_status'    => $post_status,
                 'comment_status' => isset( $postdata['_enable_reviews'] ) ? 'open' : 'closed',
             ) );
-            
+
             if ( $post_slug ) {
                 $product_info['post_name'] = wp_unique_post_slug( $post_slug, $post_id, $post_status, 'product', 0 );
             }

--- a/includes/Dashboard/Templates/Products.php
+++ b/includes/Dashboard/Templates/Products.php
@@ -431,7 +431,7 @@ class Products {
             $maximum_tags_select_length = apply_filters( 'dokan_maximum_tags_select_length', -1 );
 
             // Setting limitation for how many product tags that vendor can input.
-            if ( $maximum_tags_select_length !== -1 && count( $postdata['product_tag'] ) !== 0 && count( $postdata['product_tag'] ) > $maximum_tags_select_length ) {
+            if ( $maximum_tags_select_length !== 0 && $maximum_tags_select_length !== -1 && count( $postdata['product_tag'] ) !== 0 && count( $postdata['product_tag'] ) > $maximum_tags_select_length ) {
                 $errors[] = sprintf( __( 'You can only select %s items', 'dokan-lite' ), number_format_i18n( $maximum_tags_select_length ) );
             }
         }

--- a/includes/Dashboard/Templates/Products.php
+++ b/includes/Dashboard/Templates/Products.php
@@ -427,8 +427,14 @@ class Products {
         }
 
         if ( isset( $postdata['product_tag'] ) ) {
-            // Filter of maximun a vendor can add tags
-            $maximum_tags_select_length = apply_filters( 'dokan_maximum_tags_select_length', -1 );
+            /**
+             * Filter of maximun a vendor can add tags.
+             *
+             * @since 3.3.7
+             *
+             * @param integer default -1
+             */
+            $maximum_tags_select_length = apply_filters( 'dokan_product_tags_select_max_length', -1 );
 
             // Setting limitation for how many product tags that vendor can input.
             if ( $maximum_tags_select_length !== -1 && count( $postdata['product_tag'] ) !== 0 && count( $postdata['product_tag'] ) > $maximum_tags_select_length ) {

--- a/includes/Product/functions.php
+++ b/includes/Product/functions.php
@@ -102,7 +102,7 @@ function dokan_save_product( $args ) {
         $maximum_tags_select_length = apply_filters( 'dokan_maximum_tags_select_length', -1 );
 
         // Setting limitation for how many product tags that vendor can input.
-        if ( $maximum_tags_select_length !== -1 && count( $data['product_tag'] ) !== 0 && count( $data['product_tag'] ) > $maximum_tags_select_length ) {
+        if ( $maximum_tags_select_length !== 0 && $maximum_tags_select_length !== -1 && count( $data['product_tag'] ) !== 0 && count( $data['product_tag'] ) > $maximum_tags_select_length ) {
             return new WP_Error( 'tags-limit', sprintf( __( 'You can only select %s items', 'dokan-lite' ), number_format_i18n( $maximum_tags_select_length ) ) );
         }
 

--- a/includes/Product/functions.php
+++ b/includes/Product/functions.php
@@ -102,8 +102,8 @@ function dokan_save_product( $args ) {
         $maximum_tags_select_length = apply_filters( 'dokan_maximum_tags_select_length', -1 );
 
         // Setting limitation for how many product tags that vendor can input.
-        if ( $maximum_tags_select_length !== 0 && $maximum_tags_select_length !== -1 && count( $data['product_tag'] ) !== 0 && count( $data['product_tag'] ) > $maximum_tags_select_length ) {
-            return new WP_Error( 'tags-limit', sprintf( __( 'You can only select %s items', 'dokan-lite' ), number_format_i18n( $maximum_tags_select_length ) ) );
+        if ( $maximum_tags_select_length !== -1 && count( $data['product_tag'] ) !== 0 && count( $data['product_tag'] ) > $maximum_tags_select_length ) {
+            return new WP_Error( 'tags-limit', sprintf( __( 'You can only select %s tags', 'dokan-lite' ), number_format_i18n( $maximum_tags_select_length ) ) );
         }
 
         $post_data['tags'] = array_map( 'absint', (array) $data['product_tag'] );

--- a/includes/Product/functions.php
+++ b/includes/Product/functions.php
@@ -98,11 +98,18 @@ function dokan_save_product( $args ) {
     }
 
     if ( isset( $data['product_tag'] ) ) {
-        // Filter of maximun a vendor can add tags
-        $maximum_tags_select_length = apply_filters( 'dokan_maximum_tags_select_length', -1 );
+        /**
+         * Filter of maximun a vendor can add tags.
+         *
+         * @since 3.3.7
+         *
+         * @param integer default -1
+         */
+        $maximum_tags_select_length = apply_filters( 'dokan_product_tags_select_max_length', -1 );
 
         // Setting limitation for how many product tags that vendor can input.
         if ( $maximum_tags_select_length !== -1 && count( $data['product_tag'] ) !== 0 && count( $data['product_tag'] ) > $maximum_tags_select_length ) {
+            /* translators: %s: maximum tag length */
             return new WP_Error( 'tags-limit', sprintf( __( 'You can only select %s tags', 'dokan-lite' ), number_format_i18n( $maximum_tags_select_length ) ) );
         }
 

--- a/includes/Product/functions.php
+++ b/includes/Product/functions.php
@@ -98,6 +98,14 @@ function dokan_save_product( $args ) {
     }
 
     if ( isset( $data['product_tag'] ) ) {
+        // Filter of maximun a vendor can add tags
+        $maximum_tags_select_length = apply_filters( 'dokan_maximum_tags_select_length', -1 );
+
+        // Setting limitation for how many product tags that vendor can input.
+        if ( $maximum_tags_select_length !== -1 && count( $data['product_tag'] ) !== 0 && count( $data['product_tag'] ) > $maximum_tags_select_length ) {
+            return new WP_Error( 'tags-limit', sprintf( __( 'You can only select %s items', 'dokan-lite' ), number_format_i18n( $maximum_tags_select_length ) ) );
+        }
+
         $post_data['tags'] = array_map( 'absint', (array) $data['product_tag'] );
     }
 

--- a/templates/products/tmpl-add-product-popup.php
+++ b/templates/products/tmpl-add-product-popup.php
@@ -142,12 +142,10 @@ use WeDevs\Dokan\Walkers\TaxonomyDropdown;
                         </div>
                     <?php endif; ?>
 
-                    <?php if ( apply_filters( 'dokan_maximum_tags_select_length', -1 ) !== 0 ): ?>
                     <div class="dokan-form-group">
                         <label for="product_tag" class="form-label"><?php esc_html_e( 'Tags', 'dokan-lite' ); ?></label>
                         <select multiple="multiple" name="product_tag[]" id="product_tag_search" class="product_tag_search product_tags dokan-form-control dokan-select2" data-placeholder="<?php echo esc_attr( $tags_placeholder ); ?>"></select>
                     </div>
-                    <?php endif; ?>
 
                     <?php do_action( 'dokan_new_product_after_product_tags' ); ?>
 

--- a/templates/products/tmpl-add-product-popup.php
+++ b/templates/products/tmpl-add-product-popup.php
@@ -142,10 +142,12 @@ use WeDevs\Dokan\Walkers\TaxonomyDropdown;
                         </div>
                     <?php endif; ?>
 
+                    <?php if ( apply_filters( 'dokan_maximum_tags_select_length', -1 ) !== 0 ): ?>
                     <div class="dokan-form-group">
                         <label for="product_tag" class="form-label"><?php esc_html_e( 'Tags', 'dokan-lite' ); ?></label>
                         <select multiple="multiple" name="product_tag[]" id="product_tag_search" class="product_tag_search product_tags dokan-form-control dokan-select2" data-placeholder="<?php echo esc_attr( $tags_placeholder ); ?>"></select>
                     </div>
+                    <?php endif; ?>
 
                     <?php do_action( 'dokan_new_product_after_product_tags' ); ?>
 


### PR DESCRIPTION
Previously, vendor could add unlimited tags on his/her product in add, edit product.

But now I have added a new filter called `dokan_maximum_tags_select_length` by which maximum tag addition number can be changed. 

Also added validation in frontend and backend for maximum tag add and edit
frontend validation: https://prnt.sc/1s8veg8
Backend validation: https://prnt.sc/1s8vspn

fixes #1236 Similar code fix in dokan pro https://github.com/weDevsOfficial/dokan-pro/pull/1471