### PR TITLE
Show multistep categories as language selected by wpml

### DIFF
--- a/assets/src/js/product-category-ui.js
+++ b/assets/src/js/product-category-ui.js
@@ -107,7 +107,8 @@
         },
 
         setCatUiBasedOnOneCat: function( catId, category ) {
-            ProductCategory.disableDoneBtn( category.children.length > 0 );
+            let disable = undefined !== category.children.length && category.children.length > 0
+            ProductCategory.disableDoneBtn( disable );
 
             let allUl = [ ...category.parents ];
             let selectedInUls = [ ...category.parents ];

--- a/includes/ProductCategory/Categories.php
+++ b/includes/ProductCategory/Categories.php
@@ -138,6 +138,7 @@ class Categories {
         $wpml_exists      = function_exists( 'wpml_get_current_language' );
         $current_language = apply_filters( 'wpml_current_language', NULL );
 
+        // If wpml plugin exists and current language is not NULL then get categories as language set.
         if ( $wpml_exists && NULL !== $current_language ) {
             $join .= " INNER JOIN `{$wpdb->prefix}icl_translations` AS tr
                     ON terms.term_id = tr.element_id";

--- a/includes/ProductCategory/Categories.php
+++ b/includes/ProductCategory/Categories.php
@@ -25,12 +25,12 @@ class Categories {
 
         $this->categories = Cache::get_transient( $transient_key );
 
-        // if ( false === $this->categories ) {
+        if ( false === $this->categories ) {
             //calculate category data
             $this->get_categories();
             // set category data to cache
             Cache::set_transient( $transient_key, $this->categories, '', MONTH_IN_SECONDS );
-        // }
+        }
 
         if ( $ret ) {
             return $this->categories;

--- a/includes/ProductCategory/Categories.php
+++ b/includes/ProductCategory/Categories.php
@@ -129,11 +129,24 @@ class Categories {
         global $wpdb;
 
         // get all categories
+        $table  = $wpdb->prefix . 'terms';
+        $fields = "terms.term_id, terms.name, tax.parent AS parent_id";
+        $join   = "INNER JOIN `{$wpdb->prefix}term_taxonomy` AS tax
+                ON terms.term_id = tax.term_id";
+        $where  = " AND tax.taxonomy = 'product_cat'";
+
+        $wpml_exists      = function_exists( 'wpml_get_current_language' );
+        $current_language = apply_filters( 'wpml_current_language', NULL );
+
+        if ( $wpml_exists && NULL !== $current_language ) {
+            $join .= " INNER JOIN `{$wpdb->prefix}icl_translations` AS tr
+                    ON terms.term_id = tr.element_id";
+            $where .= " AND tr.language_code = '{$current_language}'
+                    AND tr.element_type = 'tax_product_cat'";
+        }
+
         $categories = $wpdb->get_results(
-            "SELECT terms.term_id, terms.name, tax.parent AS parent_id FROM `{$wpdb->prefix}terms` AS terms
-            INNER JOIN `{$wpdb->prefix}term_taxonomy` AS tax
-            ON terms.term_id = tax.term_id
-            WHERE tax.taxonomy = 'product_cat'",
+            "SELECT $fields FROM $table AS terms $join WHERE 1=1 $where",
             OBJECT_K
         );
 

--- a/includes/ProductCategory/Categories.php
+++ b/includes/ProductCategory/Categories.php
@@ -25,12 +25,12 @@ class Categories {
 
         $this->categories = Cache::get_transient( $transient_key );
 
-        if ( false === $this->categories ) {
+        // if ( false === $this->categories ) {
             //calculate category data
             $this->get_categories();
             // set category data to cache
             Cache::set_transient( $transient_key, $this->categories, '', MONTH_IN_SECONDS );
-        }
+        // }
 
         if ( $ret ) {
             return $this->categories;
@@ -130,26 +130,25 @@ class Categories {
 
         // get all categories
         $table  = $wpdb->prefix . 'terms';
-        $fields = "terms.term_id, terms.name, tax.parent AS parent_id";
-        $join   = "INNER JOIN `{$wpdb->prefix}term_taxonomy` AS tax
-                ON terms.term_id = tax.term_id";
+        $fields = 'terms.term_id, terms.name, tax.parent AS parent_id';
+        $join   = "INNER JOIN `{$wpdb->prefix}term_taxonomy` AS tax ON terms.term_id = tax.term_id";
         $where  = " AND tax.taxonomy = 'product_cat'";
 
         $wpml_exists      = function_exists( 'wpml_get_current_language' );
-        $current_language = apply_filters( 'wpml_current_language', NULL );
+        $current_language = apply_filters( 'wpml_current_language', null );
 
         // If wpml plugin exists and current language is not NULL then get categories as language set.
-        if ( $wpml_exists && NULL !== $current_language ) {
-            $join .= " INNER JOIN `{$wpdb->prefix}icl_translations` AS tr
-                    ON terms.term_id = tr.element_id";
-            $where .= " AND tr.language_code = '{$current_language}'
-                    AND tr.element_type = 'tax_product_cat'";
+        if ( $wpml_exists && null !== $current_language ) {
+            $join .= " INNER JOIN `{$wpdb->prefix}icl_translations` AS tr ON terms.term_id = tr.element_id";
+            $where .= " AND tr.language_code = '{$current_language}' AND tr.element_type = 'tax_product_cat'";
         }
 
+        // @codingStandardsIgnoreStart
         $categories = $wpdb->get_results(
-            "SELECT $fields FROM $table AS terms $join WHERE 1=1 $where",
+            $wpdb->prepare( "SELECT $fields FROM $table AS terms $join WHERE %d=%d $where", 1, 1 ),
             OBJECT_K
         );
+        // @codingStandardsIgnoreEnd
 
         if ( empty( $categories ) ) {
             $this->categories = [];

--- a/includes/ProductCategory/Categories.php
+++ b/includes/ProductCategory/Categories.php
@@ -134,11 +134,10 @@ class Categories {
         $join   = "INNER JOIN `{$wpdb->prefix}term_taxonomy` AS tax ON terms.term_id = tax.term_id";
         $where  = " AND tax.taxonomy = 'product_cat'";
 
-        $wpml_exists      = function_exists( 'wpml_get_current_language' );
-        $current_language = apply_filters( 'wpml_current_language', null );
+        // If wpml plugin exists then get categories as language set.
+        if ( function_exists( 'wpml_get_current_language' ) ) {
+            $current_language = wpml_get_current_language();
 
-        // If wpml plugin exists and current language is not NULL then get categories as language set.
-        if ( $wpml_exists && null !== $current_language ) {
             $join .= " INNER JOIN `{$wpdb->prefix}icl_translations` AS tr ON terms.term_id = tr.element_id";
             $where .= " AND tr.language_code = '{$current_language}' AND tr.element_type = 'tax_product_cat'";
         }

--- a/includes/ProductCategory/ProductCategoryCache.php
+++ b/includes/ProductCategory/ProductCategoryCache.php
@@ -18,8 +18,8 @@ class ProductCategoryCache {
     public function __construct() {
         add_action( 'edit_product_cat', [ $this, 'clear_multistep_category_cache' ], 10, 1 );
         add_action( 'pre_delete_term', [ $this, 'clear_multistep_category_cache' ], 10, 1 );
-        add_action( 'create_product_cat', [ $this, 'clear_multistep_category_cache' ], 10);
-        add_action( 'wpml_sync_term_hierarchy_done', [ $this, 'clear_multistep_category_cache' ], 99);
+        add_action( 'create_product_cat', [ $this, 'clear_multistep_category_cache' ], 10 );
+        add_action( 'wpml_sync_term_hierarchy_done', [ $this, 'clear_multistep_category_cache' ], 99 );
     }
 
     /**

--- a/includes/ProductCategory/ProductCategoryCache.php
+++ b/includes/ProductCategory/ProductCategoryCache.php
@@ -19,6 +19,7 @@ class ProductCategoryCache {
         add_action( 'edit_product_cat', [ $this, 'clear_multistep_category_cache' ], 10, 1 );
         add_action( 'pre_delete_term', [ $this, 'clear_multistep_category_cache' ], 10, 1 );
         add_action( 'create_product_cat', [ $this, 'clear_multistep_category_cache' ], 10);
+        add_action( 'wpml_sync_term_hierarchy_done', [ $this, 'clear_multistep_category_cache' ], 99);
     }
 
     /**
@@ -29,7 +30,13 @@ class ProductCategoryCache {
      * @return void
      */
     public function clear_multistep_category_cache() {
-        $transient_key = function_exists( 'wpml_get_current_language' ) ? 'multistep_categories_' . wpml_get_current_language() : 'multistep_categories';
-        Cache::delete_transient( $transient_key );
+        if ( function_exists( 'wpml_get_active_languages' ) ) {
+            foreach ( wpml_get_active_languages() as $active_language ) {
+                $transient_key = 'multistep_categories_' . $active_language['code'];
+                Cache::delete_transient( $transient_key );
+            }
+        }
+
+        Cache::delete_transient( 'multistep_categories' );
     }
 }


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [ ] I've included developer documentation (optional)
* [x] I've added proper labels to this pull request

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #1669

### How to test the changes in this Pull Request:

1. Install WPML and check if the multistep categories are shown as the selected language, should not show all language categories.


### Changelog entry

> Fix: wpml support in the multistep product category.


### PR Self Review Checklist:

* Code is not following code style guidelines
* Bad naming: make sure you would understand your code if you read it a few months from now.
* KISS: Keep it simple, Sweetie (not stupid!).
* DRY: Don't Repeat Yourself.
* Code that is not readable: too many nested 'if's are a bad sign.
* Performance issues
* Complicated constructions that need refactoring or comments: code should almost always be self-explanatory.
* Grammar errors.


### FOR PR REVIEWER ONLY:

> As a reviewer, your feedback should be focused on the idea, not the person. Seek to understand, be respectful, and focus on constructive dialog.

> As a contributor, your responsibility is to learn from suggestions and iterate your pull request should it be needed based on feedback. Seek to collaborate and produce the best possible contribution to the greater whole.

* [ ] Correct — Does the change do what it’s supposed to? ie: code 100% fulfilling the requirements?
* [ ] Secure — Would a nefarious party find some way to exploit this change? ie: everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities?
* [ ] Readable — Will your future self be able to understand this change months down the road?
* [ ] Elegant — Does the change fit aesthetically within the overall style and architecture?
