### PR TITLE
Prevent vendors buy their own product

### DIFF
--- a/includes/Order/Hooks.php
+++ b/includes/Order/Hooks.php
@@ -518,13 +518,16 @@ class Hooks {
     /**
      * Prevent vendor from buying their own product
      *
+     * @param bool $passed
+     * @param int $product_id
+     *
      * @since 3.3.7
      *
      * @return bool
      */
     public function prevent_vendor_buy_own_product( $passed, $product_id ) {
         $seller_id = get_post_field( 'post_author', $product_id );
-        $user_id = get_current_user_id();
+        $user_id   = get_current_user_id();
 
         // check if customer and seller is same
         if ( intval( $seller_id ) === $user_id ) {
@@ -534,11 +537,13 @@ class Hooks {
                     __( '<strong>Error!</strong> Could not add product %1$s to cart, Vendor can\'t buy their own product.', 'dokan-lite' ),
                     get_the_title( $product_id )
                 ),
+
                 [
                     'strong' => [],
                 ]
             );
             wc_add_notice( $message, 'error' );
+
             return false;
         }
 

--- a/includes/Order/Hooks.php
+++ b/includes/Order/Hooks.php
@@ -537,7 +537,6 @@ class Hooks {
                     __( '<strong>Error!</strong> Could not add product %1$s to cart, Vendor can\'t buy their own product.', 'dokan-lite' ),
                     get_the_title( $product_id )
                 ),
-
                 [
                     'strong' => [],
                 ]

--- a/includes/Order/Hooks.php
+++ b/includes/Order/Hooks.php
@@ -59,6 +59,9 @@ class Hooks {
         add_filter( 'woocommerce_order_item_display_meta_key', [ $this, 'change_order_item_display_meta_key' ] );
         add_filter( 'woocommerce_order_item_display_meta_value', [ $this, 'change_order_item_display_meta_value' ], 10, 2 );
 
+        // Prevent vendor from buying their own product
+        add_filter( 'woocommerce_add_to_cart_validation', [ $this, 'prevent_vendor_buy_own_product' ], 10, 2 );
+
         // Init Order Cache Class
         new OrderCache();
     }
@@ -510,5 +513,35 @@ class Hooks {
                 $order->add_order_note( __( 'Stock levels reduced:', 'woocommerce' ) . ' ' . $notes_content ); //phpcs:ignore WordPress.WP.I18n.TextDomainMismatch
             }
         }
+    }
+
+    /**
+     * Prevent vendor from buying their own product
+     *
+     * @since 3.3.7
+     *
+     * @return bool
+     */
+    public function prevent_vendor_buy_own_product( $passed, $product_id ) {
+        $seller_id = get_post_field( 'post_author', $product_id );
+        $user_id = get_current_user_id();
+
+        // check if customer and seller is same
+        if ( intval( $seller_id ) === $user_id ) {
+            $message = wp_kses(
+                sprintf(
+                // translators: 1) Product title
+                    __( '<strong>Error!</strong> Could not add product %1$s to cart, Vendor can\'t buy their own product.', 'dokan-lite' ),
+                    get_the_title( $product_id )
+                ),
+                [
+                    'strong' => [],
+                ]
+            );
+            wc_add_notice( $message, 'error' );
+            return false;
+        }
+
+        return $passed;
     }
 }


### PR DESCRIPTION
Vendors are prevented from buying their own products. Now vendors can't add their products to the cart. When vendors try to add their product to the cart [showing an alert](https://prnt.sc/26d2nod). Make sure customers/ can purchase that vendor's products.

Suggestion for QA:

Log in as a vendor then add a product from the vendor dashboard. And then try to add to cart own product that recently added. Show error Error! Could not add product Shirt to cart, Vendor can't buy their own product.?

