### PR TITLE
fix New Order email send to admin even if this email is not enabled in WC settings

### DIFF
--- a/includes/Emails/VendorCompletedOrder.php
+++ b/includes/Emails/VendorCompletedOrder.php
@@ -203,6 +203,6 @@ class VendorCompletedOrder extends WC_Email {
             return false;
         }
 
-        return true;
+        return $bool;
     }
 }

--- a/includes/Emails/VendorNewOrder.php
+++ b/includes/Emails/VendorNewOrder.php
@@ -211,6 +211,6 @@ class VendorNewOrder extends WC_Email {
             return false;
         }
 
-        return true;
+        return $bool;
     }
 }


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [ ] I've included developer documentation (optional)
* [x] I've added proper labels to this pull request

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Changed the callback function return value of `woocommerce_email_enabled_new_order` filter 
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #1597 

### How to test the changes in this Pull Request:

1.Woocommerce > Settings > Email Tab > Disable New order email
2. Create an Order
3. Check if the email is sent to the admin



### Changelog entry

> **fix:** Stop sending new order emails to selected recipients (including admin) when the New Order email is disabled in Woocommerce Settings


### PR Self Review Checklist:

* Code is not following code style guidelines
* Bad naming: make sure you would understand your code if you read it a few months from now.
* KISS: Keep it simple, Sweetie (not stupid!).
* DRY: Don't Repeat Yourself.
* Code that is not readable: too many nested 'if's are a bad sign.
* Performance issues
* Complicated constructions that need refactoring or comments: code should almost always be self-explanatory.
* Grammar errors.
