### PR TITLE
fix select2 container, select2 section single height 33 to 33px

### DIFF
--- a/assets/vendors/select2/select2.css
+++ b/assets/vendors/select2/select2.css
@@ -8,7 +8,7 @@
     box-sizing: border-box;
     cursor: pointer;
     display: block;
-    height: 33;
+    height: 33px;
     user-select: none;
     -webkit-user-select: none; }
     .select2-container .select2-selection--single .select2-selection__rendered {


### PR DESCRIPTION
Issue: #1483

Before,
There was a select mistake.   .select2-container .select2-selection--single { height: 33; }

Now,
The height unit is in px like, .select2-container .select2-selection--single { height: 33px; }

FIx: #1483