### PR TITLE
fix/unable-selling-actions-when-vendor-is-not-enabled

### DIFF
--- a/includes/REST/ProductController.php
+++ b/includes/REST/ProductController.php
@@ -276,7 +276,7 @@ class ProductController extends DokanRESTController {
         }
 
         if ( ! dokan_is_seller_enabled( $store_id ) ) {
-            return new WP_Error( 'invalid_request', __( 'Error! Your account is not enabled for selling, please contact the admin', 'dokan-lite' ), [ 'status' => 400 ] );;
+            return new WP_Error( 'invalid_request', __( 'Error! Your account is not enabled for selling, please contact the admin', 'dokan-lite' ), [ 'status' => 400 ] );
         }
 
         if ( ! empty( $request['id'] ) ) {

--- a/includes/REST/ProductController.php
+++ b/includes/REST/ProductController.php
@@ -276,7 +276,7 @@ class ProductController extends DokanRESTController {
         }
 
         if ( ! dokan_is_seller_enabled( $store_id ) ) {
-            return new WP_Error( 'invalid_request', __( 'Error! Your account is not enabled for selling, please contact the admin', 'dokan-lite' ), [ 'status' => 400 ] );
+            return new WP_Error( 'invalid_request', __( 'Error! Your account is not enabled for selling, please contact with the admin', 'dokan-lite' ), [ 'status' => 400 ] );
         }
 
         if ( ! empty( $request['id'] ) ) {

--- a/includes/REST/ProductController.php
+++ b/includes/REST/ProductController.php
@@ -276,7 +276,7 @@ class ProductController extends DokanRESTController {
         }
 
         if ( ! dokan_is_seller_enabled( $store_id ) ) {
-            return new WP_Error( 'invalid_request', __( 'Error! Your account is not enabled for selling, please contact with the admin', 'dokan-lite' ), [ 'status' => 400 ] );
+            return new WP_Error( 'invalid_request', __( 'Error! Your account is not enabled for selling, please contact the admin', 'dokan-lite' ), [ 'status' => 400 ] );
         }
 
         if ( ! empty( $request['id'] ) ) {

--- a/includes/REST/ProductController.php
+++ b/includes/REST/ProductController.php
@@ -275,6 +275,10 @@ class ProductController extends DokanRESTController {
             return new WP_Error( 'no_store_found', __( 'No seller found', 'dokan-lite' ), [ 'status' => 404 ] );
         }
 
+        if ( ! dokan_is_seller_enabled( $store_id ) ) {
+            return new WP_Error( 'invalid_request', __( 'Error! Your account is not enabled for selling, please contact the admin', 'dokan-lite' ), [ 'status' => 400 ] );;
+        }
+
         if ( ! empty( $request['id'] ) ) {
             /* translators: %s: product */
             return new WP_Error( "woocommerce_rest_{$this->post_type}_exists", sprintf( __( 'Cannot create existing %s.', 'dokan-lite' ), 'product' ), [ 'status' => 400 ] );


### PR DESCRIPTION
### Update vendor selling actions when vendor is not enabled

**Expected Behaviour:**
As an admin can to disable selling for a seller. So that he can manage & control seller products.

**Actual Problem:**

- The seller can edit a product from the bulk action
- The seller can delete a product permanently from the bulk action
- The seller can easily create a product with an API endpoint

**Now Result:**
If vendor isn't enabled by admin then...

- Seller can't edit a product from the bulk action & inline edit
- The seller can't delete a product permanently from the bulk action & inline edit
- The seller can't easily create a product with an API endpoint

**Video Link:**
https://share.vidyard.com/watch/ydqF8KAusi8nFuxVmBt5yh?

**Related with Dokan Pro:**
https://github.com/weDevsOfficial/dokan-pro/pull/1579

fix: https://github.com/weDevsOfficial/dokan-pro/issues/1573