### PR TITLE
Make Hello text translatable.

### DIFF
--- a/templates/emails/product-published.php
+++ b/templates/emails/product-published.php
@@ -15,8 +15,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 <p>
-    <?php esc_html_e( 'Hello '.$data['seller-name'], 'dokan-lite' ); ?>
-<p/>
+    <?php echo sprintf( __( 'Hello %s', 'dokan-lite' ), $data['seller-name'] ); ?>
+</p>
 <p>
     <?php echo wp_kses_post( sprintf( __( 'Your product : <a href="%s">%s</a> is approved by the admin, congrats!', 'dokan-lite' ), $data['product_url'], $data['product-title'] ) ); ?>
 </p>


### PR DESCRIPTION
Vendor product published mail greeting "Hello" made translatable.

Suggestion for QA: 
1. Make string translatable by WPML or other translatable string plugins to your local language.
2. Configure your mail settings by the WP Mail SMTP plugin or using your preferred plugin.
3. Add a new product from the vendor dashboard.
4. Publish that product from the admin dashbaord.
5. See your mail greeting "Hello" is translated to your local?

Fixes: #1513 