### PR TITLE
Fix downloadable virtual product support for auction module

### DIFF
--- a/assets/src/js/product-editor.js
+++ b/assets/src/js/product-editor.js
@@ -870,6 +870,7 @@
             var product_type    = $( '#product_type' ).val();
             var is_virtual      = $( 'input#_virtual:checked' ).length;
             var is_downloadable = $( 'input#_downloadable:checked' ).length;
+            let shippingTaxContainer  = $( '.dokan-product-shipping-tax' );
 
             // Hide/Show all with rules.
             var hide_classes = '.hide_if_downloadable, .hide_if_virtual';
@@ -899,6 +900,18 @@
             }
             if ( is_virtual ) {
                 $( '.hide_if_virtual' ).hide();
+
+                if ( 1 === $( '.dokan-product-shipping-tax .dokan-section-content' ).first().children().length ) {
+                    shippingTaxContainer.hide();
+                } else {
+                    if ( shippingTaxContainer.hasClass('hide_if_virtual') ) {
+                        shippingTaxContainer.removeClass('hide_if_virtual');
+                    }
+
+                    shippingTaxContainer.show();
+                }
+            } else {
+                shippingTaxContainer.show();
             }
 
             $( '.hide_if_' + product_type ).hide();


### PR DESCRIPTION
This is an enhancement for the Dokan auction module. There is no support for downloadable and virtual product for the auction product. This enhancement was requested on the Dokan pro. And there is some issue related to the Dokan lite. So here is the fix for that. 

Related pr in dokan pro: https://github.com/weDevsOfficial/dokan-pro/pull/1546

fix https://github.com/weDevsOfficial/dokan-pro/issues/1112