### PR TITLE
Render vendor email setting option conditionally

### DIFF
--- a/templates/settings/store-form.php
+++ b/templates/settings/store-form.php
@@ -155,7 +155,8 @@
         <?php do_action( 'dokan_settings_after_store_phone', $current_user, $profile_info ); ?>
 
         <?php do_action( 'dokan_settings_before_store_email', $current_user, $profile_info ); ?>
-
+        
+        <?php if ( ! dokan_is_vendor_info_hidden( 'email' ) ): ?>
         <div class="dokan-form-group">
             <label class="dokan-w3 dokan-control-label"><?php esc_html_e( 'Email', 'dokan-lite' ); ?></label>
             <div class="dokan-w5 dokan-text-left">
@@ -167,6 +168,7 @@
                 </div>
             </div>
         </div>
+        <?php endif; ?>
 
         <div class="dokan-form-group">
             <label class="dokan-w3 dokan-control-label"><?php esc_html_e( 'More products', 'dokan-lite' ); ?></label>

--- a/templates/settings/store-form.php
+++ b/templates/settings/store-form.php
@@ -156,7 +156,7 @@
 
         <?php do_action( 'dokan_settings_before_store_email', $current_user, $profile_info ); ?>
         
-        <?php if ( ! dokan_is_vendor_info_hidden( 'email' ) ): ?>
+        <?php if ( ! dokan_is_vendor_info_hidden( 'email' ) ) : ?>
         <div class="dokan-form-group">
             <label class="dokan-w3 dokan-control-label"><?php esc_html_e( 'Email', 'dokan-lite' ); ?></label>
             <div class="dokan-w5 dokan-text-left">


### PR DESCRIPTION
There is a setting in Customizer "Hide email address". If the admin checks this setting checkbox, the vendor should not see the "Show email address in store" option on the vendor setting page.