### PR TITLE
fix/css class added for styling order details page

### DIFF
--- a/assets/src/less/orders.less
+++ b/assets/src/less/orders.less
@@ -1,6 +1,7 @@
 .dokan-orders-content{
 
     .dokan-orders-area {
+        .dokan-order-details-wrap {}
 
         .dokan-order-left-content {
             margin-right: 3%;

--- a/templates/orders/details.php
+++ b/templates/orders/details.php
@@ -13,7 +13,7 @@ $order    = new WC_Order( $order_id );
 $hide_customer_info = dokan_get_option( 'hide_customer_info', 'dokan_selling', 'off' );
 $customer_ip        = get_post_meta( $order->get_id(), '_customer_ip_address', true );
 ?>
-<div class="dokan-clearfix">
+<div class="dokan-clearfix dokan-order-details-wrap">
     <div class="dokan-w8 dokan-order-left-content">
 
         <div class="dokan-clearfix">


### PR DESCRIPTION
On the order details page, there was no CSS class for custom styling. With this PR we added a CSS class so that users can customize the style.

fix #1460 