### PR TITLE
Fix/wrong url of breadcrumb on single store page

### DIFF
--- a/assets/src/js/script.js
+++ b/assets/src/js/script.js
@@ -1186,6 +1186,6 @@ jQuery(function($) {
 
 (function ($){
   $('.woocommerce-breadcrumb')
-    .find(`a[href="${dokan.vendor_store_url_prefix}"]`)
+    .find(`a[href="${dokan.store_url_prefix}"]`)
     .attr("href", dokan.store_listing_url);
 })(jQuery);

--- a/assets/src/js/script.js
+++ b/assets/src/js/script.js
@@ -1184,8 +1184,3 @@ jQuery(function($) {
   }
 }
 
-(function ($){
-  $('.woocommerce-breadcrumb')
-    .find(`a[href="${dokan.store_url_prefix}"]`)
-    .attr("href", dokan.store_listing_url);
-})(jQuery);

--- a/assets/src/js/script.js
+++ b/assets/src/js/script.js
@@ -1183,3 +1183,9 @@ jQuery(function($) {
     return false;
   }
 }
+
+(function ($){
+  $('.woocommerce-breadcrumb')
+    .find(`a[href="${dokan.vendor_store_url_prefix}"]`)
+    .attr("href", dokan.store_listing_url);
+})(jQuery);

--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -510,6 +510,8 @@ class Assets {
             'store_product_search_nonce' => wp_create_nonce( 'dokan_store_product_search_nonce' ),
             'i18n_download_permission'   => __( 'Are you sure you want to revoke access to this download?', 'dokan-lite' ),
             'i18n_download_access'       => __( 'Could not grant access - the user may already have permission for this file or billing email is not set. Ensure the billing email is set, and the order has been saved.', 'dokan-lite' ),
+            'store_url_prefix'           => home_url() . '/' . dokan_get_option( 'custom_store_url', 'dokan_general', 'store' ),
+            'store_listing_url'          => get_permalink( dokan_get_option( 'store_listing', 'dokan_pages' ) ),
             /**
              * Filter of maximun a vendor can add tags.
              *

--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -510,8 +510,6 @@ class Assets {
             'store_product_search_nonce' => wp_create_nonce( 'dokan_store_product_search_nonce' ),
             'i18n_download_permission'   => __( 'Are you sure you want to revoke access to this download?', 'dokan-lite' ),
             'i18n_download_access'       => __( 'Could not grant access - the user may already have permission for this file or billing email is not set. Ensure the billing email is set, and the order has been saved.', 'dokan-lite' ),
-            'store_url_prefix'           => home_url() . '/' . dokan_get_option( 'custom_store_url', 'dokan_general', 'store' ),
-            'store_listing_url'          => get_permalink( dokan_get_option( 'store_listing', 'dokan_pages' ) ),
             /**
              * Filter of maximun a vendor can add tags.
              *

--- a/includes/Rewrites.php
+++ b/includes/Rewrites.php
@@ -56,7 +56,7 @@ class Rewrites {
             return;
         }
 
-        $crumbs[1]   = [ ucwords( $this->custom_store_url ), site_url() . '/' . $this->custom_store_url ];
+        $crumbs[1]   = [ ucwords( $this->custom_store_url ), get_permalink( dokan_get_option( 'store_listing', 'dokan_pages' ) ) ];
         $crumbs[2]   = [ $author, dokan_get_store_url( $seller_info->data->ID ) ];
 
         return $crumbs;


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [ ] I've included developer documentation (optional)
* [x] I've added proper labels to this pull request

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Changed the url of the middle breadcrumb in single store page 
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes [Dokan pro issue #1918](https://github.com/weDevsOfficial/dokan-pro/issues/1918).

### How to test the changes in this Pull Request:

1. Please follow the steps described in the linked issue



### Changelog entry

> **fix:** Update of Vendor Store URL redirecting to incorrect page


### PR Self Review Checklist:

* Code is not following code style guidelines
* Bad naming: make sure you would understand your code if you read it a few months from now.
* KISS: Keep it simple, Sweetie (not stupid!).
* DRY: Don't Repeat Yourself.
* Code that is not readable: too many nested 'if's are a bad sign.
* Performance issues
* Complicated constructions that need refactoring or comments: code should almost always be self-explanatory.
* Grammar errors.
