### PR TITLE
fix: corrected spelling to 'picture' from 'picutre'

### DIFF
--- a/src/admin/pages/VendorAccountFields.vue
+++ b/src/admin/pages/VendorAccountFields.vue
@@ -14,7 +14,7 @@
                     </div>
 
                     <p class="picture-footer"
-                        v-html="sprintf( __( 'You can change your profile picutre on %s', 'dokan-lite' ), '<a href=\'https://gravatar.com/\' target=\'_blank\'>Gravatar</a>' )"
+                        v-html="sprintf( __( 'You can change your profile picture on %s', 'dokan-lite' ), '<a href=\'https://gravatar.com/\' target=\'_blank\'>Gravatar</a>' )"
                     />
                 </div>
 


### PR DESCRIPTION
Corrected spelling to `picture` from `picutre`.

This `PR` is linked to: https://github.com/weDevsOfficial/dokan/pull/1281