### PR TITLE
[Feat] Dokan data clear on plugin delete

### DIFF
--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -30,6 +30,7 @@ class Settings {
         add_filter( 'dokan_admin_localize_script', [ $this, 'add_admin_settings_nonce' ] );
         add_action( 'wp_ajax_dokan_refresh_admin_settings_field_options', [ $this, 'refresh_admin_settings_field_options' ] );
         add_filter( 'dokan_get_settings_values', [ $this, 'format_price_values' ], 12, 2 );
+        add_filter( 'dokan_settings_general_site_options', [ $this, 'add_dokan_data_clear_setting' ], 310 );
     }
 
     /**
@@ -749,5 +750,24 @@ class Settings {
         } catch ( Exception $e ) {
             $this->send_response_error( $e );
         }
+    }
+
+    /**
+     * Dokan data clear setting
+     *
+     * @since DOKAN_LITE_SINCE
+     *
+     * @return array $settings_fields
+     */
+    public function add_dokan_data_clear_setting( $settings_fields ) {
+        $settings_fields['data_clear_on_uninstall'] = [
+            'name'    => 'data_clear_on_uninstall',
+            'label'   => __( 'Data Clear', 'dokan-lite' ),
+            'desc'    => __( 'Clear all the data related to Dokan Lite and Pro after plugin deletion.', 'dokan-lite' ),
+            'type'    => 'checkbox',
+            'default' => 'off',
+        ];
+
+        return $settings_fields;
     }
 }

--- a/src/admin/pages/Settings.vue
+++ b/src/admin/pages/Settings.vue
@@ -83,6 +83,7 @@
     import Fields from "admin/components/Fields.vue"
     import SettingsBanner from "admin/components/SettingsBanner.vue";
     import UpgradeBanner from "admin/components/UpgradeBanner.vue";
+    import $ from 'jquery';
 
     export default {
 
@@ -405,6 +406,28 @@
 
                 self.settingFields = settingFields;
                 self.settingSections = settingSections;
+            },
+
+            handleDataClearCheckboxEvent() {
+                let self = this;
+                $('#dokan_general\\[data_clear_on_uninstall\\]').on('click', function () {
+                    if( $(this).is(':checked') ) {
+                        self.$swal({
+                            title: self.__( 'Are you sure?', 'dokan-lite' ),
+                            type: 'warning',
+                            html: self.__( 'All the data will be clear after uninstall and you will not able to recover that.', 'dokan-lite' ),
+                            showCancelButton: true,
+                            confirmButtonText: self.__( 'Okay', 'dokan-lite' ),
+                            cancelButtonText: self.__( 'Cancel', 'dokan-lite' ),
+                        }).then( async (response) => {
+                            if ( response.value ) {
+                                $('#dokan_general\\[data_clear_on_uninstall\\]').prop( 'checked', true );
+                            }
+                        })
+
+                        return false;
+                    }
+                });
             }
         },
 
@@ -419,6 +442,10 @@
             this.settingSections = dokan.settings_sections;
             this.settingFields = dokan.settings_fields;
         },
+
+        updated() {
+            this.handleDataClearCheckboxEvent();
+        }
     };
 
 </script>
@@ -638,9 +665,17 @@
     }
 
     .form-table .dokan-settings-field-type-sub_section:first-child th.dokan-settings-sub-section-title {
-
         label {
             margin-top: 0;
+        }
+    }
+
+    tr.data_clear_on_uninstall {
+        td fieldset label {
+            background: #e00;
+            padding: 5px;
+            color: white;
+            border-radius: 3px;
         }
     }
 </style>

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,201 @@
+<?php
+
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+    exit;
+}
+
+/**
+ * Dokan Uninstall
+ *
+ * Uninstalling Dokan deletes user roles, tables, pages, meta data and options.
+ *
+ * @package Dokan\Uninstaller
+ *
+ * @since DOKAN_LITE_SINCE
+ */
+class Dokan_Uninstaller {
+    /**
+     * Constructor for the class Dokan_Uninstaller
+     *
+     * @since DOKAN_LITE_SINCE
+     */
+    public function __construct() {
+        global $wpdb;
+        $general_options = get_option( 'dokan_general', [] );
+        $setting = array_key_exists( 'data_clear_on_uninstall', $general_options ) ? $general_options['data_clear_on_uninstall'] : 'off';
+
+        /*
+         * Only remove data when Dokan data clear setting is enabled by admin
+         * This is to prevent data loss when deleting the plugin and to ensure only the site owner can perform this action.
+         */
+        if ( 'on' === $setting ) {
+            // Make existing vendors to Woocommerce Customer
+            $this->change_vendor_role_to_customer();
+
+            // Roles + caps.
+            $this->remove_roles();
+
+            // Drop Dokan related Tables
+            $this->drop_tables();
+
+            // Delete Pages created by dokan
+            $pages = get_option( 'dokan_pages', [] );
+            foreach ( $pages as $page_id ) {
+                wp_trash_post( $page_id );
+            }
+
+            // Delete Dokan related options
+            $wpdb->query( "DELETE FROM $wpdb->options WHERE option_name LIKE '%dokan%';" );
+
+            // Delete Dokan related user_meta
+            $wpdb->query( "DELETE FROM $wpdb->usermeta WHERE meta_key LIKE '%dokan%';" );
+
+            // Clear any cached data that has been removed.
+            wp_cache_flush();
+        }
+    }
+
+    /**
+     * Return a list of Dokan capabilities
+     *
+     * @since DOKAN_LITE_SINCE
+     *
+     * @return string[]
+     */
+    private function get_dokan_capabilities() {
+        return [
+            'dokan_view_sales_overview',
+            'dokan_view_sales_report_chart',
+            'dokan_view_announcement',
+            'dokan_view_order_report',
+            'dokan_view_review_reports',
+            'dokan_view_product_status_report',
+            'dokan_view_overview_report',
+            'dokan_view_daily_sale_report',
+            'dokan_view_top_selling_report',
+            'dokan_view_top_earning_report',
+            'dokan_view_statement_report',
+            'dokan_view_order',
+            'dokan_manage_order',
+            'dokan_manage_order_note',
+            'dokan_manage_refund',
+            'dokan_add_coupon',
+            'dokan_edit_coupon',
+            'dokan_delete_coupon',
+            'dokan_view_reviews',
+            'dokan_manage_reviews',
+            'dokan_manage_withdraw',
+            'dokan_add_product',
+            'dokan_edit_product',
+            'dokan_delete_product',
+            'dokan_view_product',
+            'dokan_duplicate_product',
+            'dokan_import_product',
+            'dokan_export_product',
+            'dokan_view_overview_menu',
+            'dokan_view_product_menu',
+            'dokan_view_order_menu',
+            'dokan_view_coupon_menu',
+            'dokan_view_report_menu',
+            'dokan_view_review_menu',
+            'dokan_view_withdraw_menu',
+            'dokan_view_store_settings_menu',
+            'dokan_view_store_payment_menu',
+            'dokan_view_store_shipping_menu',
+            'dokan_view_store_social_menu',
+            'dokan_view_store_seo_menu',
+            'dokandar',
+            'seller',
+        ];
+    }
+
+    /**
+     * Remove Dokan roles.
+     *
+     * @since DOKAN_LITE_SINCE
+     *
+     * @return void
+     */
+    private function remove_roles() {
+        global $wp_roles;
+
+        if ( ! class_exists( 'WP_Roles' ) ) {
+            return;
+        }
+
+        if ( ! isset( $wp_roles ) ) {
+            $wp_roles = new WP_Roles(); // @codingStandardsIgnoreLine
+        }
+
+        foreach ( $this->get_dokan_capabilities() as $capability ) {
+            $wp_roles->remove_cap( 'administrator', $capability );
+            $wp_roles->remove_cap( 'shop_manager', $capability );
+        }
+
+        remove_role( 'seller' );
+    }
+
+    /**
+     * Return a list of tables. Used to make sure all Dokan tables are dropped
+     * when uninstalling the plugin
+     *
+     * @since DOKAN_LITE_SINCE
+     *
+     * @return array Dokan tables.
+     */
+    private function get_tables() {
+        global $wpdb;
+
+        return array(
+            "{$wpdb->prefix}dokan_refund",
+            "{$wpdb->prefix}dokan_withdraw",
+            "{$wpdb->prefix}dokan_announcement",
+            "{$wpdb->prefix}dokan_orders",
+            "{$wpdb->prefix}dokan_vendor_balance",
+            "{$wpdb->prefix}dokan_product_map",
+            "{$wpdb->prefix}dokan_follow_store_followers",
+            "{$wpdb->prefix}dokan_report_abuse_reports",
+            "{$wpdb->prefix}dokan_rma_conversations",
+            "{$wpdb->prefix}dokan_rma_request",
+            "{$wpdb->prefix}dokan_rma_request_product",
+            "{$wpdb->prefix}dokan_shipping_zone_methods",
+            "{$wpdb->prefix}dokan_shipping_zone_locations",
+            "{$wpdb->prefix}dokan_shipping_tracking",
+            "{$wpdb->prefix}dokan_delivery_time",
+        );
+    }
+
+    /**
+     * Drop all tables created by Dokan Lite and Pro
+     *
+     * @since DOKAN_LITE_SINCE
+     *
+     * @return void
+     */
+    private function drop_tables() {
+        global $wpdb;
+
+        $tables = $this->get_tables();
+
+        foreach ( $tables as $table ) {
+            $wpdb->query( "DROP TABLE IF EXISTS {$table}" ); // phpcs:ignore
+        }
+    }
+
+    /**
+     * Change Dokan Vendor to WooCommerce Customer
+     *
+     * @since DOKAN_LITE_SINCE
+     *
+     * @return void
+     */
+    private function change_vendor_role_to_customer() {
+        global $wpdb;
+        $ids = $wpdb->get_col( "SELECT user_id FROM {$wpdb->prefix}usermeta WHERE meta_key = 'dokan_enable_selling'" ); // phpcs:ignore
+        $capabilities = maybe_serialize( [ 'customer' => 1 ] );
+
+        $wpdb->query( "UPDATE {$wpdb->prefix}usermeta SET meta_value = '{$capabilities}' WHERE meta_key = 'wp_capabilities' AND user_id IN ('" . implode( "','", $ids ) . "')" ); // phpcs:ignore
+    }
+}
+
+new Dokan_Uninstaller();


### PR DESCRIPTION
Clear Dokan related data after plugin uninstall based on `Setting`. Following data will be clear if respective setting is on.

- Pages created by Dokan
- Options
- Meta Data
- Roles and Capabilities
- Tables

It also migrate Dokan `Vendor` and `Staff` to `WooCommerce Customer`