### PR TITLE
fix/store-times-hover-feature-not-working-for-specific-templates

### DIFF
--- a/assets/src/less/store.less
+++ b/assets/src/less/store.less
@@ -519,19 +519,17 @@
 
                 .profile-info-summery-wrapper {
                     position: relative;
-                    height: 135px;
                     background-color: #fff;
                     color: inherit;
                     border: 1px solid @borderColor;
                     padding: 0 15px;
 
                     .profile-info-summery {
+                        top: -55px;
+                        color: #444;
                         width: 100%;
                         padding: 0;
-                        position: absolute;
-                        top: -55px;
-                        height: 140px;
-                        color: #444;
+                        position: relative;
                         background: none;
 
                         .profile-info-head {

--- a/assets/src/less/store.less
+++ b/assets/src/less/store.less
@@ -580,14 +580,13 @@
                 }
 
                 .profile-info-summery-wrapper {
+                    border: 1px solid @borderColor;
                     position: relative;
 
                     .profile-info-summery {
                         background-color: #fff;
                         width: 100%;
                         padding: 10px;
-                        border: 1px solid @borderColor;
-
 
                         .profile-info-head {
                             width: 150px;
@@ -618,7 +617,9 @@
                             }
 
                             .dokan-store-info {
+                                margin: 0;
                                 padding-left: 25px;
+                                overflow: hidden;
 
                                 .store-open-close-notice {
                                     #vendor-store-times {

--- a/assets/src/less/store.less
+++ b/assets/src/less/store.less
@@ -312,6 +312,7 @@
                                     display: flex;
                                     align-items: center;
                                     position: relative;
+                                    z-index: 1;
 
                                     .store-notice {
                                         min-width: 96px;
@@ -367,7 +368,7 @@
                                             margin-bottom: 12px;
 
                                             .store-days {
-                                                flex: 2.4;
+                                                flex: 2.3;
                                             }
 
                                             .current_day,
@@ -587,7 +588,6 @@
                         background-color: #fff;
                         width: 100%;
                         padding: 10px;
-                        overflow: hidden;
                         border: 1px solid @borderColor;
 
 
@@ -621,6 +621,20 @@
 
                             .dokan-store-info {
                                 padding-left: 25px;
+
+                                .store-open-close-notice {
+                                    #vendor-store-times {
+                                        left: -30%;
+                                    }
+
+                                    &:hover {
+                                        span.fa-angle-down {
+                                            &:after {
+                                                right: -2.5px;
+                                            }
+                                        }
+                                    }
+                                }
 
                                 li {
                                     float: left;
@@ -662,6 +676,7 @@
                                 position: relative;
 
                                 .store-social {
+                                    display: flex;
                                     padding-left: 0;
 
                                     li {
@@ -1081,8 +1096,8 @@
                             }
 
                             .profile-info {
-                                position: relative;
-                                top: -75px;
+                                position: absolute;
+                                top: 15%;
 
                                 .store-name {
                                     color: inherit;
@@ -1096,8 +1111,19 @@
                                     width: 100%;
                                     margin: 0;
                                     display: block;
-                                    overflow: hidden;
                                     text-align: center;
+
+                                    .store-open-close-notice {
+                                        display: inline-block;
+
+                                        &:hover {
+                                            span.fa-angle-down {
+                                                &:after {
+                                                    right: -2.5px;
+                                                }
+                                            }
+                                        }
+                                    }
 
                                     li {
                                         text-align: left;

--- a/assets/src/less/store.less
+++ b/assets/src/less/store.less
@@ -312,7 +312,6 @@
                                     display: flex;
                                     align-items: center;
                                     position: relative;
-                                    z-index: 1;
 
                                     .store-notice {
                                         min-width: 96px;
@@ -368,7 +367,7 @@
                                             margin-bottom: 12px;
 
                                             .store-days {
-                                                flex: 2.3;
+                                                flex: 2.4;
                                             }
 
                                             .current_day,
@@ -485,7 +484,11 @@
                                     color: #55acee;
                                 }
 
-                                &.fa-linkedin-square {
+                                &.fa-pinterest-square {
+                                    color: #bd081c;
+                                }
+
+                                &.fa-linkedin {
                                     color: #007bb5;
                                 }
 
@@ -584,7 +587,9 @@
                         background-color: #fff;
                         width: 100%;
                         padding: 10px;
+                        overflow: hidden;
                         border: 1px solid @borderColor;
+
 
                         .profile-info-head {
                             width: 150px;
@@ -616,20 +621,6 @@
 
                             .dokan-store-info {
                                 padding-left: 25px;
-
-                                .store-open-close-notice {
-                                    #vendor-store-times {
-                                        left: -30%;
-                                    }
-
-                                    &:hover {
-                                        span.fa-angle-down {
-                                            &:after {
-                                                right: -2.5px;
-                                            }
-                                        }
-                                    }
-                                }
 
                                 li {
                                     float: left;
@@ -671,7 +662,6 @@
                                 position: relative;
 
                                 .store-social {
-                                    display: flex;
                                     padding-left: 0;
 
                                     li {
@@ -1091,8 +1081,8 @@
                             }
 
                             .profile-info {
-                                position: absolute;
-                                top: 15%;
+                                position: relative;
+                                top: -75px;
 
                                 .store-name {
                                     color: inherit;
@@ -1106,19 +1096,8 @@
                                     width: 100%;
                                     margin: 0;
                                     display: block;
+                                    overflow: hidden;
                                     text-align: center;
-
-                                    .store-open-close-notice {
-                                        display: inline-block;
-
-                                        &:hover {
-                                            span.fa-angle-down {
-                                                &:after {
-                                                    right: -2.5px;
-                                                }
-                                            }
-                                        }
-                                    }
 
                                     li {
                                         text-align: left;

--- a/assets/src/less/store.less
+++ b/assets/src/less/store.less
@@ -312,6 +312,7 @@
                                     display: flex;
                                     align-items: center;
                                     position: relative;
+                                    z-index: 1;
 
                                     .store-notice {
                                         min-width: 96px;
@@ -367,7 +368,7 @@
                                             margin-bottom: 12px;
 
                                             .store-days {
-                                                flex: 2.4;
+                                                flex: 2.3;
                                             }
 
                                             .current_day,
@@ -583,9 +584,7 @@
                         background-color: #fff;
                         width: 100%;
                         padding: 10px;
-                        overflow: hidden;
                         border: 1px solid @borderColor;
-
 
                         .profile-info-head {
                             width: 150px;
@@ -617,6 +616,20 @@
 
                             .dokan-store-info {
                                 padding-left: 25px;
+
+                                .store-open-close-notice {
+                                    #vendor-store-times {
+                                        left: -30%;
+                                    }
+
+                                    &:hover {
+                                        span.fa-angle-down {
+                                            &:after {
+                                                right: -2.5px;
+                                            }
+                                        }
+                                    }
+                                }
 
                                 li {
                                     float: left;
@@ -658,6 +671,7 @@
                                 position: relative;
 
                                 .store-social {
+                                    display: flex;
                                     padding-left: 0;
 
                                     li {
@@ -1077,8 +1091,8 @@
                             }
 
                             .profile-info {
-                                position: relative;
-                                top: -75px;
+                                position: absolute;
+                                top: 15%;
 
                                 .store-name {
                                     color: inherit;
@@ -1092,8 +1106,19 @@
                                     width: 100%;
                                     margin: 0;
                                     display: block;
-                                    overflow: hidden;
                                     text-align: center;
+
+                                    .store-open-close-notice {
+                                        display: inline-block;
+
+                                        &:hover {
+                                            span.fa-angle-down {
+                                                &:after {
+                                                    right: -2.5px;
+                                                }
+                                            }
+                                        }
+                                    }
 
                                     li {
                                         text-align: left;

--- a/assets/src/less/store.less
+++ b/assets/src/less/store.less
@@ -619,7 +619,7 @@
                             .dokan-store-info {
                                 margin: 0;
                                 padding-left: 25px;
-                                overflow: hidden;
+                                clear: both;
 
                                 .store-open-close-notice {
                                     #vendor-store-times {
@@ -672,6 +672,7 @@
                             }
 
                             .store-social-wrapper {
+                                clear:  both;
                                 position: relative;
 
                                 .store-social {


### PR DESCRIPTION
### Hover feature is available for 3rd & 4th store headers

When we select the 3rd or 4th store header then the store open/close hover doesn't work.
Now, this feature is absolutely fine.

Also, fix social widget icons design related issue with dokan-lite.

Related with dokan-pro: https://github.com/weDevsOfficial/dokan-pro/pull/1785

fix: https://github.com/weDevsOfficial/dokan-pro/issues/1778