### PR TITLE
CRITICAL Uncaught Error store-open-close.php

### DIFF
--- a/templates/widgets/store-open-close.php
+++ b/templates/widgets/store-open-close.php
@@ -43,16 +43,18 @@
                 <?php
                 // Get formatted store times.
                 for ( $index = 0; $index < $times_length; $index++ ) :
-                    $opening_timestamps     = dokan_current_datetime()->modify( $dokan_store_time[ $day ]['opening_time'][ $index ] )->getTimestamp();
-                    $closing_timestamps     = dokan_current_datetime()->modify( $dokan_store_time[ $day ]['closing_time'][ $index ] )->getTimestamp();
-                    $formatted_opening_time = dokan_format_date( $opening_timestamps, wc_time_format() );
-                    $formatted_closing_time = dokan_format_date( $closing_timestamps, wc_time_format() );
+                    if(!empty($dokan_store_time[ $day ]['opening_time'][ $index ])){
+                        $opening_timestamps     = dokan_current_datetime()->modify( $dokan_store_time[ $day ]['opening_time'][ $index ] )->getTimestamp();
+                        $closing_timestamps     = dokan_current_datetime()->modify( $dokan_store_time[ $day ]['closing_time'][ $index ] )->getTimestamp();
+                        $formatted_opening_time = dokan_format_date( $opening_timestamps, wc_time_format() );
+                        $formatted_closing_time = dokan_format_date( $closing_timestamps, wc_time_format() );
 
-                    echo sprintf(
-                        '<div class="store-time">%1$s <span class="separator">-</span> %2$s</div>',
-                        esc_html( $formatted_opening_time ),
-                        esc_html( $formatted_closing_time )
-                    );
+                        echo sprintf(
+                            '<div class="store-time">%1$s <span class="separator">-</span> %2$s</div>',
+                            esc_html( $formatted_opening_time ),
+                            esc_html( $formatted_closing_time )
+                        );
+                    }
                 endfor;
                 ?>
             </div>


### PR DESCRIPTION
CRITICAL Uncaught Error: Call to a member function getTimestamp() on bool in wp-content/plugins/dokan-lite/templates/widgets/store-open-close.php:47

above error fix when there is an empty string