### PR TITLE
Ensure correct order status is displayed for vendors after updating

### DIFF
--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -302,6 +302,12 @@ class Ajax {
         $order = dokan()->order->get( $order_id );
         $order->update_status( $order_status );
 
+        // Get the new order status. This is needed since plugin/theme authors might
+        // change the order status behind the scenes in certain cases.
+        // For example by moving `wc-paused` to `wc-cancelled` automatically or by
+        // moving `wc-pending` to `wc-processing`.
+        $order_status = "wc-{$order->get_status()}";
+
         $statuses     = wc_get_order_statuses();
         $status_label = isset( $statuses[ $order_status ] ) ? $statuses[ $order_status ] : $order_status;
         $status_class = dokan_get_order_status_class( $order_status );


### PR DESCRIPTION
This is a very small PR to ensure that the correct order status will be visible after updating the order status.

In some cases plugin/theme authors will hook into actions like `woocommerce_order_status_x_to_x` and similar to update the order status again depending on certain store needs. In these cases Dokan would show the wrong order status.

With this PR we ensure that we return the order status assigned to the order after all hooks has run.