### PR TITLE
fix payment settings page 404

### DIFF
--- a/templates/settings/payment.php
+++ b/templates/settings/payment.php
@@ -22,7 +22,7 @@ do_action( 'dokan_payment_settings_before_form', $current_user, $profile_info );
                         <ul>
                         <?php foreach ( $unused_methods as $method_key => $method ) :?>
                             <li>
-                                <a href="<?php echo esc_url( home_url( "dashboard/settings/payment/manage-" . $method_key ) ); ?>">
+                                <a href="<?php echo esc_url( dokan_get_page_url( 'dashboard', 'dokan', 'settings/payment/manage-' . $method_key ) ); ?>">
                                     <div>
                                         <img src="<?php echo esc_url( dokan_withdraw_get_method_icon(  $method_key ) ); ?>" alt="<?php echo esc_attr( $method_key ); ?>" />
                                         <span>
@@ -65,7 +65,7 @@ do_action( 'dokan_payment_settings_before_form', $current_user, $profile_info );
                         </span>
                     </div>
                     <div>
-                        <a href="<?php echo esc_url(  home_url( "dashboard/settings/payment/manage-" . $method_key . "/edit" ) ); ?>">
+                        <a href="<?php echo esc_url(  dokan_get_page_url( 'dashboard', 'dokan', 'settings/payment/manage-' . $method_key . '/edit' ) ); ?>">
                             <button class="dokan-btn-theme dokan-btn-sm"><?php esc_html_e( 'Manage', 'dokan-lite' ); ?></button>
                         </a>
                     </div>


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [ ] I've included developer documentation (optional)
* [x] I've added proper labels to this pull request

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
make static payment settings urls to dynamic urls
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #1609

### How to test the changes in this Pull Request:

1. please consult the related issue
2.
3.



### Changelog entry

> **fix:** payment settings page 404 if dashboard url slug is changed


### PR Self Review Checklist:

* Code is not following code style guidelines
* Bad naming: make sure you would understand your code if you read it a few months from now.
* KISS: Keep it simple, Sweetie (not stupid!).
* DRY: Don't Repeat Yourself.
* Code that is not readable: too many nested 'if's are a bad sign.
* Performance issues
* Complicated constructions that need refactoring or comments: code should almost always be self-explanatory.
* Grammar errors.

