### PR TITLE
variation virtual product auto checked fixed

### DIFF
--- a/includes/Dashboard/Templates/Products.php
+++ b/includes/Dashboard/Templates/Products.php
@@ -96,7 +96,7 @@ class Products {
             'is_downloadable' => $is_downloadable,
             'is_virtual'      => $is_virtual,
             'digital_mode'    => $digital_mode,
-            'class'           => 'show_if_subscription show_if_variable-subscription show_if_simple',
+            'class'           => 'show_if_subscription hide_if_variable-subscription show_if_simple',
         ) );
     }
 


### PR DESCRIPTION
Issue: https://github.com/weDevsOfficial/dokan-pro/issues/1301

### This issue is created on dokan-pro. And also has PR on dokan-pro, Meke sure to test with that. [PR Link](https://github.com/weDevsOfficial/dokan-pro/pull/1625)

Before,
In the vendor dashboard single product edit page if the vendor sets the product type as a subscription product and doesn't check on the virtual checkbox it is auto check-in after saving the product and it never updates. Also, the shipping box does not show and hide properly based on the virtual checkbox.
 Now,
Virtual checkbox data is updating properly and the shipping box showing and hiding properly based on the virtual checkbox.

Fix: https://github.com/weDevsOfficial/dokan-pro/issues/1301