### PR TITLE
fix: Export order permission for staffs

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -2968,8 +2968,8 @@ function dokan_get_all_caps() {
             'dokan_manage_order'      => __( 'Manage order', 'dokan-lite' ),
             'dokan_manage_order_note' => __( 'Manage order note', 'dokan-lite' ),
             'dokan_manage_refund'     => __( 'Manage refund', 'dokan-lite' ),
+            'dokan_export_order'      => __( 'Export order', 'dokan-lite' ),
         ],
-
         'coupon' => [
             'dokan_add_coupon'    => __( 'Add coupon', 'dokan-lite' ),
             'dokan_edit_coupon'   => __( 'Edit coupon', 'dokan-lite' ),

--- a/templates/orders/date-export.php
+++ b/templates/orders/date-export.php
@@ -41,17 +41,19 @@ $order_status = isset( $_GET['order_status'] ) ? sanitize_key( $_GET['order_stat
         </div>
     </form>
 
-    <form action="" method="POST" class="dokan-right">
-        <div class="dokan-form-group">
-            <?php
-                wp_nonce_field( 'dokan_vendor_order_export_action', 'dokan_vendor_order_export_nonce' );
-            ?>
-            <input type="submit" name="dokan_order_export_all"  class="dokan-btn dokan-btn-sm dokan-btn-danger dokan-btn-theme" value="<?php esc_attr_e( 'Export All', 'dokan-lite' ); ?>">
-            <input type="submit" name="dokan_order_export_filtered"  class="dokan-btn dokan-btn-sm dokan-btn-danger dokan-btn-theme" value="<?php esc_attr_e( 'Export Filtered', 'dokan-lite' ); ?>">
-            <input type="hidden" name="order_date" value="<?php echo esc_attr( $filter_date ); ?>">
-            <input type="hidden" name="order_status" value="<?php echo esc_attr( $order_status ); ?>">
-        </div>
-    </form>
+    <?php if ( current_user_can( 'seller' ) || current_user_can( 'dokan_export_order' ) ) : ?>
+        <form action="" method="POST" class="dokan-right">
+            <div class="dokan-form-group">
+                <?php
+                    wp_nonce_field( 'dokan_vendor_order_export_action', 'dokan_vendor_order_export_nonce' );
+                ?>
+                <input type="submit" name="dokan_order_export_all"  class="dokan-btn dokan-btn-sm dokan-btn-danger dokan-btn-theme" value="<?php esc_attr_e( 'Export All', 'dokan-lite' ); ?>">
+                <input type="submit" name="dokan_order_export_filtered"  class="dokan-btn dokan-btn-sm dokan-btn-danger dokan-btn-theme" value="<?php esc_attr_e( 'Export Filtered', 'dokan-lite' ); ?>">
+                <input type="hidden" name="order_date" value="<?php echo esc_attr( $filter_date ); ?>">
+                <input type="hidden" name="order_status" value="<?php echo esc_attr( $order_status ); ?>">
+            </div>
+        </form>
+    <?php endif; ?>
 
     <div class="dokan-clearfix"></div>
 </div>


### PR DESCRIPTION
**description**: when managing permissions for staff, the vendor will get a new option 'Export product' under the 'order' section. Staffs with this permission can export the order list as csv file.

1. new array element added in $capabilities array in includes/functions.php
2. 'dokan_export_order' capability check added before the export buttons and also in the action. capability check added so that vendor and staff both can view the buttons.

fix #1247 
Dokan Pro PR: https://github.com/weDevsOfficial/dokan-pro/pull/1500
Note: the previous PR is closed because the upgrader file is moved from lite to pro. Previous PR: #1322 