### PR TITLE
fix(Order): create order API with coupon lines

### DIFF
--- a/includes/Order/Hooks.php
+++ b/includes/Order/Hooks.php
@@ -293,17 +293,16 @@ class Hooks {
         $available_vendors  = [];
         $available_products = [];
 
-        if (WC()->cart) {
+        if ( WC()->cart ) {
             foreach ( WC()->cart->get_cart() as $item ) {
-                $product_id = $item['data']->get_id();
+                $product_id           = $item['data']->get_id();
                 $available_vendors[]  = (int) get_post_field( 'post_author', $product_id );
                 $available_products[] = $product_id;
             }
         } else {
-            foreach ($discount->get_items() as $item_id => $item) {
-                $product_id = $item_id;
-                $available_vendors[]  = (int) get_post_field( 'post_author', $product_id );
-                $available_products[] = $product_id;
+            foreach ( $discount->get_items() as $item_id => $item ) {
+                $available_vendors[]  = (int) get_post_field( 'post_author', $item_id );
+                $available_products[] = $item_id;
             }
         }
 

--- a/includes/Order/Hooks.php
+++ b/includes/Order/Hooks.php
@@ -37,7 +37,7 @@ class Hooks {
         add_action( 'dokan_checkout_update_order_meta', 'dokan_sync_insert_order' );
 
         // prevent non-vendor coupons from being added
-        add_filter( 'woocommerce_coupon_is_valid', [ $this, 'ensure_vendor_coupon' ], 10, 2 );
+        add_filter( 'woocommerce_coupon_is_valid', [ $this, 'ensure_vendor_coupon' ], 10, 3 );
 
         if ( is_admin() ) {
             add_action( 'woocommerce_process_shop_order_meta', 'dokan_sync_insert_order' );
@@ -284,20 +284,29 @@ class Hooks {
      *
      * @param boolean $valid
      * @param \WC_Coupon $coupon
+     * @param \WC_Discounts $discount
      *
-     * @return boolean|Execption
+     * @return boolean|Exception
      * @throws Exception
      */
-    public function ensure_vendor_coupon( $valid, $coupon ) {
+    public function ensure_vendor_coupon( $valid, $coupon, $discount ) {
         $available_vendors  = [];
         $available_products = [];
 
-        foreach ( WC()->cart->get_cart() as $item ) {
-            $product_id = $item['data']->get_id();
-
-            $available_vendors[]  = (int) get_post_field( 'post_author', $product_id );
-            $available_products[] = $product_id;
+        if (WC()->cart) {
+            foreach ( WC()->cart->get_cart() as $item ) {
+                $product_id = $item['data']->get_id();
+                $available_vendors[]  = (int) get_post_field( 'post_author', $product_id );
+                $available_products[] = $product_id;
+            }
+        } else {
+            foreach ($discount->get_items() as $item_id => $item) {
+                $product_id = $item_id;
+                $available_vendors[]  = (int) get_post_field( 'post_author', $product_id );
+                $available_products[] = $product_id;
+            }
         }
+
 
         $available_vendors = array_unique( $available_vendors );
 


### PR DESCRIPTION
# What this PR does
Fixes crash when creating an order using the woocommerce API with coupon lines.

## The stack trace
```
[03-Dec-2021 15:32:20 UTC] PHP Fatal error:  Uncaught Error: Call to a member function get_cart() on null in /Applications/MAMP/htdocs/wordpress/wp-content/plugins/dokan-lite/includes/Order/Hooks.php:284
Stack trace:
#0 /Applications/MAMP/htdocs/wordpress/wp-includes/class-wp-hook.php(303): WeDevs\Dokan\Order\Hooks->ensure_vendor_coupon(true, Object(WC_Coupon), Object(WC_Discounts))
#1 /Applications/MAMP/htdocs/wordpress/wp-includes/plugin.php(189): WP_Hook->apply_filters(true, Array)
#2 /Applications/MAMP/htdocs/wordpress/wp-content/plugins/woocommerce/includes/class-wc-discounts.php(962): apply_filters('woocommerce_cou...', true, Object(WC_Coupon), Object(WC_Discounts))
#3 /Applications/MAMP/htdocs/wordpress/wp-content/plugins/woocommerce/includes/class-wc-discounts.php(252): WC_Discounts->is_coupon_valid(Object(WC_Coupon))
#4 /Applications/MAMP/htdocs/wordpress/wp-content/plugins/woocommerce/includes/abstracts/abstract-wc-order.php(1132): WC_Discounts->apply_coupon(Object(WC_Coupon))
#5 /Applications/MAMP/htdocs/wordpress/wp-content/plugins/woocommer in /Applications/MAMP/htdocs/wordpress/wp-content/plugins/dokan-lite/includes/Order/Hooks.php on line 284
```

## The crash
![Screen Shot 2021-12-03 at 10 35 31 AM](https://user-images.githubusercontent.com/2947763/144630075-796832b8-480e-4cf5-9719-1fd002eef146.png)
 

