### PR TITLE
Fix: Vendor earning calculation with tax

### DIFF
--- a/templates/products/products-listing-row.php
+++ b/templates/products/products-listing-row.php
@@ -94,7 +94,7 @@
             $price = dokan_get_variable_product_earning( $product->get_id() );
             echo wp_kses( $price, $price_kses );
         } else {
-            $price = wc_price( dokan()->commission->get_earning_by_product( $product ) );
+            $price = wc_price( dokan()->commission->get_earning_by_product( $product, 'seller', wc_get_price_to_display( $product ) ) );
             echo wp_kses( $price, $price_kses );
         }
         ?>


### PR DESCRIPTION
Previously there was no effect on vendor earnings when WooCommerce tax change. If admin display prices including tax from [WooCommerce settings](https://prnt.sc/1s8wbgc) its calculate product price including tax but not in [vendor earning](https://prnt.sc/1s8wzhr). 

After changing this line showing [vendor earing with tax](https://prnt.sc/1s8xyc9):

`$price = wc_price( dokan()->commission->get_earning_by_product( $product, 'seller', wc_get_price_to_display( $product ) ) );`