### PR TITLE
enhance: recaptcha integration to store contact form

### DIFF
--- a/assets/src/js/helper.js
+++ b/assets/src/js/helper.js
@@ -74,3 +74,33 @@ function dokan_get_i18n_date_format( format = true ) {
       break;
   }
 }
+
+/**
+ * Execute recaptcha token request
+ *
+ * @since 3.3.3
+ *
+ * @param {string} inputFieldSelector The input field for recaptcha token
+ * @param {string} action The action for recaptcha
+ *
+ * @return {Promise} Return Promise
+ */
+function dokan_execute_recaptcha(inputFieldSelector, action) {
+  return new Promise( function(resolve) {
+    const recaptchaSiteKey    = google_recaptcha.recaptcha_sitekey;
+    const recaptchaTokenField = document.querySelector(inputFieldSelector);
+
+    // Check if the recaptcha site key exists
+    if ( '' === recaptchaSiteKey ) {
+      resolve();
+    }
+
+    // Execute recaptcha after passing checks
+    grecaptcha.ready(function() {
+      grecaptcha.execute(recaptchaSiteKey, { action: action }).then(function(token) {
+        recaptchaTokenField.value = token;
+        resolve();
+      });
+    });
+  });
+}

--- a/assets/src/js/helper.js
+++ b/assets/src/js/helper.js
@@ -87,6 +87,11 @@ function dokan_get_i18n_date_format( format = true ) {
  */
 function dokan_execute_recaptcha(inputFieldSelector, action) {
   return new Promise( function(resolve) {
+    // Check if google_recaptcha object exists
+    if ( 'undefined' === typeof google_recaptcha ) {
+      resolve();
+    }
+
     const recaptchaSiteKey    = google_recaptcha.recaptcha_sitekey;
     const recaptchaTokenField = document.querySelector(inputFieldSelector);
 

--- a/assets/src/js/helper.js
+++ b/assets/src/js/helper.js
@@ -54,11 +54,11 @@ function dokan_get_i18n_date_format( format = true ) {
  async function dokan_sweetalert( message = '' , options = {} ) {
   const defaults = {
     text              : message,
-    showCancelButton  : true, 
+    showCancelButton  : true,
     confirmButtonColor:'#28a745',
     cancelButtonColor :'#dc3545',
   };
-  
+
   const args    = { ...defaults, ...options };
 
   switch( args.action ) {
@@ -87,12 +87,12 @@ function dokan_get_i18n_date_format( format = true ) {
  */
 function dokan_execute_recaptcha(inputFieldSelector, action) {
   return new Promise( function(resolve) {
-    // Check if google_recaptcha object exists
-    if ( 'undefined' === typeof google_recaptcha ) {
+    // Check if dokan_google_recaptcha object exists
+    if ( 'undefined' === typeof dokan_google_recaptcha ) {
       resolve();
     }
 
-    const recaptchaSiteKey    = google_recaptcha.recaptcha_sitekey;
+    const recaptchaSiteKey    = dokan_google_recaptcha.recaptcha_sitekey;
     const recaptchaTokenField = document.querySelector(inputFieldSelector);
 
     // Check if the recaptcha site key exists

--- a/assets/src/js/script.js
+++ b/assets/src/js/script.js
@@ -562,7 +562,7 @@ jQuery(function($) {
   var Dokan_Seller = {
     init: function() {
       this.validate(this);
-      this.executeRecaptcha();
+      this.generateRecaptchaToken(this);
     },
 
     validate: function(self) {
@@ -574,8 +574,6 @@ jQuery(function($) {
           label.remove();
         },
         submitHandler: function(form) {
-          self.executeRecaptcha();
-
           $(form).block({
             message: null,
             overlayCSS: {
@@ -596,11 +594,18 @@ jQuery(function($) {
             }
 
             $(form)
-              .find('input[type=text], input[type=email], textarea')
+              .find('input[type=text], input[type=email], textarea, input[name=dokan_recaptcha_token]')
               .val('')
               .removeClass('valid');
           });
         }
+      });
+    },
+
+    // Generate recaptcha token
+    generateRecaptchaToken: function(self) {
+      $('form#dokan-form-contact-seller input[type=submit]').hover(function() {
+        self.executeRecaptcha();
       });
     },
 
@@ -615,9 +620,10 @@ jQuery(function($) {
       }
 
       // Execute recaptcha after passing checks
-      grecaptcha.execute(recaptchaSiteKey, { action: 'dokan_contact_seller_recaptcha' }).then(function(token) {
-        recaptchaTokenField.val('');
-        recaptchaTokenField.val(token);
+      grecaptcha.ready(function() {
+        grecaptcha.execute(recaptchaSiteKey, { action: 'dokan_contact_seller_recaptcha' }).then(function(token) {
+          recaptchaTokenField.val(token);
+        });
       });
     }
   };

--- a/assets/src/js/script.js
+++ b/assets/src/js/script.js
@@ -562,7 +562,6 @@ jQuery(function($) {
   var Dokan_Seller = {
     init: function() {
       this.validate(this);
-      this.executeRecaptcha();
     },
 
     validate: function(self) {
@@ -574,6 +573,8 @@ jQuery(function($) {
           label.remove();
         },
         submitHandler: function(form) {
+          self.executeRecaptcha();
+
           $(form).block({
             message: null,
             overlayCSS: {
@@ -604,8 +605,10 @@ jQuery(function($) {
 
     // Execute recaptcha token request
     executeRecaptcha: function() {
-      grecaptcha.execute('6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI', { action: 'dokan_contact_seller_recaptcha' }).then(function(token) {
-        document.getElementById('dokan_recaptcha_token').value = token;
+      const recaptchaSitekey = $('#dokan_recaptcha_sitekey').val();
+
+      grecaptcha.execute(recaptchaSitekey, { action: 'dokan_contact_seller_recaptcha' }).then(function(token) {
+        $('#dokan_recaptcha_token').val(token);
       });
     }
   };

--- a/assets/src/js/script.js
+++ b/assets/src/js/script.js
@@ -562,6 +562,7 @@ jQuery(function($) {
   var Dokan_Seller = {
     init: function() {
       this.validate(this);
+      this.executeRecaptcha();
     },
 
     validate: function(self) {
@@ -605,10 +606,12 @@ jQuery(function($) {
 
     // Execute recaptcha token request
     executeRecaptcha: function() {
-      const recaptchaSitekey = $('#dokan_recaptcha_sitekey').val();
+      const recaptchaSitekey    = $('#dokan_recaptcha_sitekey').val();
+      const recaptchaTokenField = $('#dokan_recaptcha_token');
 
       grecaptcha.execute(recaptchaSitekey, { action: 'dokan_contact_seller_recaptcha' }).then(function(token) {
-        $('#dokan_recaptcha_token').val(token);
+        recaptchaTokenField.val('');
+        recaptchaTokenField.val(token);
       });
     }
   };

--- a/assets/src/js/script.js
+++ b/assets/src/js/script.js
@@ -562,6 +562,7 @@ jQuery(function($) {
   var Dokan_Seller = {
     init: function() {
       this.validate(this);
+      this.executeRecaptcha();
     },
 
     validate: function(self) {
@@ -573,14 +574,6 @@ jQuery(function($) {
           label.remove();
         },
         submitHandler: function(form) {
-          // Google reCaptcha site key
-          const recaptchaSiteKey = google_recaptcha.recaptcha_sitekey;
-
-          // Execute recaptcha token request
-          grecaptcha.execute(recaptchaSiteKey, { action: 'dokan_contact_seller_recaptcha' }).then(function(token) {
-            document.getElementById('dokan_recaptcha_token').value = token;
-          });
-
           $(form).block({
             message: null,
             overlayCSS: {
@@ -606,6 +599,13 @@ jQuery(function($) {
               .removeClass('valid');
           });
         }
+      });
+    },
+
+    // Execute recaptcha token request
+    executeRecaptcha: function() {
+      grecaptcha.execute('6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI', { action: 'dokan_contact_seller_recaptcha' }).then(function(token) {
+        document.getElementById('dokan_recaptcha_token').value = token;
       });
     }
   };

--- a/assets/src/js/script.js
+++ b/assets/src/js/script.js
@@ -583,7 +583,7 @@ jQuery(function($) {
           });
 
           // Run recaptcha executer
-          await self.executeRecaptcha( 'form#dokan-form-contact-seller .dokan_recaptcha_token', 'dokan_contact_seller_recaptcha' );
+          await dokan_execute_recaptcha( 'form#dokan-form-contact-seller .dokan_recaptcha_token', 'dokan_contact_seller_recaptcha' );
 
           var form_data = $(form).serialize();
           $.post(dokan.ajaxurl, form_data, function(resp) {
@@ -601,27 +601,6 @@ jQuery(function($) {
               .removeClass('valid');
           });
         }
-      });
-    },
-
-    // Execute recaptcha token request
-    executeRecaptcha: function(inputFieldSelector, action) {
-      return new Promise( function(resolve) {
-        const recaptchaSiteKey    = google_recaptcha.recaptcha_sitekey;
-        const recaptchaTokenField = $(inputFieldSelector);
-
-        // Check if the recaptcha site key exists
-        if ( '' === recaptchaSiteKey ) {
-          resolve();
-        }
-
-        // Execute recaptcha after passing checks
-        grecaptcha.ready(function() {
-          grecaptcha.execute(recaptchaSiteKey, { action: action }).then(function(token) {
-            recaptchaTokenField.val(token);
-            resolve();
-          });
-        });
       });
     }
   };

--- a/assets/src/js/script.js
+++ b/assets/src/js/script.js
@@ -573,6 +573,14 @@ jQuery(function($) {
           label.remove();
         },
         submitHandler: function(form) {
+          // Google reCaptcha site key
+          const recaptchaSiteKey = google_recaptcha.recaptcha_sitekey;
+
+          // Execute recaptcha token request
+          grecaptcha.execute(recaptchaSiteKey, { action: 'dokan_contact_seller_recaptcha' }).then(function(token) {
+            document.getElementById('dokan_recaptcha_token').value = token;
+          });
+
           $(form).block({
             message: null,
             overlayCSS: {
@@ -1157,8 +1165,8 @@ jQuery(function($) {
  * @returns boolean
  */
  async function dokan_show_delete_prompt( event, messgae ) {
-  event.preventDefault(); 
-  
+  event.preventDefault();
+
   let answer = await dokan_sweetalert( messgae, {
     action  : 'confirm',
     icon    : 'warning'
@@ -1166,7 +1174,7 @@ jQuery(function($) {
 
   if( answer.isConfirmed && undefined !== event.target.href ) {
       window.location.href = event.target.href;
-  } 
+  }
   else if( answer.isConfirmed && undefined !== event.target.dataset.url ) {
       window.location.href = event.target.dataset.url;
   }

--- a/assets/src/js/script.js
+++ b/assets/src/js/script.js
@@ -562,7 +562,6 @@ jQuery(function($) {
   var Dokan_Seller = {
     init: function() {
       this.validate(this);
-      this.generateRecaptchaToken(this);
     },
 
     validate: function(self) {
@@ -573,7 +572,7 @@ jQuery(function($) {
           label.removeClass('error');
           label.remove();
         },
-        submitHandler: function(form) {
+        submitHandler: async function(form) {
           $(form).block({
             message: null,
             overlayCSS: {
@@ -582,6 +581,9 @@ jQuery(function($) {
               opacity: 0.6
             }
           });
+
+          // Run recaptcha executer
+          await self.executeRecaptcha();
 
           var form_data = $(form).serialize();
           $.post(dokan.ajaxurl, form_data, function(resp) {
@@ -602,27 +604,23 @@ jQuery(function($) {
       });
     },
 
-    // Generate recaptcha token
-    generateRecaptchaToken: function(self) {
-      $('form#dokan-form-contact-seller input[type=submit]').hover(function() {
-        self.executeRecaptcha();
-      });
-    },
-
     // Execute recaptcha token request
     executeRecaptcha: function() {
-      const recaptchaSiteKey    = google_recaptcha.recaptcha_sitekey;
-      const recaptchaTokenField = $('#dokan_recaptcha_token');
+      return new Promise( function( resolve ) {
+        const recaptchaSiteKey    = google_recaptcha.recaptcha_sitekey;
+        const recaptchaTokenField = $('#dokan_recaptcha_token');
 
-      // Check if the recaptcha site key exists
-      if ( '' === recaptchaSiteKey ) {
-          return;
-      }
+        // Check if the recaptcha site key exists
+        if ( '' === recaptchaSiteKey ) {
+          resolve();
+        }
 
-      // Execute recaptcha after passing checks
-      grecaptcha.ready(function() {
-        grecaptcha.execute(recaptchaSiteKey, { action: 'dokan_contact_seller_recaptcha' }).then(function(token) {
-          recaptchaTokenField.val(token);
+        // Execute recaptcha after passing checks
+        grecaptcha.ready(function() {
+          grecaptcha.execute(recaptchaSiteKey, { action: 'dokan_contact_seller_recaptcha' }).then(function(token) {
+            recaptchaTokenField.val(token);
+            resolve();
+          });
         });
       });
     }

--- a/assets/src/js/script.js
+++ b/assets/src/js/script.js
@@ -606,10 +606,16 @@ jQuery(function($) {
 
     // Execute recaptcha token request
     executeRecaptcha: function() {
-      const recaptchaSitekey    = $('#dokan_recaptcha_sitekey').val();
+      const recaptchaSiteKey    = google_recaptcha.recaptcha_sitekey;
       const recaptchaTokenField = $('#dokan_recaptcha_token');
 
-      grecaptcha.execute(recaptchaSitekey, { action: 'dokan_contact_seller_recaptcha' }).then(function(token) {
+      // Check if the recaptcha site key exists
+      if ( '' === recaptchaSiteKey ) {
+          return;
+      }
+
+      // Execute recaptcha after passing checks
+      grecaptcha.execute(recaptchaSiteKey, { action: 'dokan_contact_seller_recaptcha' }).then(function(token) {
         recaptchaTokenField.val('');
         recaptchaTokenField.val(token);
       });

--- a/assets/src/js/script.js
+++ b/assets/src/js/script.js
@@ -583,7 +583,7 @@ jQuery(function($) {
           });
 
           // Run recaptcha executer
-          await self.executeRecaptcha();
+          await self.executeRecaptcha( 'form#dokan-form-contact-seller .dokan_recaptcha_token', 'dokan_contact_seller_recaptcha' );
 
           var form_data = $(form).serialize();
           $.post(dokan.ajaxurl, form_data, function(resp) {
@@ -605,10 +605,10 @@ jQuery(function($) {
     },
 
     // Execute recaptcha token request
-    executeRecaptcha: function() {
-      return new Promise( function( resolve ) {
+    executeRecaptcha: function(inputFieldSelector, action) {
+      return new Promise( function(resolve) {
         const recaptchaSiteKey    = google_recaptcha.recaptcha_sitekey;
-        const recaptchaTokenField = $('#dokan_recaptcha_token');
+        const recaptchaTokenField = $(inputFieldSelector);
 
         // Check if the recaptcha site key exists
         if ( '' === recaptchaSiteKey ) {
@@ -617,7 +617,7 @@ jQuery(function($) {
 
         // Execute recaptcha after passing checks
         grecaptcha.ready(function() {
-          grecaptcha.execute(recaptchaSiteKey, { action: 'dokan_contact_seller_recaptcha' }).then(function(token) {
+          grecaptcha.execute(recaptchaSiteKey, { action: action }).then(function(token) {
             recaptchaTokenField.val(token);
             resolve();
           });

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -596,6 +596,12 @@ class Settings {
                     'type'    => 'checkbox',
                     'default' => 'on',
                 ],
+                'recaptcha_site_key'   => [
+                    'name'    => 'recaptcha_site_key',
+                    'label'   => __( 'Google reCaptcha v3 Site Key', 'dokan-lite' ),
+                    'desc'    => __( '<a href="https://www.google.com/recaptcha/admin/" target="_blank" rel="noopener noreferrer">Site Key</a> is needed to verify store contact form invisible captcha', 'dokan-lite' ),
+                    'type'    => 'text',
+                ],
                 'store_header_template'      => [
                     'name'    => 'store_header_template',
                     'label'   => __( 'Store Header Template', 'dokan-lite' ),

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -596,10 +596,16 @@ class Settings {
                     'type'    => 'checkbox',
                     'default' => 'on',
                 ],
-                'recaptcha_site_key'   => [
+                'recaptcha_site_key'         => [
                     'name'    => 'recaptcha_site_key',
                     'label'   => __( 'Google reCaptcha v3 Site Key', 'dokan-lite' ),
                     'desc'    => __( '<a href="https://www.google.com/recaptcha/admin/" target="_blank" rel="noopener noreferrer">Site Key</a> is needed to verify store contact form invisible captcha', 'dokan-lite' ),
+                    'type'    => 'text',
+                ],
+                'recaptcha_secret_key'       => [
+                    'name'    => 'recaptcha_secret_key',
+                    'label'   => __( 'Google reCaptcha v3 Secret Key', 'dokan-lite' ),
+                    'desc'    => __( '<a href="https://www.google.com/recaptcha/admin/" target="_blank" rel="noopener noreferrer">Secret Key</a> is needed to verify store contact form invisible captcha', 'dokan-lite' ),
                     'type'    => 'text',
                 ],
                 'store_header_template'      => [

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -601,11 +601,13 @@ class Settings {
                     'name'    => 'recaptcha_site_key',
                     'label'   => __( 'Site Key', 'dokan-lite' ),
                     'type'    => 'text',
+                    'tooltip' => __( 'Insert Google reCaptcha v3 site key.', 'dokan-lite' ),
                 ],
                 'recaptcha_secret_key'       => [
                     'name'    => 'recaptcha_secret_key',
                     'label'   => __( 'Secret Key', 'dokan-lite' ),
                     'type'    => 'text',
+                    'tooltip' => __( 'Insert Google reCaptcha v3 secret key.', 'dokan-lite' ),
                 ],
                 'contact_seller'             => [
                     'name'    => 'contact_seller',

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -589,24 +589,28 @@ class Settings {
                     'desc'    => __( '<a href="https://docs.mapbox.com/help/how-mapbox-works/access-tokens/" target="_blank" rel="noopener noreferrer">Access Token</a> is needed to display map on store page', 'dokan-lite' ),
                     'type'    => 'text',
                 ],
+                'recaptcha_validation_label' => [
+                    'name'  => 'recaptcha_validation_label',
+                    'label' => __( 'Google reCaptcha Validation', 'dokan-lite' ),
+                    'type'  => 'html',
+                    'desc'    => __( '<a href="https://developers.google.com/recaptcha/docs/v3" target="_blank" rel="noopener noreferrer">reCaptcha v3</a> credentials required to enable store contact form invisible captcha', 'dokan-lite' ),
+                ],
+                'recaptcha_site_key'         => [
+                    'name'    => 'recaptcha_site_key',
+                    'label'   => __( 'Site Key', 'dokan-lite' ),
+                    'type'    => 'text',
+                ],
+                'recaptcha_secret_key'       => [
+                    'name'    => 'recaptcha_secret_key',
+                    'label'   => __( 'Secret Key', 'dokan-lite' ),
+                    'type'    => 'text',
+                ],
                 'contact_seller'             => [
                     'name'    => 'contact_seller',
                     'label'   => __( 'Show Contact Form on Store Page', 'dokan-lite' ),
                     'desc'    => __( 'Display a vendor contact form in the store sidebar', 'dokan-lite' ),
                     'type'    => 'checkbox',
                     'default' => 'on',
-                ],
-                'recaptcha_site_key'         => [
-                    'name'    => 'recaptcha_site_key',
-                    'label'   => __( 'Google reCaptcha v3 Site Key', 'dokan-lite' ),
-                    'desc'    => __( '<a href="https://www.google.com/recaptcha/admin/" target="_blank" rel="noopener noreferrer">Site Key</a> is needed to verify store contact form invisible captcha', 'dokan-lite' ),
-                    'type'    => 'text',
-                ],
-                'recaptcha_secret_key'       => [
-                    'name'    => 'recaptcha_secret_key',
-                    'label'   => __( 'Google reCaptcha v3 Secret Key', 'dokan-lite' ),
-                    'desc'    => __( '<a href="https://www.google.com/recaptcha/admin/" target="_blank" rel="noopener noreferrer">Secret Key</a> is needed to verify store contact form invisible captcha', 'dokan-lite' ),
-                    'type'    => 'text',
                 ],
                 'store_header_template'      => [
                     'name'    => 'store_header_template',

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -595,7 +595,7 @@ class Settings {
                     'name'  => 'recaptcha_validation_label',
                     'label' => __( 'Google reCaptcha Validation', 'dokan-lite' ),
                     'type'  => 'html',
-                    'desc'    => __( '<a href="https://developers.google.com/recaptcha/docs/v3" target="_blank" rel="noopener noreferrer">reCaptcha v3</a> credentials required to enable store contact form invisible captcha', 'dokan-lite' ),
+                    'desc'    => __( '<a href="https://developers.google.com/recaptcha/docs/v3" target="_blank" rel="noopener noreferrer">reCaptcha v3</a> credentials required to enable store contact form invisible captcha. <a href="https://wedevs.com/docs/dokan/settings/dokan-recaptacha-v3-integration" target="_blank" rel="noopener noreferrer">Get Help</a>', 'dokan-lite' ),
                 ],
                 'recaptcha_site_key'         => [
                     'name'    => 'recaptcha_site_key',

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -595,7 +595,7 @@ class Settings {
                     'name'  => 'recaptcha_validation_label',
                     'label' => __( 'Google reCaptcha Validation', 'dokan-lite' ),
                     'type'  => 'html',
-                    'desc'    => sprintf( '<a href="https://developers.google.com/recaptcha/docs/v3" target="_blank" rel="noopener noreferrer">%s</a> %s. <a href="https://wedevs.com/docs/dokan/settings/dokan-recaptacha-v3-integration" target="_blank" rel="noopener noreferrer">%s</a>', __( 'reCaptcha v3', 'dokan-lite' ), __( 'credentials required to enable store contact form invisible captcha', 'dokan-lite' ), __( 'Get Help', 'dokan-lite' ) ),
+                    'desc'  => sprintf( '<a href="https://developers.google.com/recaptcha/docs/v3" target="_blank" rel="noopener noreferrer">%s</a> %s. <a href="https://wedevs.com/docs/dokan/settings/dokan-recaptacha-v3-integration" target="_blank" rel="noopener noreferrer">%s</a>', __( 'reCaptcha v3', 'dokan-lite' ), __( 'credentials required to enable store contact form invisible captcha', 'dokan-lite' ), __( 'Get Help', 'dokan-lite' ) ),
                 ],
                 'recaptcha_site_key'         => [
                     'name'    => 'recaptcha_site_key',

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -595,7 +595,7 @@ class Settings {
                     'name'  => 'recaptcha_validation_label',
                     'label' => __( 'Google reCaptcha Validation', 'dokan-lite' ),
                     'type'  => 'html',
-                    'desc'    => __( '<a href="https://developers.google.com/recaptcha/docs/v3" target="_blank" rel="noopener noreferrer">reCaptcha v3</a> credentials required to enable store contact form invisible captcha. <a href="https://wedevs.com/docs/dokan/settings/dokan-recaptacha-v3-integration" target="_blank" rel="noopener noreferrer">Get Help</a>', 'dokan-lite' ),
+                    'desc'    => sprintf( '<a href="https://developers.google.com/recaptcha/docs/v3" target="_blank" rel="noopener noreferrer">%s</a> %s. <a href="https://wedevs.com/docs/dokan/settings/dokan-recaptacha-v3-integration" target="_blank" rel="noopener noreferrer">%s</a>', __( 'reCaptcha v3', 'dokan-lite' ), __( 'credentials required to enable store contact form invisible captcha', 'dokan-lite' ), __( 'Get Help', 'dokan-lite' ) ),
                 ],
                 'recaptcha_site_key'         => [
                     'name'    => 'recaptcha_site_key',

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -325,7 +325,6 @@ class Ajax {
         $contact_email   = ! empty( $_POST['email'] ) ? sanitize_email( wp_unslash( $_POST['email'] ) ) : '';
         $contact_message = ! empty( $_POST['message'] ) ? sanitize_text_field( wp_unslash( $_POST['message'] ) ) : '';
         $captcha_token   = ! empty( $_POST['recaptcha_token'] ) ? sanitize_key( wp_unslash( $_POST['recaptcha_token'] ) ) : '';
-        $captcha_sitekey = ! empty( $_POST['recaptcha_site_key'] ) ? sanitize_key( wp_unslash( $_POST['recaptcha_site_key'] ) ) : '';
         $captcha_action  = ! empty( $_POST['recaptcha_action'] ) ? sanitize_key( wp_unslash( $_POST['recaptcha_action'] ) ) : '';
         $error_template  = '<span class="alert alert-danger error">%s</span>';
 
@@ -346,8 +345,10 @@ class Ajax {
             wp_send_json_error( $message );
         }
 
+        $captcha_sitekey = dokan_get_option( 'recaptcha_site_key', 'dokan_appearance' );
+
         // Validate captcha if checking enabled from admin setting
-        if ( ! empty( dokan_get_option( 'recaptcha_site_key', 'dokan_appearance' ) ) ) {
+        if ( ! empty( $captcha_sitekey ) ) {
             $recaptcha_validate = $this->recaptcha_validation_handler( $captcha_sitekey, $captcha_token, $captcha_action );
 
             if ( empty( $recaptcha_validate ) ) {

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -324,7 +324,6 @@ class Ajax {
         $contact_name    = ! empty( $_POST['name'] ) ? sanitize_text_field( wp_unslash( $_POST['name'] ) ) : '';
         $contact_email   = ! empty( $_POST['email'] ) ? sanitize_email( wp_unslash( $_POST['email'] ) ) : '';
         $contact_message = ! empty( $_POST['message'] ) ? sanitize_text_field( wp_unslash( $_POST['message'] ) ) : '';
-        $captcha_action  = ! empty( $_POST['dokan_recaptcha_action'] ) ? sanitize_key( wp_unslash( $_POST['dokan_recaptcha_action'] ) ) : '';
         $captcha_token   = ! empty( $_POST['dokan_recaptcha_token'] ) ? wp_unslash( $_POST['dokan_recaptcha_token'] ) : '';
         $error_template  = '<span class="alert alert-danger error">%s</span>';
 
@@ -347,6 +346,7 @@ class Ajax {
 
         $captcha_sitekey   = dokan_get_option( 'recaptcha_site_key', 'dokan_appearance' );
         $captcha_secretkey = dokan_get_option( 'recaptcha_secret_key', 'dokan_appearance' );
+        $captcha_action    = 'dokan_contact_seller_recaptcha';
 
         // Validate captcha if checking enabled from admin setting
         if ( ! empty( $captcha_sitekey ) && ! empty( $captcha_secretkey ) ) {

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -324,7 +324,7 @@ class Ajax {
         $contact_name    = ! empty( $_POST['name'] ) ? sanitize_text_field( wp_unslash( $_POST['name'] ) ) : '';
         $contact_email   = ! empty( $_POST['email'] ) ? sanitize_email( wp_unslash( $_POST['email'] ) ) : '';
         $contact_message = ! empty( $_POST['message'] ) ? sanitize_text_field( wp_unslash( $_POST['message'] ) ) : '';
-        $captcha_token   = ! empty( $_POST['dokan_recaptcha_token'] ) ? wp_unslash( $_POST['dokan_recaptcha_token'] ) : '';
+        $recaptcha_token = ! empty( $_POST['dokan_recaptcha_token'] ) ? wp_unslash( $_POST['dokan_recaptcha_token'] ) : '';
         $error_template  = '<span class="alert alert-danger error">%s</span>';
 
         if ( empty( $contact_name ) ) {
@@ -347,7 +347,7 @@ class Ajax {
         // Validate recaptcha if site key and secret key exist
         if ( dokan_get_recpatcha_site_and_secret_keys( true ) ) {
             $recaptcha_keys     = dokan_get_recpatcha_site_and_secret_keys();
-            $recaptcha_validate = $this->recaptcha_validation_handler( 'dokan_contact_seller_recaptcha', $recaptcha_keys['site_key'], $recaptcha_keys['secret_key'] );
+            $recaptcha_validate = $this->recaptcha_validation_handler( 'dokan_contact_seller_recaptcha', $recaptcha_token, $recaptcha_keys['secret_key'] );
 
             if ( empty( $recaptcha_validate ) ) {
                 $message = sprintf( $error_template, __( 'Google reCaptcha varification failed!', 'dokan-lite' ) );

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -339,7 +339,7 @@ class Ajax {
             wp_send_json_error( $message );
         }
 
-        $seller = ! empty( $_POST['seller_id'] ) ? get_user_by( 'id', intval( wp_unslash( $_POST['seller_id'] ) ) ) : 0;
+        $seller = ! empty( $_POST['seller_id'] ) ? get_user_by( 'id', absint( wp_unslash( $_POST['seller_id'] ) ) ) : 0;
 
         if ( empty( $seller ) ) {
             $message = sprintf( $error_template, __( 'Something went wrong!', 'dokan-lite' ) );
@@ -1059,19 +1059,20 @@ class Ajax {
      * @return boolean
      */
     public function recaptcha_validation_handler( $sitekey, $token, $action ) {
-        if ( empty( $sitekey ) || empty( $token ) ) {
+        if ( empty( $sitekey ) || empty( $token ) || empty( $action ) ) {
             return false;
         }
 
-        $siteverify = 'https://www.google.com/recaptcha/api/siteverify';
-        $response   = file_get_contents( $siteverify . '?secret=' . $sitekey . '&response=' . $token );
-        $response   = json_decode( $response, true );
+        $siteverify    = 'https://www.google.com/recaptcha/api/siteverify';
+        $response      = wp_remote_get( $siteverify . '?secret=' . $sitekey . '&response=' . $token );
+        $response_body = wp_remote_retrieve_body( $response );
+        $response_data = json_decode( $response_body, true );
 
         // Validate reCaptcha action
-        if ( $action !== $response['action'] ) {
+        if ( empty( $response_data['action'] ) || $action !== $response_data['action'] ) {
             return false;
         }
 
-        return $response['success'];
+        return $response_data['success'];
     }
 }

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -339,7 +339,7 @@ class Ajax {
             wp_send_json_error( $message );
         }
 
-        $seller =  ! empty( $_POST['seller_id'] ) ? get_user_by( 'id', intval( wp_unslash( $_POST['seller_id'] ) ) ): 0;
+        $seller = ! empty( $_POST['seller_id'] ) ? get_user_by( 'id', intval( wp_unslash( $_POST['seller_id'] ) ) ) : 0;
 
         if ( empty( $seller ) ) {
             $message = sprintf( $error_template, __( 'Something went wrong!', 'dokan-lite' ) );

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -345,8 +345,8 @@ class Ajax {
         }
 
         // Validate recaptcha if site key and secret key exist
-        if ( dokan_get_recpatcha_site_and_secret_keys( true ) ) {
-            $recaptcha_keys     = dokan_get_recpatcha_site_and_secret_keys();
+        if ( dokan_get_recaptcha_site_and_secret_keys( true ) ) {
+            $recaptcha_keys     = dokan_get_recaptcha_site_and_secret_keys();
             $recaptcha_validate = $this->recaptcha_validation_handler( 'dokan_contact_seller_recaptcha', $recaptcha_token, $recaptcha_keys['secret_key'] );
 
             if ( empty( $recaptcha_validate ) ) {

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -339,7 +339,7 @@ class Ajax {
             wp_send_json_error( $message );
         }
 
-        $seller = get_user_by( 'id', intval( wp_unslash( $_POST['seller_id'] ) ) );
+        $seller =  ! empty( $_POST['seller_id'] ) ? get_user_by( 'id', intval( wp_unslash( $_POST['seller_id'] ) ) ): 0;
 
         if ( empty( $seller ) ) {
             $message = sprintf( $error_template, __( 'Something went wrong!', 'dokan-lite' ) );
@@ -351,7 +351,7 @@ class Ajax {
             $recaptcha_validate = $this->recaptcha_validation_handler( $captcha_sitekey, $captcha_token, $captcha_action );
 
             if ( empty( $recaptcha_validate ) ) {
-                $message = sprintf( $error_template, __( 'Google reCaptcha varification failed!' ) );
+                $message = sprintf( $error_template, __( 'Google reCaptcha varification failed!', 'dokan-lite' ) );
                 wp_send_json_error( $message );
             }
         }
@@ -1058,7 +1058,7 @@ class Ajax {
      *
      * @return boolean
      */
-    function recaptcha_validation_handler( $sitekey, $token, $action ) {
+    public function recaptcha_validation_handler( $sitekey, $token, $action ) {
         if ( empty( $sitekey ) || empty( $token ) ) {
             return false;
         }

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -1049,7 +1049,7 @@ class Ajax {
     /**
      * Handler for reCaptcha validation request.
      *
-     * @since 3.3.2
+     * @since 3.3.3
      *
      * @param string $action
      * @param string $token

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -346,12 +346,14 @@ class Ajax {
             wp_send_json_error( $message );
         }
 
-        // Validate reCaptcha
-        $recaptcha_validate = $this->recaptcha_validation_handler( $captcha_sitekey, $captcha_token, $captcha_action );
+        // Validate captcha if checking enabled from admin setting
+        if ( ! empty( dokan_get_option( 'recaptcha_site_key', 'dokan_appearance' ) ) ) {
+            $recaptcha_validate = $this->recaptcha_validation_handler( $captcha_sitekey, $captcha_token, $captcha_action );
 
-        if ( empty( $recaptcha_validate ) ) {
-            $message = sprintf( $error_template, __( 'Google reCaptcha varification failed!' ) );
-            wp_send_json_error( $message );
+            if ( empty( $recaptcha_validate ) ) {
+                $message = sprintf( $error_template, __( 'Google reCaptcha varification failed!' ) );
+                wp_send_json_error( $message );
+            }
         }
 
         do_action( 'dokan_trigger_contact_seller_mail', $seller->user_email, $contact_name, $contact_email, $contact_message );

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -324,8 +324,8 @@ class Ajax {
         $contact_name    = ! empty( $_POST['name'] ) ? sanitize_text_field( wp_unslash( $_POST['name'] ) ) : '';
         $contact_email   = ! empty( $_POST['email'] ) ? sanitize_email( wp_unslash( $_POST['email'] ) ) : '';
         $contact_message = ! empty( $_POST['message'] ) ? sanitize_text_field( wp_unslash( $_POST['message'] ) ) : '';
-        $captcha_action  = ! empty( $_POST['recaptcha_action'] ) ? sanitize_key( wp_unslash( $_POST['recaptcha_action'] ) ) : '';
-        $captcha_token   = ! empty( $_POST['recaptcha_token'] ) ? wp_unslash( $_POST['recaptcha_token'] ) : '';
+        $captcha_action  = ! empty( $_POST['dokan_recaptcha_action'] ) ? sanitize_key( wp_unslash( $_POST['dokan_recaptcha_action'] ) ) : '';
+        $captcha_token   = ! empty( $_POST['dokan_recaptcha_token'] ) ? wp_unslash( $_POST['dokan_recaptcha_token'] ) : '';
         $error_template  = '<span class="alert alert-danger error">%s</span>';
 
         if ( empty( $contact_name ) ) {

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -1073,6 +1073,6 @@ class Ajax {
             return false;
         }
 
-        return $response_data['success'];
+        return $response_data['success'] ? $response_data['success'] : false;
     }
 }

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -324,7 +324,7 @@ class Ajax {
         $contact_name    = ! empty( $_POST['name'] ) ? sanitize_text_field( wp_unslash( $_POST['name'] ) ) : '';
         $contact_email   = ! empty( $_POST['email'] ) ? sanitize_email( wp_unslash( $_POST['email'] ) ) : '';
         $contact_message = ! empty( $_POST['message'] ) ? sanitize_text_field( wp_unslash( $_POST['message'] ) ) : '';
-        $recaptcha_token = ! empty( $_POST['dokan_recaptcha_token'] ) ? wp_unslash( $_POST['dokan_recaptcha_token'] ) : '';
+        $recaptcha_token = ! empty( $_POST['dokan_recaptcha_token'] ) ? wp_unslash( $_POST['dokan_recaptcha_token'] ) : ''; // phpcs:ignore
         $error_template  = '<span class="alert alert-danger error">%s</span>';
 
         if ( empty( $contact_name ) ) {

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -344,13 +344,10 @@ class Ajax {
             wp_send_json_error( $message );
         }
 
-        $captcha_sitekey   = dokan_get_option( 'recaptcha_site_key', 'dokan_appearance' );
-        $captcha_secretkey = dokan_get_option( 'recaptcha_secret_key', 'dokan_appearance' );
-        $captcha_action    = 'dokan_contact_seller_recaptcha';
-
-        // Validate captcha if checking enabled from admin setting
-        if ( ! empty( $captcha_sitekey ) && ! empty( $captcha_secretkey ) ) {
-            $recaptcha_validate = $this->recaptcha_validation_handler( $captcha_action, $captcha_token, $captcha_secretkey );
+        // Validate recaptcha if site key and secret key exist
+        if ( dokan_get_recpatcha_site_and_secret_keys( true ) ) {
+            $recaptcha_keys     = dokan_get_recpatcha_site_and_secret_keys();
+            $recaptcha_validate = $this->recaptcha_validation_handler( 'dokan_contact_seller_recaptcha', $recaptcha_keys['site_key'], $recaptcha_keys['secret_key'] );
 
             if ( empty( $recaptcha_validate ) ) {
                 $message = sprintf( $error_template, __( 'Google reCaptcha varification failed!', 'dokan-lite' ) );

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -1073,6 +1073,12 @@ class Ajax {
             return false;
         }
 
-        return $response_data['success'] ? $response_data['success'] : false;
+        // Check if the response data is not empty
+        if ( empty( $response_data['success'] ) ) {
+            return false;
+        }
+
+        // Return success after passing checks
+        return $response_data['success'];
     }
 }

--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -505,15 +505,16 @@ class Assets {
             }
         }
 
-        // Script for contact form widget google recaptcha
+        // Scripts for contact form widget google recaptcha
         if ( dokan_is_store_page() || is_product() ) {
-            if ( ! empty( dokan_get_option( 'recaptcha_site_key', 'dokan_appearance' ) ) && ! empty( dokan_get_option( 'recaptcha_secret_key', 'dokan_appearance' ) ) ) {
+            // Checks if recaptcha site key and secret key exist
+            if ( dokan_get_recpatcha_site_and_secret_keys( true ) ) {
                 wp_enqueue_script( 'dokan-google-recaptcha' );
+
+                // Localized script for recaptcha
+                wp_localize_script( 'dokan-google-recaptcha', 'google_recaptcha', [ 'recaptcha_sitekey' => dokan_get_option( 'recaptcha_site_key', 'dokan_appearance' ) ] );
             }
         }
-
-        // Localized script for google recaptcha
-        wp_localize_script( 'dokan-google-recaptcha', 'google_recaptcha', [ 'recaptcha_sitekey' => dokan_get_option( 'recaptcha_site_key', 'dokan_appearance' ) ] );
 
         wp_enqueue_script( 'dokan-login-form-popup' );
 

--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -505,6 +505,14 @@ class Assets {
             }
         }
 
+        // Script for contact form widget google recaptcha
+        if ( dokan_is_store_page()
+             && ! empty( dokan_get_option( 'recaptcha_site_key', 'dokan_appearance' ) )
+             && ! empty( dokan_get_option( 'recaptcha_secret_key', 'dokan_appearance' ) )
+        ) {
+            wp_enqueue_script( 'dokan-google-recaptcha' );
+        }
+
         wp_enqueue_script( 'dokan-login-form-popup' );
 
         do_action( 'dokan_enqueue_scripts' );

--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -506,7 +506,8 @@ class Assets {
         }
 
         // Script for contact form widget google recaptcha
-        if ( dokan_is_store_page() && ! empty( dokan_get_option( 'recaptcha_site_key', 'dokan_appearance' ) ) && ! empty( dokan_get_option( 'recaptcha_secret_key', 'dokan_appearance' ) ) ) {
+        if ( dokan_is_store_page() || is_product() ) {
+            if ( ! empty( dokan_get_option( 'recaptcha_site_key', 'dokan_appearance' ) ) && ! empty( dokan_get_option( 'recaptcha_secret_key', 'dokan_appearance' ) ) )
             wp_enqueue_script( 'dokan-google-recaptcha' );
         }
 

--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -515,7 +515,7 @@ class Assets {
                 wp_enqueue_script( 'dokan-google-recaptcha' );
 
                 // Localized script for recaptcha
-                wp_localize_script( 'dokan-google-recaptcha', 'google_recaptcha', [ 'recaptcha_sitekey' => $recaptcha_keys['site_key'] ] );
+                wp_localize_script( 'dokan-google-recaptcha', 'dokan_google_recaptcha', [ 'recaptcha_sitekey' => $recaptcha_keys['site_key'] ] );
             }
         }
 

--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -319,7 +319,7 @@ class Assets {
                 'deps'      => [ 'jquery' ],
                 'in_footer' => false,
             ],
-            'dokan-recaptcha' => [
+            'dokan-google-recaptcha' => [
                 'src'       => 'https://www.google.com/recaptcha/api.js?render=' . dokan_get_option( 'recaptcha_site_key', 'dokan_appearance' ),
                 'in_footer' => false,
             ],

--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -321,6 +321,7 @@ class Assets {
             ],
             'dokan-google-recaptcha' => [
                 'src'       => 'https://www.google.com/recaptcha/api.js?render=' . dokan_get_option( 'recaptcha_site_key', 'dokan_appearance' ),
+                'deps'      => [ 'dokan-util-helper' ],
                 'in_footer' => false,
             ],
 
@@ -395,7 +396,7 @@ class Assets {
             ],
             'dokan-util-helper' => [
                 'src'       => $asset_url . '/js/helper.js',
-                'deps'      => [ 'jquery', 'dokan-sweetalert2', 'dokan-google-recaptcha' ],
+                'deps'      => [ 'jquery', 'dokan-sweetalert2' ],
                 'version'   => filemtime( $asset_path . 'js/helper.js' ),
                 'in_footer' => false,
             ],

--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -506,10 +506,7 @@ class Assets {
         }
 
         // Script for contact form widget google recaptcha
-        if ( dokan_is_store_page()
-             && ! empty( dokan_get_option( 'recaptcha_site_key', 'dokan_appearance' ) )
-             && ! empty( dokan_get_option( 'recaptcha_secret_key', 'dokan_appearance' ) )
-        ) {
+        if ( dokan_is_store_page() && ! empty( dokan_get_option( 'recaptcha_site_key', 'dokan_appearance' ) ) && ! empty( dokan_get_option( 'recaptcha_secret_key', 'dokan_appearance' ) ) ) {
             wp_enqueue_script( 'dokan-google-recaptcha' );
         }
 

--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -319,6 +319,10 @@ class Assets {
                 'deps'      => [ 'jquery' ],
                 'in_footer' => false,
             ],
+            'dokan-recaptcha' => [
+                'src'       => 'https://www.google.com/recaptcha/api.js?render=' . dokan_get_option( 'recaptcha_site_key', 'dokan_appearance' ),
+                'in_footer' => false,
+            ],
 
             // customize scripts
             'customize-base' => [
@@ -436,7 +440,7 @@ class Assets {
             'loading_img'                => DOKAN_PLUGIN_ASSEST . '/images/loading.gif',
             'store_product_search_nonce' => wp_create_nonce( 'dokan_store_product_search_nonce' ),
             'i18n_download_permission'   => __( 'Are you sure you want to revoke access to this download?', 'dokan-lite' ),
-            'i18n_download_access'       => __( 'Could not grant access - the user may already have permission for this file or billing email is not set. Ensure the billing email is set, and the order has been saved.', 'dokan-lite' ),   
+            'i18n_download_access'       => __( 'Could not grant access - the user may already have permission for this file or billing email is not set. Ensure the billing email is set, and the order has been saved.', 'dokan-lite' ),
             /**
              * Filter of maximun a vendor can add tags.
              *

--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -512,6 +512,7 @@ class Assets {
             }
         }
 
+        // Localized script for google recaptcha
         wp_localize_script( 'dokan-google-recaptcha', 'google_recaptcha', [ 'recaptcha_sitekey' => dokan_get_option( 'recaptcha_site_key', 'dokan_appearance' ) ] );
 
         wp_enqueue_script( 'dokan-login-form-popup' );

--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -507,9 +507,12 @@ class Assets {
 
         // Script for contact form widget google recaptcha
         if ( dokan_is_store_page() || is_product() ) {
-            if ( ! empty( dokan_get_option( 'recaptcha_site_key', 'dokan_appearance' ) ) && ! empty( dokan_get_option( 'recaptcha_secret_key', 'dokan_appearance' ) ) )
-            wp_enqueue_script( 'dokan-google-recaptcha' );
+            if ( ! empty( dokan_get_option( 'recaptcha_site_key', 'dokan_appearance' ) ) && ! empty( dokan_get_option( 'recaptcha_secret_key', 'dokan_appearance' ) ) ) {
+                wp_enqueue_script( 'dokan-google-recaptcha' );
+            }
         }
+
+        wp_localize_script( 'dokan-google-recaptcha', 'google_recaptcha', [ 'recaptcha_sitekey' => dokan_get_option( 'recaptcha_site_key', 'dokan_appearance' ) ] );
 
         wp_enqueue_script( 'dokan-login-form-popup' );
 

--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -395,7 +395,7 @@ class Assets {
             ],
             'dokan-util-helper' => [
                 'src'       => $asset_url . '/js/helper.js',
-                'deps'      => [ 'jquery', 'dokan-sweetalert2' ],
+                'deps'      => [ 'jquery', 'dokan-sweetalert2', 'dokan-google-recaptcha' ],
                 'version'   => filemtime( $asset_path . 'js/helper.js' ),
                 'in_footer' => false,
             ],
@@ -508,11 +508,13 @@ class Assets {
         // Scripts for contact form widget google recaptcha
         if ( dokan_is_store_page() || is_product() ) {
             // Checks if recaptcha site key and secret key exist
-            if ( dokan_get_recpatcha_site_and_secret_keys( true ) ) {
+            if ( dokan_get_recaptcha_site_and_secret_keys( true ) ) {
+                $recaptcha_keys = dokan_get_recaptcha_site_and_secret_keys();
+
                 wp_enqueue_script( 'dokan-google-recaptcha' );
 
                 // Localized script for recaptcha
-                wp_localize_script( 'dokan-google-recaptcha', 'google_recaptcha', [ 'recaptcha_sitekey' => dokan_get_option( 'recaptcha_site_key', 'dokan_appearance' ) ] );
+                wp_localize_script( 'dokan-google-recaptcha', 'google_recaptcha', [ 'recaptcha_sitekey' => $recaptcha_keys['site_key'] ] );
             }
         }
 

--- a/includes/Widgets/StoreContactForm.php
+++ b/includes/Widgets/StoreContactForm.php
@@ -20,7 +20,7 @@ class StoreContactForm extends WP_Widget {
      *
      * @var string|boolean
      */
-    public $recaptcha_site_key;
+    protected $recaptcha_site_key;
 
     /**
      * Constructor
@@ -151,6 +151,12 @@ class StoreContactForm extends WP_Widget {
      * @return void
      */
     public function enqueue_contact_widget_scripts() {
+        // Check if recaptcha sitekey exists and the page is a store page
+        if ( empty( $this->recaptcha_site_key ) || ! dokan_is_store_page() ) {
+            return;
+        }
+
+        // Enqueue scripts after passing check
         wp_enqueue_script( 'dokan-google-recaptcha' );
         ?>
         <script>

--- a/includes/Widgets/StoreContactForm.php
+++ b/includes/Widgets/StoreContactForm.php
@@ -90,11 +90,10 @@ class StoreContactForm extends WP_Widget {
 
             dokan_get_template_part(
                 'widgets/store-contact-form', '', array(
-                    'seller_id'          => $seller_id,
-                    'store_info'         => $store_info,
-                    'username'           => $username,
-                    'email'              => $email,
-                    'recaptcha_site_key' => $this->recaptcha_site_key,
+                    'seller_id'  => $seller_id,
+                    'store_info' => $store_info,
+                    'username'   => $username,
+                    'email'      => $email,
                 )
             );
 

--- a/includes/Widgets/StoreContactForm.php
+++ b/includes/Widgets/StoreContactForm.php
@@ -151,7 +151,7 @@ class StoreContactForm extends WP_Widget {
      * @return void
      */
     public function enqueue_contact_widget_scripts() {
-        wp_enqueue_script( 'dokan-recaptcha' );
+        wp_enqueue_script( 'dokan-google-recaptcha' );
         ?>
         <script>
             grecaptcha.ready( function() {

--- a/includes/Widgets/StoreContactForm.php
+++ b/includes/Widgets/StoreContactForm.php
@@ -156,7 +156,7 @@ class StoreContactForm extends WP_Widget {
         <script>
             grecaptcha.ready( function() {
                 grecaptcha.execute( '<?php echo esc_html( $this->recaptcha_site_key ); ?>', { action: 'dokan_contact_seller_recaptcha' } ).then( function( token ) {
-                document.getElementById( 'token' ).value = 'token';
+                document.getElementById( 'token' ).value = token;
                 } );
             } );
         </script>

--- a/includes/Widgets/StoreContactForm.php
+++ b/includes/Widgets/StoreContactForm.php
@@ -14,32 +14,11 @@ use WP_Widget;
 class StoreContactForm extends WP_Widget {
 
     /**
-     * Google reCaptcha site key
-     *
-     * @since 3.3.2
-     *
-     * @var string
-     */
-    protected $recaptcha_site_key;
-
-    /**
-     * Google reCaptcha secret key
-     *
-     * @since 3.3.2
-     *
-     * @var string
-     */
-    protected $recaptcha_secret_key;
-
-    /**
      * Constructor
      *
      * @return void
      */
     public function __construct() {
-        $this->recaptcha_site_key   = dokan_get_option( 'recaptcha_site_key', 'dokan_appearance' );
-        $this->recaptcha_secret_key = dokan_get_option( 'recaptcha_secret_key', 'dokan_appearance' );
-
         $widget_ops = array(
 			'classname' => 'dokan-store-contact',
 			'description' => __( 'Dokan Vendor Contact Form', 'dokan-lite' ),
@@ -104,8 +83,6 @@ class StoreContactForm extends WP_Widget {
                     'email'      => $email,
                 )
             );
-
-            wp_localize_script( 'dokan-script', 'google_recaptcha', [ 'recaptcha_sitekey' => $this->recaptcha_site_key ] );
 
             echo $after_widget; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
         }

--- a/includes/Widgets/StoreContactForm.php
+++ b/includes/Widgets/StoreContactForm.php
@@ -98,13 +98,14 @@ class StoreContactForm extends WP_Widget {
 
             dokan_get_template_part(
                 'widgets/store-contact-form', '', array(
-                    'seller_id'         => $seller_id,
-                    'store_info'        => $store_info,
-                    'username'          => $username,
-                    'email'             => $email,
-                    'recaptcha_sitekey' => $this->recaptcha_site_key,
+                    'seller_id'  => $seller_id,
+                    'store_info' => $store_info,
+                    'username'   => $username,
+                    'email'      => $email,
                 )
             );
+
+            wp_localize_script( 'dokan-script', 'google_recaptcha', [ 'recaptcha_sitekey' => $this->recaptcha_site_key ] );
 
             echo $after_widget; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
         }

--- a/includes/Widgets/StoreContactForm.php
+++ b/includes/Widgets/StoreContactForm.php
@@ -45,8 +45,6 @@ class StoreContactForm extends WP_Widget {
 			'description' => __( 'Dokan Vendor Contact Form', 'dokan-lite' ),
 		);
         parent::__construct( 'dokan-store-contact-widget', __( 'Dokan: Store Contact Form', 'dokan-lite' ), $widget_ops );
-
-        add_action( 'wp_head', [ $this, 'enqueue_contact_widget_scripts' ] );
     }
 
     /**
@@ -107,6 +105,8 @@ class StoreContactForm extends WP_Widget {
                 )
             );
 
+            wp_localize_script( 'dokan-script', 'google_recaptcha', [ 'recaptcha_sitekey' => $this->recaptcha_site_key ] );
+
             echo $after_widget; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
         }
 
@@ -149,31 +149,6 @@ class StoreContactForm extends WP_Widget {
             <label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_html_e( 'Title:', 'dokan-lite' ); ?></label>
             <input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo esc_attr( $title ); ?>" />
         </p>
-        <?php
-    }
-
-    /**
-     * Enqueue handler for contact widget assets
-     *
-     * @since 3.3.2
-     *
-     * @return void
-     */
-    public function enqueue_contact_widget_scripts() {
-        // Check if the page is a store page and recaptcha sitekey, secretkey exist
-        if ( ! dokan_is_store_page() || empty( $this->recaptcha_site_key ) || empty( $this->recaptcha_secret_key ) ) {
-            return;
-        }
-
-        // Enqueue scripts after passing check
-        ?>
-        <script>
-            grecaptcha.ready( function() {
-                grecaptcha.execute( '<?php echo esc_html( $this->recaptcha_site_key ); ?>', { action: 'dokan_contact_seller_recaptcha' } ).then( function( token ) {
-                document.getElementById( 'token' ).value = token;
-                } );
-            } );
-        </script>
         <?php
     }
 }

--- a/includes/Widgets/StoreContactForm.php
+++ b/includes/Widgets/StoreContactForm.php
@@ -18,7 +18,7 @@ class StoreContactForm extends WP_Widget {
      *
      * @since 3.3.2
      *
-     * @var string|boolean
+     * @var string
      */
     protected $recaptcha_site_key;
 
@@ -27,7 +27,7 @@ class StoreContactForm extends WP_Widget {
      *
      * @since 3.3.2
      *
-     * @var string|boolean
+     * @var string
      */
     protected $recaptcha_secret_key;
 

--- a/includes/Widgets/StoreContactForm.php
+++ b/includes/Widgets/StoreContactForm.php
@@ -77,10 +77,10 @@ class StoreContactForm extends WP_Widget {
 
             dokan_get_template_part(
                 'widgets/store-contact-form', '', array(
-                    'seller_id'  => $seller_id,
-                    'store_info' => $store_info,
-                    'username'   => $username,
-                    'email'      => $email,
+					'seller_id'  => $seller_id,
+					'store_info' => $store_info,
+					'username'   => $username,
+					'email'      => $email,
                 )
             );
 

--- a/includes/Widgets/StoreContactForm.php
+++ b/includes/Widgets/StoreContactForm.php
@@ -23,12 +23,22 @@ class StoreContactForm extends WP_Widget {
     protected $recaptcha_site_key;
 
     /**
+     * Google reCaptcha secret key
+     *
+     * @since 3.3.2
+     *
+     * @var string|boolean
+     */
+    protected $recaptcha_secret_key;
+
+    /**
      * Constructor
      *
      * @return void
      */
     public function __construct() {
-        $this->recaptcha_site_key = dokan_get_option( 'recaptcha_site_key', 'dokan_appearance' );
+        $this->recaptcha_site_key   = dokan_get_option( 'recaptcha_site_key', 'dokan_appearance' );
+        $this->recaptcha_secret_key = dokan_get_option( 'recaptcha_secret_key', 'dokan_appearance' );
 
         $widget_ops = array(
 			'classname' => 'dokan-store-contact',
@@ -150,13 +160,12 @@ class StoreContactForm extends WP_Widget {
      * @return void
      */
     public function enqueue_contact_widget_scripts() {
-        // Check if recaptcha sitekey exists and the page is a store page
-        if ( empty( $this->recaptcha_site_key ) || ! dokan_is_store_page() ) {
+        // Check if the page is a store page and recaptcha sitekey, secretkey exist
+        if ( ! dokan_is_store_page() || empty( $this->recaptcha_site_key ) || empty( $this->recaptcha_secret_key ) ) {
             return;
         }
 
         // Enqueue scripts after passing check
-        wp_enqueue_script( 'dokan-google-recaptcha' );
         ?>
         <script>
             grecaptcha.ready( function() {

--- a/includes/Widgets/StoreContactForm.php
+++ b/includes/Widgets/StoreContactForm.php
@@ -98,14 +98,13 @@ class StoreContactForm extends WP_Widget {
 
             dokan_get_template_part(
                 'widgets/store-contact-form', '', array(
-                    'seller_id'  => $seller_id,
-                    'store_info' => $store_info,
-                    'username'   => $username,
-                    'email'      => $email,
+                    'seller_id'         => $seller_id,
+                    'store_info'        => $store_info,
+                    'username'          => $username,
+                    'email'             => $email,
+                    'recaptcha_sitekey' => $this->recaptcha_site_key,
                 )
             );
-
-            wp_localize_script( 'dokan-script', 'google_recaptcha', [ 'recaptcha_sitekey' => $this->recaptcha_site_key ] );
 
             echo $after_widget; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
         }

--- a/includes/Widgets/StoreContactForm.php
+++ b/includes/Widgets/StoreContactForm.php
@@ -77,10 +77,11 @@ class StoreContactForm extends WP_Widget {
 
             dokan_get_template_part(
                 'widgets/store-contact-form', '', array(
-					'seller_id'  => $seller_id,
-					'store_info' => $store_info,
-					'username'   => $username,
-					'email'      => $email,
+					'seller_id'          => $seller_id,
+					'store_info'         => $store_info,
+					'username'           => $username,
+					'email'              => $email,
+                    'recaptcha_site_key' => dokan_get_option( 'recaptcha_site_key', 'dokan_appearance' ),
                 )
             );
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -4170,7 +4170,7 @@ function dokan_get_vendor_store_banner_height() {
  *
  * @return array|bool
  */
-function dokan_get_recpatcha_site_and_secret_keys( $bool = false ) {
+function dokan_get_recaptcha_site_and_secret_keys( $bool = false ) {
     $recaptcha_keys = [
         'site_key'   => dokan_get_option( 'recaptcha_site_key', 'dokan_appearance' ),
         'secret_key' => dokan_get_option( 'recaptcha_secret_key', 'dokan_appearance' ),

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -4160,3 +4160,29 @@ function dokan_get_vendor_store_banner_height() {
 
     return ( $height !== 0 ) ? $height : 300;
 }
+
+/**
+ * Get google recaptcha site key and secret key
+ *
+ * @param bool $bool
+ *
+ * @since 3.3.3
+ *
+ * @return array|bool
+ */
+function dokan_get_recpatcha_site_and_secret_keys( $bool = false ) {
+    $recaptcha_keys = [
+        'site_key'   => dokan_get_option( 'recaptcha_site_key', 'dokan_appearance' ),
+        'secret_key' => dokan_get_option( 'recaptcha_secret_key', 'dokan_appearance' ),
+    ];
+
+    if ( $bool ) {
+        if ( empty( $recaptcha_keys['site_key'] ) || empty( $recaptcha_keys['secret_key'] ) ) {
+            return false;
+        }
+
+        return true;
+    }
+
+    return $recaptcha_keys;
+}

--- a/templates/widgets/store-contact-form.php
+++ b/templates/widgets/store-contact-form.php
@@ -26,7 +26,6 @@
 
     <?php wp_nonce_field( 'dokan_contact_seller', 'dokan_contact_seller_nonce' ); ?>
     <input type="hidden" name="dokan_recaptcha_action" value="dokan_contact_seller_recaptcha">
-    <input type="hidden" name="dokan_recaptcha_sitekey" id="dokan_recaptcha_sitekey" value="<?php echo esc_attr( $recaptcha_sitekey ) ?>">
     <input type="hidden" name="dokan_recaptcha_token" id="dokan_recaptcha_token">
     <input type="hidden" name="seller_id" value="<?php echo esc_html( $seller_id ); ?>">
     <input type="hidden" name="action" value="dokan_contact_seller">

--- a/templates/widgets/store-contact-form.php
+++ b/templates/widgets/store-contact-form.php
@@ -26,8 +26,7 @@
 
     <?php wp_nonce_field( 'dokan_contact_seller', 'dokan_contact_seller_nonce' ); ?>
     <input type="hidden" name="recaptcha_token" id="token">
-    <input type="hidden" name="recaptcha_site_key" id="sitekey" value="<?php echo esc_attr( $recaptcha_site_key ); ?>">
-    <input type="hidden" name="recaptcha_action" id="sitekey" value="<?php echo esc_attr( 'dokan_contact_seller_recaptcha' ); ?>">
+    <input type="hidden" name="recaptcha_action" value="<?php echo esc_attr( 'dokan_contact_seller_recaptcha' ); ?>">
     <input type="hidden" name="seller_id" value="<?php echo esc_html( $seller_id ); ?>">
     <input type="hidden" name="action" value="dokan_contact_seller">
     <input type="submit" name="store_message_send" value="<?php esc_attr_e( 'Send Message', 'dokan-lite' ); ?>" class="dokan-right dokan-btn dokan-btn-theme">

--- a/templates/widgets/store-contact-form.php
+++ b/templates/widgets/store-contact-form.php
@@ -25,7 +25,8 @@
     <?php do_action( 'dokan_contact_form', $seller_id ) ?>
 
     <?php wp_nonce_field( 'dokan_contact_seller', 'dokan_contact_seller_nonce' ); ?>
-    <input type="hidden" name="dokan_recaptcha_action" value="<?php echo esc_attr( 'dokan_contact_seller_recaptcha' ); ?>">
+    <input type="hidden" name="dokan_recaptcha_action" value="dokan_contact_seller_recaptcha">
+    <input type="hidden" name="dokan_recaptcha_sitekey" value="<?php echo esc_attr( $recaptcha_sitekey ) ?>">
     <input type="hidden" name="dokan_recaptcha_token" id="dokan_recaptcha_token">
     <input type="hidden" name="seller_id" value="<?php echo esc_html( $seller_id ); ?>">
     <input type="hidden" name="action" value="dokan_contact_seller">

--- a/templates/widgets/store-contact-form.php
+++ b/templates/widgets/store-contact-form.php
@@ -25,8 +25,8 @@
     <?php do_action( 'dokan_contact_form', $seller_id ) ?>
 
     <?php wp_nonce_field( 'dokan_contact_seller', 'dokan_contact_seller_nonce' ); ?>
-    <input type="hidden" name="recaptcha_token" id="token">
     <input type="hidden" name="recaptcha_action" value="<?php echo esc_attr( 'dokan_contact_seller_recaptcha' ); ?>">
+    <input type="hidden" name="recaptcha_token" id="token">
     <input type="hidden" name="seller_id" value="<?php echo esc_html( $seller_id ); ?>">
     <input type="hidden" name="action" value="dokan_contact_seller">
     <input type="submit" name="store_message_send" value="<?php esc_attr_e( 'Send Message', 'dokan-lite' ); ?>" class="dokan-right dokan-btn dokan-btn-theme">

--- a/templates/widgets/store-contact-form.php
+++ b/templates/widgets/store-contact-form.php
@@ -25,7 +25,6 @@
     <?php do_action( 'dokan_contact_form', $seller_id ) ?>
 
     <?php wp_nonce_field( 'dokan_contact_seller', 'dokan_contact_seller_nonce' ); ?>
-    <input type="hidden" name="dokan_recaptcha_action" value="dokan_contact_seller_recaptcha">
     <input type="hidden" name="dokan_recaptcha_token" class="dokan_recaptcha_token">
     <input type="hidden" name="seller_id" value="<?php echo esc_html( $seller_id ); ?>">
     <input type="hidden" name="action" value="dokan_contact_seller">

--- a/templates/widgets/store-contact-form.php
+++ b/templates/widgets/store-contact-form.php
@@ -26,7 +26,7 @@
 
     <?php wp_nonce_field( 'dokan_contact_seller', 'dokan_contact_seller_nonce' ); ?>
     <input type="hidden" name="dokan_recaptcha_action" value="dokan_contact_seller_recaptcha">
-    <input type="hidden" name="dokan_recaptcha_token" id="dokan_recaptcha_token">
+    <input type="hidden" name="dokan_recaptcha_token" class="dokan_recaptcha_token">
     <input type="hidden" name="seller_id" value="<?php echo esc_html( $seller_id ); ?>">
     <input type="hidden" name="action" value="dokan_contact_seller">
     <input type="submit" name="store_message_send" value="<?php esc_attr_e( 'Send Message', 'dokan-lite' ); ?>" class="dokan-right dokan-btn dokan-btn-theme">

--- a/templates/widgets/store-contact-form.php
+++ b/templates/widgets/store-contact-form.php
@@ -26,7 +26,7 @@
 
     <?php wp_nonce_field( 'dokan_contact_seller', 'dokan_contact_seller_nonce' ); ?>
     <input type="hidden" name="dokan_recaptcha_action" value="dokan_contact_seller_recaptcha">
-    <input type="hidden" name="dokan_recaptcha_sitekey" value="<?php echo esc_attr( $recaptcha_sitekey ) ?>">
+    <input type="hidden" name="dokan_recaptcha_sitekey" id="dokan_recaptcha_sitekey" value="<?php echo esc_attr( $recaptcha_sitekey ) ?>">
     <input type="hidden" name="dokan_recaptcha_token" id="dokan_recaptcha_token">
     <input type="hidden" name="seller_id" value="<?php echo esc_html( $seller_id ); ?>">
     <input type="hidden" name="action" value="dokan_contact_seller">

--- a/templates/widgets/store-contact-form.php
+++ b/templates/widgets/store-contact-form.php
@@ -25,8 +25,8 @@
     <?php do_action( 'dokan_contact_form', $seller_id ) ?>
 
     <?php wp_nonce_field( 'dokan_contact_seller', 'dokan_contact_seller_nonce' ); ?>
-    <input type="hidden" name="recaptcha_action" value="<?php echo esc_attr( 'dokan_contact_seller_recaptcha' ); ?>">
-    <input type="hidden" name="recaptcha_token" id="token">
+    <input type="hidden" name="dokan_recaptcha_action" value="<?php echo esc_attr( 'dokan_contact_seller_recaptcha' ); ?>">
+    <input type="hidden" name="dokan_recaptcha_token" id="dokan_recaptcha_token">
     <input type="hidden" name="seller_id" value="<?php echo esc_html( $seller_id ); ?>">
     <input type="hidden" name="action" value="dokan_contact_seller">
     <input type="submit" name="store_message_send" value="<?php esc_attr_e( 'Send Message', 'dokan-lite' ); ?>" class="dokan-right dokan-btn dokan-btn-theme">

--- a/templates/widgets/store-contact-form.php
+++ b/templates/widgets/store-contact-form.php
@@ -24,8 +24,20 @@
 
     <?php do_action( 'dokan_contact_form', $seller_id ) ?>
 
-    <?php wp_nonce_field( 'dokan_contact_seller' ); ?>
+    <?php wp_nonce_field( 'dokan_contact_seller', 'dokan_contact_seller_nonce' ); ?>
+    <input type="hidden" name="recaptcha_token" id="token">
+    <input type="hidden" name="recaptcha_site_key" id="sitekey" value="<?php echo esc_attr( $recaptcha_site_key ); ?>">
     <input type="hidden" name="seller_id" value="<?php echo esc_html( $seller_id ); ?>">
     <input type="hidden" name="action" value="dokan_contact_seller">
     <input type="submit" name="store_message_send" value="<?php esc_attr_e( 'Send Message', 'dokan-lite' ); ?>" class="dokan-right dokan-btn dokan-btn-theme">
 </form>
+
+<script src="https://www.google.com/recaptcha/api.js?render=<?php echo esc_attr( $recaptcha_site_key ); ?>"></script>
+
+<script>
+    grecaptcha.ready( function() {
+        grecaptcha.execute( '<?php echo esc_html( $recaptcha_site_key ); ?>', { action: 'dokan_contact_seller_recaptcha' } ).then( function( token ) {
+        document.getElementById( 'token' ).value = token;
+        } );
+    } );
+</script>

--- a/templates/widgets/store-contact-form.php
+++ b/templates/widgets/store-contact-form.php
@@ -27,17 +27,8 @@
     <?php wp_nonce_field( 'dokan_contact_seller', 'dokan_contact_seller_nonce' ); ?>
     <input type="hidden" name="recaptcha_token" id="token">
     <input type="hidden" name="recaptcha_site_key" id="sitekey" value="<?php echo esc_attr( $recaptcha_site_key ); ?>">
+    <input type="hidden" name="recaptcha_action" id="sitekey" value="<?php echo esc_attr( 'dokan_contact_seller_recaptcha' ); ?>">
     <input type="hidden" name="seller_id" value="<?php echo esc_html( $seller_id ); ?>">
     <input type="hidden" name="action" value="dokan_contact_seller">
     <input type="submit" name="store_message_send" value="<?php esc_attr_e( 'Send Message', 'dokan-lite' ); ?>" class="dokan-right dokan-btn dokan-btn-theme">
 </form>
-
-<script src="https://www.google.com/recaptcha/api.js?render=<?php echo esc_attr( $recaptcha_site_key ); ?>"></script>
-
-<script>
-    grecaptcha.ready( function() {
-        grecaptcha.execute( '<?php echo esc_html( $recaptcha_site_key ); ?>', { action: 'dokan_contact_seller_recaptcha' } ).then( function( token ) {
-        document.getElementById( 'token' ).value = token;
-        } );
-    } );
-</script>


### PR DESCRIPTION
Previously, there was no captcha checking on store page contact form.

Now, Google reCaptcha checking is integrated to store contact form.

Also, added reCaptcha site key input field on the `Dokan->Settings->Appearance` admin menu. Screenshot: https://imgur.com/VNdgSCj