### PR TITLE
fix/vendor-info

### DIFF
--- a/templates/global/product-tab.php
+++ b/templates/global/product-tab.php
@@ -13,24 +13,23 @@
 <ul class="list-unstyled">
     <?php do_action( 'dokan_product_seller_tab_start', $author, $store_info ); ?>
 
-    <?php if ( !empty( $store_info['store_name'] ) ) { ?>
+    <?php if ( !empty( $store_info['store_name'] ) ) : ?>
         <li class="store-name">
             <span><?php esc_html_e( 'Store Name:', 'dokan-lite' ); ?></span>
             <span class="details">
                 <?php echo esc_html( $store_info['store_name'] ); ?>
             </span>
         </li>
-    <?php } ?>
+        <li class="seller-name">
+            <span>
+                <?php esc_html_e( 'Vendor:', 'dokan-lite' ); ?>
+            </span>
 
-    <li class="seller-name">
-        <span>
-            <?php esc_html_e( 'Vendor:', 'dokan-lite' ); ?>
-        </span>
-
-        <span class="details">
-            <?php printf( '<a href="%s">%s</a>', esc_url( dokan_get_store_url( $author->ID ) ), esc_attr( $author->display_name ) ); ?>
-        </span>
-    </li>
+            <span class="details">
+                <?php printf( '<a href="%1$s">%2$s</a>', esc_url( dokan_get_store_url( $author->ID ) ), esc_html( $store_info['store_name'] ) ); ?>
+            </span>
+        </li>
+    <?php endif; ?>
     <?php if ( ! dokan_is_vendor_info_hidden( 'address' ) && ! empty( $store_info['address'] ) ) { ?>
         <li class="store-address">
             <span><b><?php esc_html_e( 'Address:', 'dokan-lite' ); ?></b></span>


### PR DESCRIPTION
The single product page displays the seller's real name on the vendor info tab.
https://prnt.sc/1s8w0xd

Fix #1143