### PR TITLE
Fix/render vendor email setting conditionally

### DIFF
--- a/includes/Upgrade/Upgrades/V_3_3_1.php
+++ b/includes/Upgrade/Upgrades/V_3_3_1.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace WeDevs\Dokan\Upgrade\Upgrades;
+
+use WeDevs\Dokan\Abstracts\DokanUpgrader;
+
+class V_3_3_1 extends DokanUpgrader {
+
+    /**
+     * Updates withdraw database table
+     *
+     * @since 3.3.7
+     *
+     * @return void
+     */
+    public static function update_withdraw_table() {
+        global $wpdb;
+
+        include_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+        $existing_columns = $wpdb->get_col( "DESC `{$wpdb->prefix}dokan_withdraw`", 0 );
+
+        if ( in_array( 'details', $existing_columns, true ) ) {
+            return;
+        }
+
+        $wpdb->query(
+            "ALTER TABLE `{$wpdb->prefix}dokan_withdraw` ADD COLUMN details longtext NOT NULL AFTER note" // phpcs:ignore WordPress.DB.DirectDatabaseQuery.SchemaChange
+        );
+    }
+
+    /**
+     * Updates refund database table
+     *
+     * @since 3.3.7
+     *
+     * @return void
+     */
+    public static function update_refund_table() {
+        global $wpdb;
+
+        include_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+        $existing_columns = $wpdb->get_col( "DESC `{$wpdb->prefix}dokan_refund`", 0 );
+
+        if ( in_array( 'item_totals', $existing_columns, true ) && in_array( 'item_tax_totals', $existing_columns, true ) ) {
+            $wpdb->query(
+                "ALTER TABLE `{$wpdb->prefix}dokan_refund` MODIFY COLUMN item_totals text" // phpcs:ignore
+            );
+
+            $wpdb->query(
+                "ALTER TABLE `{$wpdb->prefix}dokan_refund` MODIFY COLUMN item_tax_totals text" // phpcs:ignore
+            );
+        }
+    }
+}

--- a/templates/settings/store-form.php
+++ b/templates/settings/store-form.php
@@ -156,6 +156,7 @@
 
         <?php do_action( 'dokan_settings_before_store_email', $current_user, $profile_info ); ?>
 
+        <?php if ( ! dokan_is_vendor_info_hidden( 'email' ) ): ?>
         <div class="dokan-form-group">
             <label class="dokan-w3 dokan-control-label"><?php esc_html_e( 'Email', 'dokan-lite' ); ?></label>
             <div class="dokan-w5 dokan-text-left">
@@ -167,7 +168,8 @@
                 </div>
             </div>
         </div>
-
+        <?php endif; ?>
+        
         <div class="dokan-form-group">
             <label class="dokan-w3 dokan-control-label"><?php esc_html_e( 'More products', 'dokan-lite' ); ?></label>
             <div class="dokan-w5 dokan-text-left">


### PR DESCRIPTION
There is a setting in Customizer "Hide email address". If the admin checks this setting checkbox, the vendor should not see the "Show email address in store" option on the vendor setting page.