### PR TITLE
Enhancement: Section, sub-section label, description added in Setting…

### DIFF
--- a/src/admin/pages/Settings.vue
+++ b/src/admin/pages/Settings.vue
@@ -419,12 +419,16 @@
                     return;
                 }
 
-                if (!this.awaitingSearch) {
-                    setTimeout(() => {
-                        let searchText = this.$refs.searchInSettings.value.toLowerCase();
-                        this.doSearch(searchText);
+                if ( ! this.awaitingSearch ) {
+                    setTimeout( () => {
+                        let searchText = this.$refs.searchInSettings.value;
+
+                        // If more than two (space/tab) found, replace with space > trim > lowercase.
+                        searchText = searchText.replace( /\s\s+/g,' ' ).trim().toLowerCase();
+
+                        this.doSearch( searchText );
                         this.awaitingSearch = false;
-                    }, 1000);
+                    }, 1000 );
                 }
 
                 this.awaitingSearch = true;
@@ -439,11 +443,23 @@
 
                 Object.keys( dokan_setting_fields ).forEach( function( section, index ) {
                     Object.keys( dokan_setting_fields[section] ).forEach( function( field, i ) {
-                        if (dokan_setting_fields[section][field].type === "sub_section") {
-                            return;
+                        let label = '';
+
+                        // Append section field label.
+                        label += dokan_setting_fields[section][field]['label'];
+
+                        // Append section label and description.
+                        if ( typeof self.settingSections[index] !== 'undefined' ) {
+                            label += ` ${self.settingSections[index]['title']} ${self.settingSections[index]['description']}`;
                         }
 
-                        let label = dokan_setting_fields[section][field]['label'].toLowerCase();
+                        // Append sub-section label and description.
+                        if ( 'sub_section' === dokan_setting_fields[section][field].type ) {
+                            label += ` ${dokan_setting_fields[section][field]['label']} ${dokan_setting_fields[section][field]['description']}`;
+                        }
+
+                        // Make the label lowercase, as `searchText` is also like that.
+                        label = label.toLocaleLowerCase();
 
                         if ( label && label.includes(searchText) ) {
                             if (!settingFields[section]) {


### PR DESCRIPTION
## What has been done
Previously, in Admin Settings sidebar, **Searching** will only work for `fields` and not for section title, description and subsection title, description.

Now, we've added searching system which will search from -

- Section label, description, detail description
- Field label, description
- **Search text trimming** also added. While searching user can give space before and after of their search term.

### Previous settings search
<img width="870" alt="Previous-settings-search" src="https://user-images.githubusercontent.com/17502625/203479039-b5442601-3f3e-4811-bcaa-395c862d60c9.png">

### Current settings search
<img width="870" alt="Current-settings-search" src="https://user-images.githubusercontent.com/17502625/203479068-b42aa392-fd41-40bc-b8e0-220658ca6301.png">

