### PR TITLE
fix: Store Address input fields are missing in store setting form

### DIFF
--- a/templates/settings/store-form.php
+++ b/templates/settings/store-form.php
@@ -131,10 +131,10 @@
          <!--address-->
 
         <?php
-            if (  class_exists( 'Dokan_Pro' ) && ! dokan_pro()->module->is_active( 'delivery_time' ) ) {
+            if ( ! function_exists( 'dokan_pro' ) || ( function_exists( 'dokan_pro' ) && ! dokan_pro()->module->is_active( 'delivery_time' ) ) ) {
                 $verified = false;
 
-                if ( isset( $profile_info['dokan_verification']['info']['store_address']['v_status'] ) ) {
+                if ( function_exists( 'dokan_pro' ) && dokan_pro()->module->is_active( 'vendor_verification' ) && isset( $profile_info['dokan_verification']['info']['store_address']['v_status'] ) ) {
                     if ( $profile_info['dokan_verification']['info']['store_address']['v_status'] == 'approved' ) {
                         $verified = true;
                     }


### PR DESCRIPTION
Issue: #1359
Previously, in vendor store setting form, address input fields were missing. Screenshot [here](https://prnt.sc/1uq8grw).
Now, address input fields are shown and working fine. Screenshot [here](https://prnt.sc/1uq8ahs).

Fix: #1359