### PR TITLE
Fix: Store product category translation support for WPML

### DIFF
--- a/includes/Vendor/Vendor.php
+++ b/includes/Vendor/Vendor.php
@@ -595,9 +595,17 @@ class Vendor {
      * @return array
      */
     public function get_store_categories( $best_selling = false ) {
-        $transient_key = 'dokan_vendor_get_store_categories_' . $this->id;
-        if ( $best_selling ) {
-            $transient_key = 'dokan_vendor_get_best_selling_categories_' . $this->id;
+        if ( function_exists( 'wpml_get_current_language' ) ) {
+            $current_lang  = wpml_get_current_language();
+            $transient_key = 'dokan_vendor_get_store_categories_' . $current_lang . '_' . $this->id;
+            if ( $best_selling ) {
+                $transient_key = 'dokan_vendor_get_best_selling_categories_' . $current_lang . '_' . $this->id;
+            }
+        } else {
+            $transient_key = 'dokan_vendor_get_store_categories_' . $this->id;
+            if ( $best_selling ) {
+                $transient_key = 'dokan_vendor_get_best_selling_categories_' . $this->id;
+            }
         }
 
         if ( false === ( $all_categories = get_transient( $transient_key ) ) ) {

--- a/includes/wc-functions.php
+++ b/includes/wc-functions.php
@@ -964,6 +964,13 @@ function dokan_clear_product_category_cache( $post_id ) {
     delete_transient( 'dokan_vendor_get_published_products_' . $seller_id );
     delete_transient( 'dokan_vendor_get_best_selling_products_' . $seller_id );
 
+    if ( function_exists( 'wpml_get_current_language' ) ) {
+        $current_lang = wpml_get_current_language();
+        // delete vendor get_store_categories() method transient
+        delete_transient( 'dokan_vendor_get_store_categories_' . $current_lang . '_' . $seller_id );
+        delete_transient( 'dokan_vendor_get_best_selling_categories_' . $current_lang . '_' . $seller_id );
+    }
+
     // delete vendor get_store_categories() method transient
     delete_transient( 'dokan_vendor_get_store_categories_' . $seller_id );
     delete_transient( 'dokan_vendor_get_best_selling_categories_' . $seller_id );
@@ -1040,6 +1047,10 @@ function dokan_clear_edit_product_category_cache( $term_id ) {
 
     foreach ( $seller_ids as $seller_id ) {
         // delete vendor get_store_categories() method transient
+        if ( function_exists( 'wpml_get_current_language' ) ) {
+            $current_lang = wpml_get_current_language();
+            delete_transient( 'dokan_vendor_get_store_categories_' . $current_lang . '_' . $seller_id );
+        }
         delete_transient( 'dokan_vendor_get_store_categories_' . $seller_id );
     }
 }


### PR DESCRIPTION
Product categories are showing untranslated in Dokan [Store Product Category Widget](https://prnt.sc/1uqslq3) although translation added translation for product categories from WPML > Taxonomy Translation. This happens for transient. I have added transient for the selected language and removed it.
