### PR TITLE
Enha: New action hook dokan_after_product_listing_status_filter added

### DIFF
--- a/templates/products/listing-status-filter.php
+++ b/templates/products/listing-status-filter.php
@@ -34,5 +34,5 @@
         </li>
     <?php endif; ?>
 
-    <?php do_action( 'dokan_after_product_listing_status_filter' ); ?>
+    <?php do_action( 'dokan_after_product_listing_status_filter', $permalink, $status_class, $post_counts, $statuses ); ?>
 </ul> <!-- .post-statuses-filter -->

--- a/templates/products/listing-status-filter.php
+++ b/templates/products/listing-status-filter.php
@@ -33,4 +33,6 @@
             <a href="<?php echo esc_url( add_query_arg( array( 'post_status' => 'outofstock' ), $permalink ) ); ?>"><?php echo esc_html_e( 'Out of stock', 'dokan-lite' ). ' (' . esc_html( $outofstock_counts ) . ')'; ?></a>
         </li>
     <?php endif; ?>
+
+    <?php do_action( 'dokan_after_product_listing_status_filter' ); ?>
 </ul> <!-- .post-statuses-filter -->


### PR DESCRIPTION
For showing products counts for each language on the vendor dashboard inside the products screen. I have added a new action hook called `dokan_after_product_listing_status_filter` on file `dokan-lite/templates/products/listing-status-filter.php`