### PR TITLE
Fix[Product]: allow filter to prevent adding cart-item tag

### DIFF
--- a/includes/Product/functions.php
+++ b/includes/Product/functions.php
@@ -543,10 +543,6 @@ function dokan_get_vendor_by_product( $product, $id = false ) {
 
     $vendor_id = apply_filters( 'dokan_get_vendor_by_product', $vendor_id, $product );
 
-    if ( ! $vendor_id ) {
-        return false;
-    }
-
     return false === $id ? dokan()->vendor->get( $vendor_id ) : (int) $vendor_id;
 }
 

--- a/includes/Product/functions.php
+++ b/includes/Product/functions.php
@@ -543,6 +543,10 @@ function dokan_get_vendor_by_product( $product, $id = false ) {
 
     $vendor_id = apply_filters( 'dokan_get_vendor_by_product', $vendor_id, $product );
 
+    if ( ! $vendor_id ) {
+        return false;
+    }
+
     return false === $id ? dokan()->vendor->get( $vendor_id ) : (int) $vendor_id;
 }
 

--- a/includes/wc-template.php
+++ b/includes/wc-template.php
@@ -9,7 +9,7 @@
 function dokan_product_seller_info( $item_data, $cart_item ) {
     $vendor = dokan_get_vendor_by_product( $cart_item['product_id'] );
 
-    if ( ! $vendor ) {
+    if ( ! $vendor || ! $vendor->get_id() ) {
         return $item_data;
     }
 


### PR DESCRIPTION
Allow filter dokan_get_vendor_by_product preventing the addition of the "Vendor" cart-item tag if it doesn't return a valid vendor

Fixes: #1400