### PR TITLE
Fix: Vendor Contact form doesn't contain customer email

### DIFF
--- a/includes/Emails/ContactSeller.php
+++ b/includes/Emails/ContactSeller.php
@@ -14,6 +14,8 @@ use WC_Email;
  */
 class ContactSeller extends WC_Email {
 
+    private $reply_to;
+
     /**
      * Constructor.
      */
@@ -27,6 +29,7 @@ class ContactSeller extends WC_Email {
 
         // Triggers for this email
         add_action( 'dokan_trigger_contact_seller_mail', array( $this, 'trigger' ), 30, 4 );
+        add_filter( 'woocommerce_email_from_address', array( $this, 'set_reply_to' ) );
 
         // Call parent constructor
         parent::__construct();
@@ -42,7 +45,7 @@ class ContactSeller extends WC_Email {
      * @return string
      */
     public function get_default_subject() {
-            return __( '[{customer_name}] sent you a message from your store at - {site_name}', 'dokan-lite' );
+        return __( '[{customer_name}] sent you a message from your store at - {site_name}', 'dokan-lite' );
     }
 
     /**
@@ -52,56 +55,68 @@ class ContactSeller extends WC_Email {
      * @return string
      */
     public function get_default_heading() {
-            return __( '{customer_name} - Sent a message from {site_name}', 'dokan-lite' );
+        return __( '{customer_name} - Sent a message from {site_name}', 'dokan-lite' );
     }
 
     /**
      * Trigger the this email.
      */
     public function trigger( $seller_email, $contact_name, $contact_email, $contact_message ) {
-		if ( ! $this->is_enabled() || ! $this->get_recipient() ) {
-			return;
-		}
+        if ( ! $this->is_enabled() || ! $this->get_recipient() ) {
+            return;
+        }
 
-            $seller = get_user_by( 'email', $seller_email );
+        $this->reply_to = $contact_email;
+        $seller = get_user_by( 'email', $seller_email );
 
-            $this->find['seller_name']    = '{seller_name}';
-            $this->find['customer_name']  = '{customer_name}';
-            $this->find['customer_email'] = '{customer_email}';
-            $this->find['message']        = '{message}';
-            $this->find['site_name']      = '{site_name}';
-            $this->find['site_url']       = '{site_url}';
+        $this->find['seller_name']    = '{seller_name}';
+        $this->find['customer_name']  = '{customer_name}';
+        $this->find['customer_email'] = '{customer_email}';
+        $this->find['message']        = '{message}';
+        $this->find['site_name']      = '{site_name}';
+        $this->find['site_url']       = '{site_url}';
 
-            $this->replace['seller_name']    = $seller->display_name;
-            $this->replace['customer_name']  = $contact_name;
-            $this->replace['customer_email'] = $contact_email;
-            $this->replace['message']        = $contact_message;
-            $this->replace['site_name']      = $this->get_from_name();
-            $this->replace['site_url']       = site_url();
+        $this->replace['seller_name']    = $seller->display_name;
+        $this->replace['customer_name']  = $contact_name;
+        $this->replace['customer_email'] = $contact_email;
+        $this->replace['message']        = $contact_message;
+        $this->replace['site_name']      = $this->get_from_name();
+        $this->replace['site_url']       = site_url();
 
-            $this->setup_locale();
-            $this->send( $seller_email, $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
-            $this->restore_locale();
+        $this->setup_locale();
+        $this->send( $seller_email, $this->get_subject(), $this->get_content(), $this->get_headers(), $this->get_attachments() );
+        $this->restore_locale();
     }
 
-        /**
+    /**
+     * Set customer email address for reply
+     *
+     * DOKAN_LITE_SINCE
+     *
+     * @return mixed
+     */
+    public function set_reply_to() {
+        return $this->reply_to;
+    }
+
+    /**
      * Get content html.
      *
      * @access public
      * @return string
      */
     public function get_content_html() {
-            ob_start();
-                wc_get_template(
-                    $this->template_html, array(
-						'email_heading' => $this->get_heading(),
-						'sent_to_admin' => true,
-						'plain_text'    => false,
-						'email'         => $this,
-						'data'          => $this->replace,
-                    ), 'dokan/', $this->template_base
-                );
-            return ob_get_clean();
+        ob_start();
+        wc_get_template(
+            $this->template_html, array(
+            'email_heading' => $this->get_heading(),
+            'sent_to_admin' => true,
+            'plain_text'    => false,
+            'email'         => $this,
+            'data'          => $this->replace,
+        ), 'dokan/', $this->template_base
+        );
+        return ob_get_clean();
     }
 
     /**
@@ -111,17 +126,17 @@ class ContactSeller extends WC_Email {
      * @return string
      */
     public function get_content_plain() {
-            ob_start();
-                wc_get_template(
-                    $this->template_html, array(
-						'email_heading' => $this->get_heading(),
-						'sent_to_admin' => true,
-						'plain_text'    => true,
-						'email'         => $this,
-						'data'          => $this->replace,
-                    ), 'dokan/', $this->template_base
-                );
-            return ob_get_clean();
+        ob_start();
+        wc_get_template(
+            $this->template_html, array(
+            'email_heading' => $this->get_heading(),
+            'sent_to_admin' => true,
+            'plain_text'    => true,
+            'email'         => $this,
+            'data'          => $this->replace,
+        ), 'dokan/', $this->template_base
+        );
+        return ob_get_clean();
     }
 
     /**


### PR DESCRIPTION
When a customer contacts a vendor via the vendor contact form widget. It does send emails to the vendor. but when the vendor tries to reply to the customer he/she can't because there is no customer email in To or email cc. Email send to the vendor self instead of the customer. 

Fixes #1346