### PR TITLE
Fix: handle store not found exception

### DIFF
--- a/includes/Rewrites.php
+++ b/includes/Rewrites.php
@@ -37,7 +37,7 @@ class Rewrites {
      *
      * @since 2.4.7
      *
-     * @return array $crumbs
+     * @return void | array $crumbs
      */
     public function store_page_breadcrumb( $crumbs ) {
         if ( ! dokan_is_store_page() ) {
@@ -52,6 +52,11 @@ class Rewrites {
 
         $author      = get_query_var( $this->custom_store_url );
         $seller_info = get_user_by( 'slug', $author );
+
+        if ( ! $seller_info ) {
+            return;
+        }
+
         $crumbs[1]   = [ ucwords( $this->custom_store_url ), site_url() . '/' . $this->custom_store_url ];
         $crumbs[2]   = [ $author, dokan_get_store_url( $seller_info->data->ID ) ];
 


### PR DESCRIPTION
If users enter [wrong store name on search bar](https://prnt.sc/26ezyt0) getting the error Trying to get property 'data' of non-object and Trying to get property 'ID' of non-object.