### PR TITLE
Enhancement: Order REST API date filter - after/before

### DIFF
--- a/includes/REST/OrderController.php
+++ b/includes/REST/OrderController.php
@@ -434,6 +434,15 @@ class OrderController extends DokanRESTController {
             'seller_id'   => dokan_get_current_user_id(),
         ];
 
+        // Add after and before support for order date-filtering.
+        if ( $request['after'] ) {
+            $args['date']['from'] = sanitize_text_field( wp_unslash( $request['after'] ) );
+        }
+
+        if ( $request['before'] ) {
+            $args['date']['to'] = sanitize_text_field( wp_unslash( $request['before'] ) );
+        }
+
         $orders = dokan()->order->all( $args );
 
         $data_objects = array();

--- a/includes/REST/OrderController.php
+++ b/includes/REST/OrderController.php
@@ -1748,6 +1748,20 @@ class OrderController extends DokanRESTController {
             'type'        => $schema_properties['customer_id']['type'],
         );
 
+        $params['after'] = array(
+            'description'        => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'dokan-lite' ),
+            'type'               => 'string',
+            'format'             => 'date-time',
+            'validate_callback'  => 'rest_validate_request_arg',
+        );
+
+        $params['before'] = array(
+            'description'        => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'dokan-lite' ),
+            'type'               => 'string',
+            'format'             => 'date-time',
+            'validate_callback'  => 'rest_validate_request_arg',
+        );
+
         return $query_params;
     }
 }

--- a/includes/REST/OrderController.php
+++ b/includes/REST/OrderController.php
@@ -432,16 +432,11 @@ class OrderController extends DokanRESTController {
             'paged'       => isset( $request['page'] ) ? absint( $request['page'] ) : 1,
             'customer_id' => $request['customer_id'],
             'seller_id'   => dokan_get_current_user_id(),
+            'date'        => [
+                'from' => isset( $request['after'] ) ? sanitize_text_field( wp_unslash( $request['after'] ) ) : '',
+                'to'   => isset( $request['before'] ) ? sanitize_text_field( wp_unslash( $request['before'] ) ) : '',
+            ]
         ];
-
-        // Add after and before support for order date-filtering.
-        if ( $request['after'] ) {
-            $args['date']['from'] = sanitize_text_field( wp_unslash( $request['after'] ) );
-        }
-
-        if ( $request['before'] ) {
-            $args['date']['to'] = sanitize_text_field( wp_unslash( $request['before'] ) );
-        }
 
         $orders = dokan()->order->all( $args );
 


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [x] I've added proper labels to this pull request

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In this PR, we've added after and before filter in order list API -

```sh
dokan/v1/orders?after=2022-10-01&before=2022-10-30
```

### Changelog entry

> Order list Rest API support after-before date filter.