### PR TITLE
Added per_page and page param support on store products rest api

### DIFF
--- a/includes/REST/StoreController.php
+++ b/includes/REST/StoreController.php
@@ -519,6 +519,8 @@ class StoreController extends WP_REST_Controller {
 
         $request->set_param( 'post_status', [ 'publish' ] );
         $request->set_param( 'author', $request['id'] );
+        $request->set_param( 'per_page', $request['per_page'] );
+        $request->set_param( 'paged', $request['page'] );
 
         $response = $product_controller->get_items( $request );
 


### PR DESCRIPTION
Usage: `http://dokan.test/wp-json/dokan/v1/stores/<store_id>/products?per_page=20&page=2`