### PR TITLE
enhance/delivery-time-week-starts-day-settings

### DIFF
--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -580,6 +580,7 @@ class Assets {
         $localize_data = [
             'i18n_date_format' => wc_date_format(),
             'i18n_time_format' => wc_time_format(),
+            'week_starts_day'  => intval( get_option( 'start_of_week', 0 ) ),
         ];
 
         wp_localize_script( 'dokan-util-helper', 'dokan_helper', $localize_data );


### PR DESCRIPTION
### Update delivery time calendars week starts day settings.

Previous this enhance the calendar of delivery time does not start respecting the site settings week starting day.
Now, It's fine.

Related with dokan-pro: https://github.com/weDevsOfficial/dokan-pro/pull/1805

fix: https://github.com/weDevsOfficial/dokan-pro/issues/1803