### PR TITLE
Fix/contact form widget ajax problem

### DIFF
--- a/assets/src/js/script.js
+++ b/assets/src/js/script.js
@@ -578,6 +578,7 @@ jQuery(function($) {
         },
         submitHandler: async function(form, event) {
           event.preventDefault();
+
           $(form).block({
             message: null,
             overlayCSS: {

--- a/assets/src/js/script.js
+++ b/assets/src/js/script.js
@@ -576,7 +576,8 @@ jQuery(function($) {
           label.removeClass('error');
           label.remove();
         },
-        submitHandler: async function(form) {
+        submitHandler: async function(form, event) {
+          event.preventDefault();
           $(form).block({
             message: null,
             overlayCSS: {


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [ ] My code has proper inline documentation
* [ ] I've included developer documentation (optional)
* [x] I've added proper labels to this pull request

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Stopped default submission of contact form.
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #1591 

### How to test the changes in this Pull Request:

1. add the Dokan: Store Contact Form widget to a proper place
2. visit a store page or a product page
3. a form will appear
4. fillup the form and submit



### Changelog entry

> **fix:** Dokan: Store Contact Form widget submits the contact form directly instead of ajax submission


### PR Self Review Checklist:

* Code is not following code style guidelines
* Bad naming: make sure you would understand your code if you read it a few months from now.
* KISS: Keep it simple, Sweetie (not stupid!).
* DRY: Don't Repeat Yourself.
* Code that is not readable: too many nested 'if's are a bad sign.
* Performance issues
* Complicated constructions that need refactoring or comments: code should almost always be self-explanatory.
* Grammar errors.

