### PR TITLE
update/send-order-status-notification-to-vendor-when-order-status-change-from-canceled

### DIFF
--- a/includes/Emails/VendorNewOrder.php
+++ b/includes/Emails/VendorNewOrder.php
@@ -40,6 +40,9 @@ class VendorNewOrder extends WC_Email {
         add_action( 'woocommerce_order_status_failed_to_processing_notification', array( $this, 'trigger' ), 10, 2 );
         add_action( 'woocommerce_order_status_failed_to_completed_notification', array( $this, 'trigger' ), 10, 2 );
         add_action( 'woocommerce_order_status_failed_to_on-hold_notification', array( $this, 'trigger' ), 10, 2 );
+        add_action( 'woocommerce_order_status_cancelled_to_processing_notification', array( $this, 'trigger' ), 10, 2 );
+        add_action( 'woocommerce_order_status_cancelled_to_completed_notification', array( $this, 'trigger' ), 10, 2 );
+        add_action( 'woocommerce_order_status_cancelled_to_on-hold_notification', array( $this, 'trigger' ), 10, 2 );
 		//Prevent admin email for sub-order
         add_filter( 'woocommerce_email_enabled_new_order', [ $this, 'prevent_sub_order_admin_email' ], 10, 2 );
         // Call parent constructor.


### PR DESCRIPTION
Before vendor wasn't getting a notification when order status change from cancelled to processing, on-hold, or completed.

In this PR, I've added the following action hooks to send a notification vendor when order status changes from cancelled to processing, on-hold, or completed.

```
add_action( 'woocommerce_order_status_cancelled_to_processing_notification', array( $this, 'trigger' ), 10, 2 );
add_action( 'woocommerce_order_status_cancelled_to_completed_notification', array( $this, 'trigger' ), 10, 2 );
add_action( 'woocommerce_order_status_cancelled_to_on-hold_notification', array( $this, 'trigger' ), 10, 2 );
```

GitHub Issue: #1342