### PR TITLE
Per Product Shipping Integration for Dokan

### DIFF
--- a/assets/src/less/products.less
+++ b/assets/src/less/products.less
@@ -255,8 +255,58 @@
     }
   }
 
-  .dokan-product-edit-form .dokan-new-product-featured-img {
-    height: auto !important;
+  .dokan-product-edit-form {
+    .dokan-new-product-featured-img {
+      height: auto !important;
+    }
+
+    .per-order-shipping {
+      display: flex;
+      align-items: center;
+    }
+
+    .per_product_shipping_rules {
+      .sort {
+        position: relative;
+        i {
+          position: absolute;
+          top: 50%;
+          left: 50%;
+          transform: translate(0%, -50%);
+        }
+      }
+
+      td {
+        input[type='text'] {
+          width: 118px;
+        }
+      }
+
+      tfoot {
+        .button {
+          position: relative;
+
+          input[type="file"] {
+            z-index: 1;
+            position: absolute;
+            width: 100%;
+            height: 100%;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            opacity: 0;
+            cursor: pointer;
+          }
+        }
+
+        .import,
+        .export,
+        .import-override {
+          float: right;
+          margin-left: 3px;
+        }
+      }
+    }
   }
 
   label {

--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -805,6 +805,7 @@ class Assets {
                 'csv_imported_msg'                    => __( 'Please upload a file with .csv extension.', 'dokan-lite' ),
                 'import_limitation_msg'               => __( 'You can import 200 data at a time.', 'dokan-lite' ),
                 'csv_not_valid_msg'                   => __( 'Please import your valid csv data with matching ruled headers.', 'dokan-lite' ),
+                'empty_product_shipping_rules'        => __( 'Can\'t export empty shipping rules.', 'dokan-lite' ),
             ];
 
             $default_args = array_merge( $default_args, $custom_args );

--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -795,6 +795,16 @@ class Assets {
                 'i18n_attribute_label'                => __( 'Attribute Name', 'dokan-lite' ),
                 'i18n_date_format'                    => get_option( 'date_format' ),
                 'dokan_banner_added_alert_msg'        => __( 'Are you sure? You have uploaded banner but didn\'t click the Update Settings button!', 'dokan-lite' ),
+                'i18n_no_row_selected'                => __( 'No row selected', 'dokan-lite' ),
+                'i18n_product_id'                     => __( 'Product ID', 'dokan-lite' ),
+                'i18n_country_code'                   => __( 'Country Code', 'dokan-lite' ),
+                'i18n_state'                          => __( 'State/County Code', 'dokan-lite' ),
+                'i18n_postcode'                       => __( 'Zip/Postal Code', 'dokan-lite' ),
+                'i18n_cost'                           => __( 'Cost', 'dokan-lite' ),
+                'i18n_item_cost'                      => __( 'Item Cost', 'dokan-lite' ),
+                'csv_imported_msg'                    => __( 'Please upload a file with .csv extension.', 'dokan-lite' ),
+                'import_limitation_msg'               => __( 'You can import 200 data at a time.', 'dokan-lite' ),
+                'csv_not_valid_msg'                   => __( 'Please import your valid csv data with matching ruled headers.', 'dokan-lite' ),
             ];
 
             $default_args = array_merge( $default_args, $custom_args );


### PR DESCRIPTION
### Define shipping costs per-product and per-variation

Per product shipping allows you to define different shipping costs for products, based on customer location.
Costs can be added to other shipping methods, or used as a standalone shipping method.

**Video:**
https://share.vidyard.com/watch/WmGgk2fUiJbYB2RrYSquWj?

**Features:**

- Define line and per-item costs per product.
- Define line and per-item costs per variation.
- Costs can vary depending on the destination.
- Import and export rates via the built-in simple CSV handler.
- 200 CSV data can import at a time.
- Use as a standalone shipping method, where the final cost is the sum of all product costs.
- or add per-product costs to other shipping methods.

**Dependency With:**

- woocommerce
- woocommerce-shipping-per-product
- dokan-pro ( https://github.com/weDevsOfficial/dokan-pro/pull/1703 )