### PR TITLE
fix/used-for-variation-is-shown-for-new-attribute-even-if-product-type-is-not-variable

### DIFF
--- a/assets/src/js/product-editor.js
+++ b/assets/src/js/product-editor.js
@@ -517,7 +517,9 @@
                             let labels = $( 'div.dokan-product-attribute-wrapper label.show_if_variable' );
 
                             for( let label of labels ) {
-                                if ( label.textContent.includes( "Used for variations" ) ) {
+                                let checkBox = $( label ).find('input[type="checkbox"]');
+
+                                if ( checkBox.length > 0 && checkBox[0].getAttribute('name')?.startsWith('attribute_variation[') ) {
                                     $( label ).hide();
                                 }
                             }

--- a/assets/src/js/product-editor.js
+++ b/assets/src/js/product-editor.js
@@ -450,8 +450,8 @@
 
                 var $wrapper           = $(this).closest( 'li.product-attribute-list' );
                 var attribute          = $wrapper.data( 'taxonomy' );
-                let result             = await dokan_sweetalert( dokan.new_attribute_prompt, {  
-                    action : 'prompt', 
+                let result             = await dokan_sweetalert( dokan.new_attribute_prompt, {
+                    action : 'prompt',
                     input  :'text'
                 } );
                 var new_attribute_name = result.value;
@@ -467,7 +467,7 @@
 
                     $.post( dokan.ajaxurl, data, function( response ) {
                         if ( response.error ) {
-                            dokan_sweetalert( response.error, { 
+                            dokan_sweetalert( response.error, {
                                 action : 'alert',
                                 icon   : 'warning'
                             } );
@@ -512,6 +512,16 @@
                         Dokan_Editor.loadSelect2();
                         Dokan_Editor.bindProductTagDropdown();
                         Dokan_Editor.attribute.reArrangeAttribute();
+
+                        if ( "variable" !== $( 'select#product_type' ).val() ) {
+                            let labels = $( 'div.dokan-product-attribute-wrapper label.show_if_variable' );
+
+                            for( let label of labels ) {
+                                if ( label.textContent.includes( "Used for variations" ) ) {
+                                    $( label ).hide();
+                                }
+                            }
+                        }
                     }
 
                     self.closest('.dokan-attribute-type').find('span.dokan-attribute-spinner').addClass('dokan-hide');
@@ -527,9 +537,9 @@
                 evt.stopPropagation();
                 evt.preventDefault();
 
-                const isRemoved = await dokan_sweetalert( dokan.remove_attribute, { 
+                const isRemoved = await dokan_sweetalert( dokan.remove_attribute, {
                     action :'confirm',
-                    icon   :'warning' 
+                    icon   :'warning'
                 } );
 
                 if ( 'undefined' !== isRemoved && isRemoved.isConfirmed ) {


### PR DESCRIPTION
'User for Variation' checkbox is hidden when new attribute is loaded and product type is not variable type

we can't use the change trigger defined on line 511 because when there is only one product type then this trigger has no effect.

Fixes [this dokan pro issue](https://github.com/weDevsOfficial/dokan-pro/issues/1755)