### PR TITLE
Fix/geolocation filter form vendor search url redirect

### DIFF
--- a/assets/js/dokan.js
+++ b/assets/js/dokan.js
@@ -785,6 +785,7 @@ jQuery(function($) {
                     if ( ! $found ) data.unshift( tag );
                 },
                 minimumInputLength: 2,
+                maximumSelectionLength: dokan.maximum_tags_select_length !== undefined ? dokan.maximum_tags_select_length : -1,
                 ajax: {
                     url: dokan.ajaxurl,
                     dataType: 'json',

--- a/assets/src/js/product-editor.js
+++ b/assets/src/js/product-editor.js
@@ -182,6 +182,7 @@
                     if ( ! $found ) data.unshift( tag );
                 },
                 minimumInputLength: 2,
+                maximumSelectionLength: dokan.maximum_tags_select_length !== undefined ? dokan.maximum_tags_select_length : -1,
                 ajax: {
                     url: dokan.ajaxurl,
                     dataType: 'json',

--- a/includes/Abstracts/DokanShortcode.php
+++ b/includes/Abstracts/DokanShortcode.php
@@ -18,5 +18,5 @@ abstract class DokanShortcode {
         return $this->shortcode;
     }
 
-    abstract public function render_shortcode( $atts );
+    abstract public function render_shortcode( $atts, $content = null, $tag = '' );
 }

--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -430,6 +430,7 @@ class Assets {
             'product_types'      => apply_filters( 'dokan_product_types', [ 'simple' ] ),
             'loading_img'        => DOKAN_PLUGIN_ASSEST . '/images/loading.gif',
             'store_product_search_nonce' => wp_create_nonce( 'dokan_store_product_search_nonce' ),
+            'maximum_tags_select_length' => apply_filters( 'dokan_maximum_tags_select_length', -1 ),  // Filter of maximun a vendor can add tags
         ];
 
         $localize_script     = apply_filters( 'dokan_localized_args', $default_script );

--- a/includes/Dashboard/Templates/Products.php
+++ b/includes/Dashboard/Templates/Products.php
@@ -431,8 +431,8 @@ class Products {
             $maximum_tags_select_length = apply_filters( 'dokan_maximum_tags_select_length', -1 );
 
             // Setting limitation for how many product tags that vendor can input.
-            if ( $maximum_tags_select_length !== 0 && $maximum_tags_select_length !== -1 && count( $postdata['product_tag'] ) !== 0 && count( $postdata['product_tag'] ) > $maximum_tags_select_length ) {
-                $errors[] = sprintf( __( 'You can only select %s items', 'dokan-lite' ), number_format_i18n( $maximum_tags_select_length ) );
+            if ( $maximum_tags_select_length !== -1 && count( $postdata['product_tag'] ) !== 0 && count( $postdata['product_tag'] ) > $maximum_tags_select_length ) {
+                $errors[] = sprintf( __( 'You can only select %s tags', 'dokan-lite' ), number_format_i18n( $maximum_tags_select_length ) );
             }
         }
 

--- a/includes/Dashboard/Templates/Products.php
+++ b/includes/Dashboard/Templates/Products.php
@@ -426,6 +426,16 @@ class Products {
             $errors[] = __( 'I swear this is not your product!', 'dokan-lite' );
         }
 
+        if ( isset( $postdata['product_tag'] ) ) {
+            // Filter of maximun a vendor can add tags
+            $maximum_tags_select_length = apply_filters( 'dokan_maximum_tags_select_length', -1 );
+
+            // Setting limitation for how many product tags that vendor can input.
+            if ( $maximum_tags_select_length !== -1 && count( $postdata['product_tag'] ) !== 0 && count( $postdata['product_tag'] ) > $maximum_tags_select_length ) {
+                $errors[] = sprintf( __( 'You can only select %s items', 'dokan-lite' ), number_format_i18n( $maximum_tags_select_length ) );
+            }
+        }
+
         self::$errors = apply_filters( 'dokan_can_edit_product', $errors );
 
         if ( ! self::$errors ) {
@@ -437,7 +447,7 @@ class Products {
                 'post_status'    => $post_status,
                 'comment_status' => isset( $postdata['_enable_reviews'] ) ? 'open' : 'closed',
             ) );
-            
+
             if ( $post_slug ) {
                 $product_info['post_name'] = wp_unique_post_slug( $post_slug, $post_id, $post_status, 'product', 0 );
             }

--- a/includes/Dashboard/Templates/Products.php
+++ b/includes/Dashboard/Templates/Products.php
@@ -431,7 +431,7 @@ class Products {
             $maximum_tags_select_length = apply_filters( 'dokan_maximum_tags_select_length', -1 );
 
             // Setting limitation for how many product tags that vendor can input.
-            if ( $maximum_tags_select_length !== -1 && count( $postdata['product_tag'] ) !== 0 && count( $postdata['product_tag'] ) > $maximum_tags_select_length ) {
+            if ( $maximum_tags_select_length !== 0 && $maximum_tags_select_length !== -1 && count( $postdata['product_tag'] ) !== 0 && count( $postdata['product_tag'] ) > $maximum_tags_select_length ) {
                 $errors[] = sprintf( __( 'You can only select %s items', 'dokan-lite' ), number_format_i18n( $maximum_tags_select_length ) );
             }
         }

--- a/includes/Product/functions.php
+++ b/includes/Product/functions.php
@@ -102,7 +102,7 @@ function dokan_save_product( $args ) {
         $maximum_tags_select_length = apply_filters( 'dokan_maximum_tags_select_length', -1 );
 
         // Setting limitation for how many product tags that vendor can input.
-        if ( $maximum_tags_select_length !== -1 && count( $data['product_tag'] ) !== 0 && count( $data['product_tag'] ) > $maximum_tags_select_length ) {
+        if ( $maximum_tags_select_length !== 0 && $maximum_tags_select_length !== -1 && count( $data['product_tag'] ) !== 0 && count( $data['product_tag'] ) > $maximum_tags_select_length ) {
             return new WP_Error( 'tags-limit', sprintf( __( 'You can only select %s items', 'dokan-lite' ), number_format_i18n( $maximum_tags_select_length ) ) );
         }
 

--- a/includes/Product/functions.php
+++ b/includes/Product/functions.php
@@ -102,8 +102,8 @@ function dokan_save_product( $args ) {
         $maximum_tags_select_length = apply_filters( 'dokan_maximum_tags_select_length', -1 );
 
         // Setting limitation for how many product tags that vendor can input.
-        if ( $maximum_tags_select_length !== 0 && $maximum_tags_select_length !== -1 && count( $data['product_tag'] ) !== 0 && count( $data['product_tag'] ) > $maximum_tags_select_length ) {
-            return new WP_Error( 'tags-limit', sprintf( __( 'You can only select %s items', 'dokan-lite' ), number_format_i18n( $maximum_tags_select_length ) ) );
+        if ( $maximum_tags_select_length !== -1 && count( $data['product_tag'] ) !== 0 && count( $data['product_tag'] ) > $maximum_tags_select_length ) {
+            return new WP_Error( 'tags-limit', sprintf( __( 'You can only select %s tags', 'dokan-lite' ), number_format_i18n( $maximum_tags_select_length ) ) );
         }
 
         $post_data['tags'] = array_map( 'absint', (array) $data['product_tag'] );

--- a/includes/Product/functions.php
+++ b/includes/Product/functions.php
@@ -98,6 +98,14 @@ function dokan_save_product( $args ) {
     }
 
     if ( isset( $data['product_tag'] ) ) {
+        // Filter of maximun a vendor can add tags
+        $maximum_tags_select_length = apply_filters( 'dokan_maximum_tags_select_length', -1 );
+
+        // Setting limitation for how many product tags that vendor can input.
+        if ( $maximum_tags_select_length !== -1 && count( $data['product_tag'] ) !== 0 && count( $data['product_tag'] ) > $maximum_tags_select_length ) {
+            return new WP_Error( 'tags-limit', sprintf( __( 'You can only select %s items', 'dokan-lite' ), number_format_i18n( $maximum_tags_select_length ) ) );
+        }
+
         $post_data['tags'] = array_map( 'absint', (array) $data['product_tag'] );
     }
 

--- a/includes/Shortcodes/BestSellingProduct.php
+++ b/includes/Shortcodes/BestSellingProduct.php
@@ -15,7 +15,7 @@ class BestSellingProduct extends DokanShortcode {
      *
      * @return string
      */
-    public function render_shortcode( $atts ) {
+    public function render_shortcode(  $atts, $content = null, $tag = '' ) {
         /**
         * Filter return the number of best selling product per page.
         *

--- a/includes/Shortcodes/Dashboard.php
+++ b/includes/Shortcodes/Dashboard.php
@@ -18,7 +18,7 @@ class Dashboard extends DokanShortcode {
      *
      * @return void
      */
-    public function render_shortcode( $atts ) {
+    public function render_shortcode(  $atts, $content = null, $tag = '' ) {
         global $wp;
 
         if ( ! function_exists( 'WC' ) ) {

--- a/includes/Shortcodes/MyOrders.php
+++ b/includes/Shortcodes/MyOrders.php
@@ -13,7 +13,7 @@ class MyOrders extends DokanShortcode {
      *
      * @return string
      */
-    public function render_shortcode( $atts ) {
+    public function render_shortcode(  $atts, $content = null, $tag = '' ) {
         if ( ! is_user_logged_in() ) {
             return;
         }

--- a/includes/Shortcodes/Stores.php
+++ b/includes/Shortcodes/Stores.php
@@ -17,7 +17,7 @@ class Stores extends DokanShortcode {
      *
      * @return string
      */
-    public function render_shortcode( $atts ) {
+    public function render_shortcode( $atts, $content = null, $tag = ''  ) {
         $defaults = array(
             'per_page'           => 10,
             'search'             => 'yes',
@@ -100,13 +100,14 @@ class Stores extends DokanShortcode {
          */
         $template_args = apply_filters(
             'dokan_store_list_args', array(
-				'sellers'    => $sellers,
-				'limit'      => $limit,
-				'offset'     => $offset,
-				'paged'      => $paged,
-				'image_size' => 'full',
-				'search'     => $attr['search'],
-				'per_row'    => $attr['per_row'],
+				'sellers'       => $sellers,
+				'limit'         => $limit,
+				'offset'        => $offset,
+				'paged'         => $paged,
+				'image_size'    => 'full',
+				'search'        => $attr['search'],
+				'per_row'       => $attr['per_row'],
+				'shortcode_tag' => $tag,
             )
         );
 

--- a/includes/Shortcodes/TopRatedProduct.php
+++ b/includes/Shortcodes/TopRatedProduct.php
@@ -14,7 +14,7 @@ class TopRatedProduct extends DokanShortcode {
      *
      * @return string
      */
-    public function render_shortcode( $atts ) {
+    public function render_shortcode( $atts, $content = null, $tag = ''  ) {
 
         /**
          * Filter return the number of top rated product per page.

--- a/includes/Shortcodes/VendorRegistration.php
+++ b/includes/Shortcodes/VendorRegistration.php
@@ -13,7 +13,7 @@ class VendorRegistration extends DokanShortcode {
      *
      * @return string
      */
-    public function render_shortcode( $atts ) {
+    public function render_shortcode( $atts, $content = null, $tag = ''  ) {
         if ( is_user_logged_in() ) {
             return esc_html__( 'You are already logged in', 'dokan-lite' );
         }

--- a/templates/products/tmpl-add-product-popup.php
+++ b/templates/products/tmpl-add-product-popup.php
@@ -142,12 +142,10 @@ use WeDevs\Dokan\Walkers\TaxonomyDropdown;
                         </div>
                     <?php endif; ?>
 
-                    <?php if ( apply_filters( 'dokan_maximum_tags_select_length', -1 ) !== 0 ): ?>
                     <div class="dokan-form-group">
                         <label for="product_tag" class="form-label"><?php esc_html_e( 'Tags', 'dokan-lite' ); ?></label>
                         <select multiple="multiple" name="product_tag[]" id="product_tag_search" class="product_tag_search product_tags dokan-form-control dokan-select2" data-placeholder="<?php echo esc_attr( $tags_placeholder ); ?>"></select>
                     </div>
-                    <?php endif; ?>
 
                     <?php do_action( 'dokan_new_product_after_product_tags' ); ?>
 

--- a/templates/products/tmpl-add-product-popup.php
+++ b/templates/products/tmpl-add-product-popup.php
@@ -142,10 +142,12 @@ use WeDevs\Dokan\Walkers\TaxonomyDropdown;
                         </div>
                     <?php endif; ?>
 
+                    <?php if ( apply_filters( 'dokan_maximum_tags_select_length', -1 ) !== 0 ): ?>
                     <div class="dokan-form-group">
                         <label for="product_tag" class="form-label"><?php esc_html_e( 'Tags', 'dokan-lite' ); ?></label>
                         <select multiple="multiple" name="product_tag[]" id="product_tag_search" class="product_tag_search product_tags dokan-form-control dokan-select2" data-placeholder="<?php echo esc_attr( $tags_placeholder ); ?>"></select>
                     </div>
+                    <?php endif; ?>
 
                     <?php do_action( 'dokan_new_product_after_product_tags' ); ?>
 

--- a/templates/store-lists.php
+++ b/templates/store-lists.php
@@ -7,6 +7,8 @@ $get_data = wp_unslash( $_GET );
 
 $search_query = null;
 
+$recived_template_args = isset( $args ) ? $args : [];
+
 if ( 'yes' === $search ) {
     $search_query = isset( $get_data['dokan_seller_search'] ) ? sanitize_text_field( $get_data['dokan_seller_search'] ) : '';
 }
@@ -61,7 +63,7 @@ do_action( 'dokan_after_seller_listing_serach_form', $sellers );
  *
  * @var array $sellers
  */
-do_action( 'dokan_before_seller_listing_loop', $sellers );
+do_action( 'dokan_before_seller_listing_loop', $sellers, $recived_template_args );
 
 $template_args = array(
     'sellers'         => $sellers,


### PR DESCRIPTION
Issue: [Dokan-pro 1469](https://github.com/weDevsOfficial/dokan-pro/issues/1469) ( Dokan Geolocation Filter Form vendor search doesn't redirect to the store list page )

Previously, Dokan geolocation Filter Form widget, form submit redirected in the current URL. 
Now, geolocation Filter Form widget, form submit redirected in the store list page URL.

But there is a conflict with a previously solved similar issue in [dokan-pro 1281](https://github.com/weDevsOfficial/dokan-pro/issues/1281), here [dokan-stores] shortcode uses the same template of geolocation Filter Form widget.
The  widget search redirect URL will be in the store list page and shortcode search redirect URL will be in the same URL. 
So what is did, I checked if the form summited form the shortcode the search redirect URL will be in the same page or the redirect URL will be in the store list page.

So we need to test for both [Dokan-pro 1469](https://github.com/weDevsOfficial/dokan-pro/issues/1469) and [dokan-pro 1281](https://github.com/weDevsOfficial/dokan-pro/issues/1281).

fix: https://github.com/weDevsOfficial/dokan-pro/issues/1469
