### PR TITLE
Added custom withdraw method option

### DIFF
--- a/includes/Withdraw/Manager.php
+++ b/includes/Withdraw/Manager.php
@@ -292,7 +292,7 @@ class Manager {
 
             return [
                 'value' => $store_settings['payment']['custom']['value'],
-                'method' => dokan_get_option( 'dokan_withdraw_method_custom', 'dokan_withdraw' ),
+                'method' => dokan_get_option( 'withdraw_method_name', 'dokan_withdraw' ),
             ];
         }
 
@@ -314,15 +314,12 @@ class Manager {
         switch ( absint( $code ) ) {
             case 0:
                 return 'pending';
-                break;
 
             case 1:
                 return 'approved';
-                break;
 
             case 2:
                 return 'cancelled';
-                break;
         }
 
         return null;

--- a/includes/Withdraw/Manager.php
+++ b/includes/Withdraw/Manager.php
@@ -263,16 +263,13 @@ class Manager {
         switch ( $status ) {
             case 'pending':
                 return 0;
-                break;
 
             case 'completed':
             case 'approved':
                 return 1;
-                break;
 
             case 'cancelled':
                 return 2;
-                break;
         }
 
         return null;

--- a/includes/Withdraw/Manager.php
+++ b/includes/Withdraw/Manager.php
@@ -284,9 +284,18 @@ class Manager {
      * @param  string $method
      * @param  int    $user_id
      *
-     * @return integer
+     * @return array
      */
     public function get_formatted_details( $method, $user_id ) {
+        if ( 'custom' === $method ) {
+            $store_settings = dokan_get_store_info( $user_id );
+
+            return [
+                'value' => $store_settings['payment']['custom']['value'],
+                'method' => dokan_get_option( 'dokan_withdraw_method_custom', 'dokan_withdraw' ),
+            ];
+        }
+
         $vendor = dokan()->vendor->get( $user_id );
 
         return isset( $vendor->get_payment_profiles()[ $method ] ) ? (array) $vendor->get_payment_profiles()[ $method ] : [];

--- a/includes/Withdraw/Manager.php
+++ b/includes/Withdraw/Manager.php
@@ -287,11 +287,11 @@ class Manager {
      * @return array
      */
     public function get_formatted_details( $method, $user_id ) {
-        if ( 'custom' === $method ) {
+        if ( 'dokan_custom' === $method ) {
             $store_settings = dokan_get_store_info( $user_id );
 
             return [
-                'value' => $store_settings['payment']['custom']['value'],
+                'value' => $store_settings['payment']['dokan_custom']['value'],
                 'method' => dokan_get_option( 'withdraw_method_name', 'dokan_withdraw' ),
             ];
         }

--- a/includes/Withdraw/functions.php
+++ b/includes/Withdraw/functions.php
@@ -126,7 +126,7 @@ function dokan_withdraw_get_method_title( $method_key ) {
 function render_withdraw_method_details( $request ) {
     $details = maybe_unserialize( $request->details );
     if ( isset( $details['value'] ) && 'custom' === $request->method ) {
-        return '- ' . $details['value'];
+        return ' - ' . $details['value'];
     }
 }
 

--- a/includes/Withdraw/functions.php
+++ b/includes/Withdraw/functions.php
@@ -107,11 +107,27 @@ function dokan_withdraw_get_method( $method_key ) {
 function dokan_withdraw_get_method_title( $method_key ) {
     $registered = dokan_withdraw_register_methods();
 
-    if ( isset( $registered[ $method_key ] ) ) {
+    if ( 'custom' === $method_key ) {
+        return dokan_get_option( 'withdraw_method_name', 'dokan_withdraw' );
+    } elseif ( isset( $registered[ $method_key ] ) ) {
         return $registered[ $method_key ]['title'];
     }
 
     return '';
+}
+
+/**
+ * Get withdraw method details (email/phone)
+ *
+ * @param object $request
+ *
+ * @return string
+ */
+function render_withdraw_method_details( $request ) {
+    $details = maybe_unserialize( $request->details );
+    if ( isset( $details['value'] ) && 'custom' === $request->method ) {
+        return '- ' . $details['value'];
+    }
 }
 
 /**

--- a/includes/Withdraw/functions.php
+++ b/includes/Withdraw/functions.php
@@ -126,7 +126,7 @@ function dokan_withdraw_get_method_title( $method_key ) {
 function render_withdraw_method_details( $request ) {
     $details = maybe_unserialize( $request->details );
     if ( isset( $details['value'] ) && 'custom' === $request->method ) {
-        return ' - ' . $details['value'];
+        return '- ' . $details['value'];
     }
 }
 

--- a/includes/Withdraw/functions.php
+++ b/includes/Withdraw/functions.php
@@ -104,29 +104,22 @@ function dokan_withdraw_get_method( $method_key ) {
  *
  * @return string
  */
-function dokan_withdraw_get_method_title( $method_key ) {
+function dokan_withdraw_get_method_title( $method_key, $request = null ) {
     $registered = dokan_withdraw_register_methods();
 
-    if ( 'custom' === $method_key ) {
-        return dokan_get_option( 'withdraw_method_name', 'dokan_withdraw' );
-    } elseif ( isset( $registered[ $method_key ] ) ) {
-        return $registered[ $method_key ]['title'];
+    if ( 'dokan_custom' === $method_key ) {
+        $title = dokan_get_option( 'withdraw_method_name', 'dokan_withdraw' );
+        if ( null !== $request ) {
+            $details = maybe_unserialize( $request->details );
+            if ( isset( $details['value'] ) ) {
+                $title .= ' - ' . $details['value'];
+            }
+        }
+        return $title;
     }
 
-    return '';
-}
-
-/**
- * Get withdraw method details (email/phone)
- *
- * @param object $request
- *
- * @return string
- */
-function render_withdraw_method_details( $request ) {
-    $details = maybe_unserialize( $request->details );
-    if ( isset( $details['value'] ) && 'custom' === $request->method ) {
-        return '- ' . $details['value'];
+    if ( isset( $registered[ $method_key ] ) ) {
+        return $registered[ $method_key ]['title'];
     }
 }
 

--- a/src/admin/components/Fields.vue
+++ b/src/admin/components/Fields.vue
@@ -1,5 +1,5 @@
 <template>
-    <tr :class="[id, `dokan-settings-field-type-${fieldData.type}`]" v-if="shoudShow">
+    <tr :class="[id, `dokan-settings-field-type-${fieldData.type}`]" v-if="shouldShow">
         <template v-if="'sub_section' === fieldData.type">
             <th colspan="2" class="dokan-settings-sub-section-title">
                 <label>{{ fieldData.label }}</label>
@@ -437,8 +437,8 @@ export default {
     },
 
     computed: {
-        shoudShow() {
-            let shoudShow = true;
+        shouldShow() {
+            let shouldShow = true;
 
             if ( this.fieldData.show_if ) {
                 const conditions = this.fieldData.show_if;
@@ -455,43 +455,49 @@ export default {
                     switch ( operator ) {
                         case 'greater_than':
                             if ( ! (dependencyValue > value ) ) {
-                                shoudShow = false;
+                                shouldShow = false;
                             }
                             break;
 
                         case 'greater_than_equal':
                             if ( ! (dependencyValue >= value ) ) {
-                                shoudShow = false;
+                                shouldShow = false;
                             }
                             break;
 
                         case 'less_than':
                             if ( ! (dependencyValue < value ) ) {
-                                shoudShow = false;
+                                shouldShow = false;
                             }
                             break;
 
                         case 'less_than':
                             if ( ! (dependencyValue <= value ) ) {
-                                shoudShow = false;
+                                shouldShow = false;
+                            }
+                            break;
+
+                        case 'contains':
+                            if ( ! Object.values(dependencyValue).includes( value ) ) {
+                                shouldShow = false;
                             }
                             break;
 
                         case 'equal':
                         default:
                             if ( dependencyValue != value ) {
-                                shoudShow = false;
+                                shouldShow = false;
                             }
                             break;
                     }
 
-                    if ( ! shoudShow ) {
+                    if ( ! shouldShow ) {
                         break;
                     }
                 }
             }
 
-            return shoudShow;
+            return shouldShow;
         },
 
         mapApiSource() {

--- a/src/admin/pages/Withdraw.vue
+++ b/src/admin/pages/Withdraw.vue
@@ -467,7 +467,7 @@ export default {
                         details += '<p>' + this.sprintf( this.__( 'Swift Code: %s', 'dokan-lite' ), data.bank.swift ) + '</p>';
                     }
                 } else if ( 'dokan_custom' === method ) {
-                    details = data[method].value || '';
+                    details = data[method].value ?? '';
                 }
             }
 

--- a/src/admin/pages/Withdraw.vue
+++ b/src/admin/pages/Withdraw.vue
@@ -66,6 +66,10 @@
                     {{ moment(data.row.created).format('MMM D, YYYY') }}
                 </template>
 
+                <template slot="method_title" slot-scope="data">
+                    <div class="method_title_inner" v-html="getPaymentTitle(data.row.method, data.row)"></div>
+                </template>
+
                 <template slot="method_details" slot-scope="data">
                     <div class="method_details_inner" v-html="getPaymentDetails(data.row.method, data.row.details)"></div>
                 </template>
@@ -421,6 +425,20 @@ export default {
             }
         },
 
+        getPaymentTitle(method, data) {
+            let title;
+
+            if ( data.details[method] !== undefined ) {
+                if ( 'custom' === method ) {
+                    title = data.details[method].method || '';
+                } else {
+                    title = data.method_title;
+                }
+            }
+
+            return dokan.hooks.applyFilters( 'dokan_get_payment_title', title, method, data );
+        },
+
         getPaymentDetails(method, data) {
             let details = '—';
 
@@ -452,6 +470,8 @@ export default {
                     if ( data.bank.hasOwnProperty('swift') ) {
                         details += '<p>' + this.sprintf( this.__( 'Swift Code: %s', 'dokan-lite' ), data.bank.swift ) + '</p>';
                     }
+                } else if ( 'custom' === method ) {
+                    details = data[method].value || '';
                 }
             }
 

--- a/src/admin/pages/Withdraw.vue
+++ b/src/admin/pages/Withdraw.vue
@@ -426,14 +426,10 @@ export default {
         },
 
         getPaymentTitle(method, data) {
-            let title;
+            let title = data.method_title;
 
-            if ( data.details[method] !== undefined ) {
-                if ( 'custom' === method ) {
-                    title = data.details[method].method || '';
-                } else {
-                    title = data.method_title;
-                }
+            if ( data.details[method] !== undefined && 'dokan_custom' === method  ) {
+                title = data.details[method].method ?? '';
             }
 
             return dokan.hooks.applyFilters( 'dokan_get_payment_title', title, method, data );
@@ -470,7 +466,7 @@ export default {
                     if ( data.bank.hasOwnProperty('swift') ) {
                         details += '<p>' + this.sprintf( this.__( 'Swift Code: %s', 'dokan-lite' ), data.bank.swift ) + '</p>';
                     }
-                } else if ( 'custom' === method ) {
+                } else if ( 'dokan_custom' === method ) {
                     details = data[method].value || '';
                 }
             }

--- a/templates/settings/payment.php
+++ b/templates/settings/payment.php
@@ -25,7 +25,7 @@ do_action( 'dokan_payment_settings_before_form', $current_user, $profile_info );
         ?>
             <fieldset class="payment-field-<?php echo esc_attr( $method_key ); ?>">
                 <div class="dokan-form-group">
-                    <label class="dokan-w3 dokan-control-label" for="dokan_setting"><?php echo esc_html( $method['title'] ) ?></label>
+                    <label class="dokan-w3 dokan-control-label" for="dokan_setting"><?php echo esc_html( apply_filters( 'dokan_payment_method_title', $method['title'] ) ); ?></label>
                     <div class="dokan-w6">
                         <?php call_user_func( $method['callback'], $profile_info ); ?>
                     </div> <!-- .dokan-w6 -->

--- a/templates/settings/payment.php
+++ b/templates/settings/payment.php
@@ -25,7 +25,7 @@ do_action( 'dokan_payment_settings_before_form', $current_user, $profile_info );
         ?>
             <fieldset class="payment-field-<?php echo esc_attr( $method_key ); ?>">
                 <div class="dokan-form-group">
-                    <label class="dokan-w3 dokan-control-label" for="dokan_setting"><?php echo esc_html( apply_filters( 'dokan_payment_method_title', $method['title'] ) ); ?></label>
+                    <label class="dokan-w3 dokan-control-label" for="dokan_setting"><?php echo esc_html( apply_filters( 'dokan_payment_method_title', $method['title'], $method ) ); ?></label>
                     <div class="dokan-w6">
                         <?php call_user_func( $method['callback'], $profile_info ); ?>
                     </div> <!-- .dokan-w6 -->

--- a/templates/withdraw/approved-request-listing.php
+++ b/templates/withdraw/approved-request-listing.php
@@ -21,7 +21,7 @@
     <?php foreach ( $requests as $row ) { ?>
         <tr>
             <td><?php echo wp_kses_post( wc_price( $row->amount ) ); ?></td>
-            <td><?php echo esc_html( dokan_withdraw_get_method_title( $row->method ) ); ?></td>
+            <td><?php echo esc_html( dokan_withdraw_get_method_title( $row->method ) ); ?> <?php echo esc_html( render_withdraw_method_details( $row ) ); ?></td>
             <td><?php echo esc_html( date_i18n( get_option( 'date_format' ), strtotime( $row->date ) ) ); ?></td>
         </tr>
     <?php } ?>

--- a/templates/withdraw/approved-request-listing.php
+++ b/templates/withdraw/approved-request-listing.php
@@ -21,7 +21,7 @@
     <?php foreach ( $requests as $row ) { ?>
         <tr>
             <td><?php echo wp_kses_post( wc_price( $row->amount ) ); ?></td>
-            <td><?php echo esc_html( dokan_withdraw_get_method_title( $row->method ) ); ?> <?php echo esc_html( render_withdraw_method_details( $row ) ); ?></td>
+            <td><?php echo esc_html( dokan_withdraw_get_method_title( $row->method, $row ) ); ?> </td>
             <td><?php echo esc_html( date_i18n( get_option( 'date_format' ), strtotime( $row->date ) ) ); ?></td>
         </tr>
     <?php } ?>

--- a/templates/withdraw/cancelled-request-listing.php
+++ b/templates/withdraw/cancelled-request-listing.php
@@ -22,7 +22,7 @@
     <?php foreach ( $requests as $row ) { ?>
         <tr>
             <td><?php echo wp_kses_post( wc_price( $row->amount ) ); ?></td>
-            <td><?php echo esc_html( dokan_withdraw_get_method_title( $row->method ) ); ?> <?php echo esc_html( render_withdraw_method_details( $row ) ); ?></td>
+            <td><?php echo esc_html( dokan_withdraw_get_method_title( $row->method, $row ) ); ?></td>
             <td><?php echo esc_html( date_i18n( get_option( 'date_format' ), strtotime( $row->date ) ) ); ?></td>
             <td><?php echo wp_kses_post( $row->note ); ?></td>
         </tr>

--- a/templates/withdraw/cancelled-request-listing.php
+++ b/templates/withdraw/cancelled-request-listing.php
@@ -22,7 +22,7 @@
     <?php foreach ( $requests as $row ) { ?>
         <tr>
             <td><?php echo wp_kses_post( wc_price( $row->amount ) ); ?></td>
-            <td><?php echo esc_html( dokan_withdraw_get_method_title( $row->method ) ); ?></td>
+            <td><?php echo esc_html( dokan_withdraw_get_method_title( $row->method ) ); ?> <?php echo esc_html( render_withdraw_method_details( $row ) ); ?></td>
             <td><?php echo esc_html( date_i18n( get_option( 'date_format' ), strtotime( $row->date ) ) ); ?></td>
             <td><?php echo wp_kses_post( $row->note ); ?></td>
         </tr>

--- a/templates/withdraw/pending-request-listing.php
+++ b/templates/withdraw/pending-request-listing.php
@@ -22,7 +22,7 @@ if ( $withdraw_requests ) {
 
             <tr>
                 <td><?php echo wp_kses_post( wc_price( $request->amount ) ); ?></td>
-                <td><?php echo esc_html( dokan_withdraw_get_method_title( $request->method ) ); ?> <?php echo esc_html( render_withdraw_method_details( $request ) ); ?></td>
+                <td><?php echo esc_html( dokan_withdraw_get_method_title( $request->method, $request ) ); ?></td>
                 <td><?php echo esc_html( dokan_format_time( $request->date ) ); ?></td>
                 <td>
                     <?php

--- a/templates/withdraw/pending-request-listing.php
+++ b/templates/withdraw/pending-request-listing.php
@@ -22,7 +22,7 @@ if ( $withdraw_requests ) {
 
             <tr>
                 <td><?php echo wp_kses_post( wc_price( $request->amount ) ); ?></td>
-                <td><?php echo esc_html( dokan_withdraw_get_method_title( $request->method ) ); ?></td>
+                <td><?php echo esc_html( dokan_withdraw_get_method_title( $request->method ) ); ?> <?php echo esc_html( render_withdraw_method_details( $request ) ); ?></td>
                 <td><?php echo esc_html( dokan_format_time( $request->date ) ); ?></td>
                 <td>
                     <?php


### PR DESCRIPTION
Now admin can add custom withdrawal methods for their vendors from the Dokan admin settings [under withdraw section](https://prnt.sc/26c4ku2). Then vendors can set their custom payment option from the vendor dashboard under [the payment menu](https://prnt.sc/26c4ljz). And then they can select withdrew method from [their withdrawal section](https://prnt.sc/26c4mfw). After sending withdrawal request check custom payment info show both [vendor](https://prnt.sc/26c4ojo) and [admin dashboard](https://prnt.sc/26c4osk). Finally, deactivate Dokan PRO and check have no issue.

PRO Pull: [#1686](https://github.com/weDevsOfficial/dokan-pro/pull/1686)