### PR TITLE
Fix/account type field is missing for vendors created by admin

### DIFF
--- a/includes/Dashboard/Templates/Settings.php
+++ b/includes/Dashboard/Templates/Settings.php
@@ -841,7 +841,7 @@ class Settings {
 
         switch ( $payment_method_id ) {
             case 'bank':
-                $required_fields = [ 'ac_name', 'ac_number', 'routing_number', 'ac_type', 'declaration' ];
+                $required_fields = [ 'ac_name', 'ac_number', 'routing_number', 'ac_type' ];
                 break;
 
             case 'paypal':

--- a/includes/Dashboard/Templates/Settings.php
+++ b/includes/Dashboard/Templates/Settings.php
@@ -864,12 +864,11 @@ class Settings {
         if ( ! empty( $payment_settings ) && is_array( $payment_settings ) ) {
             $is_connected = true;
 
-            foreach ( $payment_settings as $field => $value ) {
-                if ( ! in_array( $field, $required_fields, true ) ) {
-                    continue;
-                }
-
-                if ( empty( $value ) || ( 'email' === $field && ! is_email( $value ) ) ) {
+            foreach ( $required_fields as $required_field ) {
+                if ( empty( $payment_settings[ $required_field ] ) ) {
+                    $is_connected = false;
+                    break;
+                } elseif ( 'email' === $required_field && ! is_email( $payment_settings[ $required_field ] ) ) {
                     $is_connected = false;
                     break;
                 }

--- a/includes/Vendor/Vendor.php
+++ b/includes/Vendor/Vendor.php
@@ -1239,6 +1239,15 @@ class Vendor {
     }
 
     /**
+     * Set bank ac type
+     *
+     * @param string $value
+     */
+    public function set_bank_ac_type( $value ) {
+        $this->set_payment_prop( 'ac_type', 'bank', wc_clean( $value ) );
+    }
+
+    /**
      * Set bank ac number
      *
      * @param string $value

--- a/src/admin/pages/AddVendor.vue
+++ b/src/admin/pages/AddVendor.vue
@@ -105,6 +105,7 @@ export default {
                 payment: {
                     bank: {
                         ac_name: '',
+                        ac_type: '',
                         ac_number: '',
                         bank_name: '',
                         bank_addr: '',

--- a/src/admin/pages/VendorPaymentFields.vue
+++ b/src/admin/pages/VendorPaymentFields.vue
@@ -17,6 +17,15 @@
                 </div>
 
                 <div class="column">
+                    <label for="account-type">{{ __( 'Account Type', 'dokan-lite') }}</label>
+                    <select id="account-type" class="dokan-form-input" v-model="vendorInfo.payment.bank.ac_type" >
+                        <option value="">{{__('Please Select...', 'dokan-lite')}}</option>
+                        <option value="personal">{{__('Personal', 'dokan-lite')}}</option>
+                        <option value="business">{{__('Business', 'dokan-lite')}}</option>
+                    </select>
+                </div>
+
+                <div class="column">
                     <label for="bank-name">{{ __( 'Bank Name', 'dokan-lite') }}</label>
                     <input type="text" id="bank-name" class="dokan-form-input" v-model="vendorInfo.payment.bank.bank_name" :placeholder="__( 'Bank Name', 'dokan-lite')">
                 </div>

--- a/templates/settings/bank-payment-method-settings.php
+++ b/templates/settings/bank-payment-method-settings.php
@@ -95,7 +95,7 @@
     </div>
 
     <div class="dokan-form-group dokan-text-left">
-        <input id="declaration" name="settings[bank][declaration]" checked type="checkbox" required/>
+        <input id="declaration" name="settings[bank][declaration]" checked type="checkbox"/>
         <label for="declaration">
             <?php esc_html_e( 'I attest that I am the owner and have full authorization to this bank account', 'dokan-lite' ); ?>
         </label>


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [ ] I've included developer documentation (optional)
* [x] I've added proper labels to this pull request

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Part of this [dokan pro pr](https://github.com/weDevsOfficial/dokan-pro/pull/1951)
Closes [this Dokan Pro issue](https://github.com/weDevsOfficial/dokan-pro/issues/1943)

### How to test the changes in this Pull Request:

1. Please follow the steps in the linked issue



### Changelog entry

> **fix:** Account Type for bank payment method is missing when admin is creating/editing a vendor


### PR Self Review Checklist:

* Code is not following code style guidelines
* Bad naming: make sure you would understand your code if you read it a few months from now.
* KISS: Keep it simple, Sweetie (not stupid!).
* DRY: Don't Repeat Yourself.
* Code that is not readable: too many nested 'if's are a bad sign.
* Performance issues
* Complicated constructions that need refactoring or comments: code should almost always be self-explanatory.
* Grammar errors.