### PR TITLE
Fix: Load Divi theme assets when product is empty in store page

### DIFF
--- a/includes/ThemeSupport/Divi.php
+++ b/includes/ThemeSupport/Divi.php
@@ -125,6 +125,5 @@ class Divi {
         $post->post_type    = '';
 
         setup_postdata( $post );
-        wp_reset_postdata();
     }
 }


### PR DESCRIPTION
### Updated Divi Theme Support
Divi Theme based site’s store page style breaks when a store doesn’t have any products.

- Added "wp" action in Divi theme support for create a post id if empty post object.
- Checked dokan store page, set post id and reset setup post data.