### PR TITLE
fix dokan payment settings doesn't support wpml translated links

### DIFF
--- a/includes/Dashboard/Templates/Settings.php
+++ b/includes/Dashboard/Templates/Settings.php
@@ -231,16 +231,16 @@ class Settings {
          * If we are requesting a single payment method page (to edit or for first time setup)
          * then we have the corresponding payment method key in the url.
          */
-        $method_key   = str_replace( '/manage-', '', $slug_suffix );
+        $method_key   = str_replace( '-manage-', '', $slug_suffix );
         $is_edit_mode = false;
 
         /*
          * If payment method key has /edit suffix then we are trying to edit the method,
          * otherwise we are doing a initial setup for that payment method.
          */
-        if ( false !== stripos( $method_key, '/edit' ) ) {
+        if ( false !== stripos( $method_key, '-edit' ) ) {
             $is_edit_mode = true;
-            $method_key   = str_replace( '/edit', '', $method_key ); // removing '/edit' suffix to get payment method key
+            $method_key   = str_replace( '-edit', '', $method_key ); // removing '/edit' suffix to get payment method key
         }
 
         $profile_info = get_user_meta( $seller_id, 'dokan_profile_settings', true );

--- a/templates/settings/bank-payment-method-settings.php
+++ b/templates/settings/bank-payment-method-settings.php
@@ -122,7 +122,7 @@
         <button class="ajax_prev dokan-btn dokan-btn-theme" type="submit" name="dokan_update_payment_settings">
             <?php echo esc_html( $save_or_add_btn_text ); ?>
         </button>
-        <a href="<?php echo esc_url( dokan_get_page_url( 'dashboard', 'dokan', 'settings/payment' ) ); ?>">
+        <a href="<?php echo esc_url( dokan_get_navigation_url( 'settings' ) . 'payment' ); ?>">
             <?php esc_html_e( 'Cancel', 'dokan-lite' ); ?>
         </a>
     </div>

--- a/templates/settings/bank-payment-method-settings.php
+++ b/templates/settings/bank-payment-method-settings.php
@@ -122,7 +122,7 @@
         <button class="ajax_prev dokan-btn dokan-btn-theme" type="submit" name="dokan_update_payment_settings">
             <?php echo esc_html( $save_or_add_btn_text ); ?>
         </button>
-        <a href="<?php echo esc_url( dokan_get_navigation_url( 'settings' ) . 'payment' ); ?>">
+        <a href="<?php echo esc_url( dokan_get_navigation_url( 'settings/payment' ) ); ?>">
             <?php esc_html_e( 'Cancel', 'dokan-lite' ); ?>
         </a>
     </div>

--- a/templates/settings/payment-manage.php
+++ b/templates/settings/payment-manage.php
@@ -6,7 +6,7 @@
  */
 ?>
 
-<a href="<?php echo esc_url_raw( dokan_get_page_url( 'dashboard' ) . 'settings/payment' ); ?>">
+<a href="<?php echo esc_url_raw( dokan_get_navigation_url( 'settings' ) . 'payment' ); ?>">
     &larr; <?php esc_html_e( 'Back', 'dokan-lite' ); ?>
 </a>
 

--- a/templates/settings/payment-manage.php
+++ b/templates/settings/payment-manage.php
@@ -6,7 +6,7 @@
  */
 ?>
 
-<a href="<?php echo esc_url_raw( dokan_get_navigation_url( 'settings' ) . 'payment' ); ?>">
+<a href="<?php echo esc_url_raw( dokan_get_navigation_url( 'settings/payment' ) ); ?>">
     &larr; <?php esc_html_e( 'Back', 'dokan-lite' ); ?>
 </a>
 

--- a/templates/settings/payment.php
+++ b/templates/settings/payment.php
@@ -23,9 +23,9 @@ do_action( 'dokan_payment_settings_before_form', $current_user, $profile_info );
                             <ul>
                             <?php foreach ( $unused_methods as $method_key => $method ) :?>
                                 <li>
-                                    <a href="<?php echo esc_url( dokan_get_page_url( 'dashboard', 'dokan', 'settings/payment/manage-' . $method_key ) ); ?>">
+                                    <a href="<?php echo esc_url( dokan_get_navigation_url( 'settings' ) . 'payment/manage-' . $method_key ); ?>">
                                         <div>
-                                            <img src="<?php echo esc_url( dokan_withdraw_get_method_icon(  $method_key ) ); ?>" alt="<?php echo esc_attr( $method_key ); ?>" />
+                                            <img src="<?php echo esc_url( dokan_withdraw_get_method_icon( $method_key ) ); ?>" alt="<?php echo esc_attr( $method_key ); ?>" />
                                             <span>
                                                 <?php
                                                 //translators: %s: payment method title
@@ -67,7 +67,7 @@ do_action( 'dokan_payment_settings_before_form', $current_user, $profile_info );
                         </span>
                     </div>
                     <div>
-                        <a href="<?php echo esc_url(  dokan_get_page_url( 'dashboard', 'dokan', 'settings/payment/manage-' . $method_key . '/edit' ) ); ?>">
+                        <a href="<?php echo esc_url(  dokan_get_navigation_url( 'settings' ) . 'payment/manage-' . $method_key . '/edit' ); ?>">
                             <button class="dokan-btn-theme dokan-btn-sm"><?php esc_html_e( 'Manage', 'dokan-lite' ); ?></button>
                         </a>
                     </div>

--- a/templates/settings/payment.php
+++ b/templates/settings/payment.php
@@ -23,7 +23,7 @@ do_action( 'dokan_payment_settings_before_form', $current_user, $profile_info );
                             <ul>
                             <?php foreach ( $unused_methods as $method_key => $method ) :?>
                                 <li>
-                                    <a href="<?php echo esc_url( dokan_get_navigation_url( 'settings' ) . 'payment/manage-' . $method_key ); ?>">
+                                    <a href="<?php echo esc_url( dokan_get_navigation_url( 'settings/payment-manage-' . $method_key ) ); ?>">
                                         <div>
                                             <img src="<?php echo esc_url( dokan_withdraw_get_method_icon( $method_key ) ); ?>" alt="<?php echo esc_attr( $method_key ); ?>" />
                                             <span>
@@ -67,7 +67,7 @@ do_action( 'dokan_payment_settings_before_form', $current_user, $profile_info );
                         </span>
                     </div>
                     <div>
-                        <a href="<?php echo esc_url(  dokan_get_navigation_url( 'settings' ) . 'payment/manage-' . $method_key . '/edit' ); ?>">
+                        <a href="<?php echo esc_url(  dokan_get_navigation_url( 'settings/payment-manage-' . $method_key . '-edit' ) ); ?>">
                             <button class="dokan-btn-theme dokan-btn-sm"><?php esc_html_e( 'Manage', 'dokan-lite' ); ?></button>
                         </a>
                     </div>


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [ ] I've included developer documentation (optional)
* [x] I've added proper labels to this pull request

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
used `dokan_get_navigation_url` instead of `dokan_get_page_url` to get the links
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes [Dokan Pro issue 1907](https://github.com/weDevsOfficial/dokan-pro/issues/1907) .

### How to test the changes in this Pull Request:

1. Please follow the linked issue



### Changelog entry

> **fix:** WPML translated endpoint not working in payment settings page


### PR Self Review Checklist:

* Code is not following code style guidelines
* Bad naming: make sure you would understand your code if you read it a few months from now.
* KISS: Keep it simple, Sweetie (not stupid!).
* DRY: Don't Repeat Yourself.
* Code that is not readable: too many nested 'if's are a bad sign.
* Performance issues
* Complicated constructions that need refactoring or comments: code should almost always be self-explanatory.
* Grammar errors.