### PR TITLE
fix: Geolocation filter form vendor search url redirect

### DIFF
--- a/includes/Abstracts/DokanShortcode.php
+++ b/includes/Abstracts/DokanShortcode.php
@@ -18,5 +18,5 @@ abstract class DokanShortcode {
         return $this->shortcode;
     }
 
-    abstract public function render_shortcode( $atts );
+    abstract public function render_shortcode( $atts, $content = null, $tag = '' );
 }

--- a/includes/Shortcodes/BestSellingProduct.php
+++ b/includes/Shortcodes/BestSellingProduct.php
@@ -15,7 +15,7 @@ class BestSellingProduct extends DokanShortcode {
      *
      * @return string
      */
-    public function render_shortcode( $atts ) {
+    public function render_shortcode( $atts, $content = null, $tag = '' ) {
         /**
         * Filter return the number of best selling product per page.
         *

--- a/includes/Shortcodes/Dashboard.php
+++ b/includes/Shortcodes/Dashboard.php
@@ -18,7 +18,7 @@ class Dashboard extends DokanShortcode {
      *
      * @return void
      */
-    public function render_shortcode( $atts ) {
+    public function render_shortcode( $atts, $content = null, $tag = '' ) {
         global $wp;
 
         if ( ! function_exists( 'WC' ) ) {

--- a/includes/Shortcodes/MyOrders.php
+++ b/includes/Shortcodes/MyOrders.php
@@ -13,7 +13,7 @@ class MyOrders extends DokanShortcode {
      *
      * @return string
      */
-    public function render_shortcode( $atts ) {
+    public function render_shortcode( $atts, $content = null, $tag = '' ) {
         if ( ! is_user_logged_in() ) {
             return;
         }

--- a/includes/Shortcodes/Stores.php
+++ b/includes/Shortcodes/Stores.php
@@ -17,7 +17,7 @@ class Stores extends DokanShortcode {
      *
      * @return string
      */
-    public function render_shortcode( $atts ) {
+    public function render_shortcode( $atts, $content = null, $tag = '' ) {
         $defaults = array(
             'per_page'           => 10,
             'search'             => 'yes',
@@ -100,13 +100,14 @@ class Stores extends DokanShortcode {
          */
         $template_args = apply_filters(
             'dokan_store_list_args', array(
-				'sellers'    => $sellers,
-				'limit'      => $limit,
-				'offset'     => $offset,
-				'paged'      => $paged,
-				'image_size' => 'full',
-				'search'     => $attr['search'],
-				'per_row'    => $attr['per_row'],
+				'sellers'       => $sellers,
+				'limit'         => $limit,
+				'offset'        => $offset,
+				'paged'         => $paged,
+				'image_size'    => 'full',
+				'search'        => $attr['search'],
+				'per_row'       => $attr['per_row'],
+                'shortcode_tag' => $tag,
             )
         );
 

--- a/includes/Shortcodes/TopRatedProduct.php
+++ b/includes/Shortcodes/TopRatedProduct.php
@@ -14,7 +14,7 @@ class TopRatedProduct extends DokanShortcode {
      *
      * @return string
      */
-    public function render_shortcode( $atts ) {
+    public function render_shortcode( $atts, $content = null, $tag = '' ) {
 
         /**
          * Filter return the number of top rated product per page.

--- a/includes/Shortcodes/VendorRegistration.php
+++ b/includes/Shortcodes/VendorRegistration.php
@@ -13,7 +13,7 @@ class VendorRegistration extends DokanShortcode {
      *
      * @return string
      */
-    public function render_shortcode( $atts ) {
+    public function render_shortcode( $atts, $content = null, $tag = '' ) {
         if ( is_user_logged_in() ) {
             return esc_html__( 'You are already logged in', 'dokan-lite' );
         }

--- a/templates/store-lists.php
+++ b/templates/store-lists.php
@@ -7,6 +7,8 @@ $get_data = wp_unslash( $_GET );
 
 $search_query = null;
 
+$recived_template_args = isset( $args ) ? $args : [];
+
 if ( 'yes' === $search ) {
     $search_query = isset( $get_data['dokan_seller_search'] ) ? sanitize_text_field( $get_data['dokan_seller_search'] ) : '';
 }
@@ -61,7 +63,7 @@ do_action( 'dokan_after_seller_listing_serach_form', $sellers );
  *
  * @var array $sellers
  */
-do_action( 'dokan_before_seller_listing_loop', $sellers );
+do_action( 'dokan_before_seller_listing_loop', $sellers, $recived_template_args );
 
 $template_args = array(
     'sellers'         => $sellers,


### PR DESCRIPTION
Issue: [Dokan-pro 1469](https://github.com/weDevsOfficial/dokan-pro/issues/1469) ( Dokan Geolocation Filter Form vendor search doesn't redirect to the store list page )

Previously, Dokan geolocation Filter Form widget, form submit redirected in the current URL. 
Now, geolocation Filter Form widget, form submit redirected in the store list page URL.

But there is a conflict with a previously solved similar issue in [dokan-pro 1281](https://github.com/weDevsOfficial/dokan-pro/issues/1281), here [dokan-stores] shortcode uses the same template of geolocation Filter Form widget.
The  widget search redirect URL will be in the store list page and shortcode search redirect URL will be in the same URL. 
So what is did, I checked if the form summited form the shortcode the search redirect URL will be in the same page or the redirect URL will be in the store list page.

So we need to test for both [Dokan-pro 1469](https://github.com/weDevsOfficial/dokan-pro/issues/1469) and [dokan-pro 1281](https://github.com/weDevsOfficial/dokan-pro/issues/1281).

fix: https://github.com/weDevsOfficial/dokan-pro/issues/1469
