### PR TITLE
fix/dokan_pro_withdraw_methods_shown_even_if_dokan_pro_is_disabled

### DIFF
--- a/includes/Withdraw/functions.php
+++ b/includes/Withdraw/functions.php
@@ -374,9 +374,7 @@ function dokan_withdraw_get_withdrawable_active_methods() {
             'dokan_withdraw_withdrawable_payment_methods',
             [
                 'paypal',
-                'dokan_custom',
                 'bank',
-                'skrill',
             ]
         )
     );


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [ ] I've included developer documentation (optional)
* [x] I've added proper labels to this pull request

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
part of [this](https://github.com/weDevsOfficial/dokan-pro/pull/1940) pr
Closes [Dokan pro pr](https://github.com/weDevsOfficial/dokan-pro/issues/1939)
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1.disable dokan pro and go to vendor dashboard > withdraw then look at Payment Methods section
2. you will see some methods having no name
3. here we are trying to fix them.



### Changelog entry

> **fix:** Some empty method names in Payment Methods section of Vendor Dashboard > Withdraw


### PR Self Review Checklist:

* Code is not following code style guidelines
* Bad naming: make sure you would understand your code if you read it a few months from now.
* KISS: Keep it simple, Sweetie (not stupid!).
* DRY: Don't Repeat Yourself.
* Code that is not readable: too many nested 'if's are a bad sign.
* Performance issues
* Complicated constructions that need refactoring or comments: code should almost always be self-explanatory.
* Grammar errors.