### PR TITLE
fix: Custom Withdrawal method enabling and display conditional restriction

### DIFF
--- a/includes/Admin/SetupWizard.php
+++ b/includes/Admin/SetupWizard.php
@@ -479,6 +479,7 @@ class SetupWizard {
         $withdraw_methods      = ! empty( $options['withdraw_methods'] ) ? $options['withdraw_methods'] : [];
         $withdraw_limit        = ! empty( $options['withdraw_limit'] ) ? $options['withdraw_limit'] : 0;
         $withdraw_order_status = ! empty( $options['withdraw_order_status'] ) ? $options['withdraw_order_status'] : [];
+        $hide_custom_method    = empty( $options['withdraw_method_name'] ) || empty( $options['withdraw_method_type'] );
         ?>
         <h1><?php esc_html_e( 'Withdraw Setup', 'dokan-lite' ); ?></h1>
         <form method="post">
@@ -489,7 +490,12 @@ class SetupWizard {
                 <tr>
                     <td colspan="2">
                         <ul class="wc-wizard-payment-gateways wc-wizard-services">
-                            <?php foreach ( dokan_withdraw_register_methods() as $key => $method ) : ?>
+                            <?php
+                            foreach ( dokan_withdraw_register_methods() as $key => $method ) :
+                                if ( 'dokan_custom' === $key && $hide_custom_method ) {
+                                    continue;
+                                }
+                                ?>
                                 <li class="wc-wizard-service-item <?php echo ( in_array( $key, array_values( $withdraw_methods ), true ) ) ? 'checked="checked"' : ''; ?>">
                                     <div class="wc-wizard-service-name">
                                         <p><?php echo esc_html( dokan_withdraw_get_method_title( $key ) ); ?></p>


### PR DESCRIPTION
### All Submissions:

* [ ] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [ ] My code satisfies feature requirements
* [ ] My code is tested
* [ ] My code passes the PHPCS tests
* [ ] My code has proper inline documentation
* [ ] I've included developer documentation (optional)
* [ ] I've added proper labels to this pull request

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Conditionally removing Custom Withdrawal method from Setup Wizard. This Closes https://github.com/weDevsOfficial/dokan-pro/issues/1923

### How to test the changes in this Pull Request:

1. Please check the issue https://github.com/weDevsOfficial/dokan-pro/issues/1923



### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

**update**: conditional rendering custom withdrawal method in the admin setup wizard.
As we know, the custom withdrawal method needs not only to enable the method but also to populate the method name and method type. And as in the Settings wizard, we are not populating the method name and type, the method is not enablable. 
If Admin previously saved those values only then the custom withdrawal method is displayed and can be activated.
 
### PR Self Review Checklist:

* Code is not following code style guidelines
* Bad naming: make sure you would understand your code if you read it a few months from now.
* KISS: Keep it simple, Sweetie (not stupid!).
* DRY: Don't Repeat Yourself.
* Code that is not readable: too many nested 'if's are a bad sign.
* Performance issues
* Complicated constructions that need refactoring or comments: code should almost always be self-explanatory.
* Grammar errors.


### FOR PR REVIEWER ONLY:

> As a reviewer, your feedback should be focused on the idea, not the person. Seek to understand, be respectful, and focus on constructive dialog.

> As a contributor, your responsibility is to learn from suggestions and iterate your pull request should it be needed based on feedback. Seek to collaborate and produce the best possible contribution to the greater whole.

* [ ] Correct — Does the change do what it’s supposed to? ie: code 100% fulfilling the requirements?
* [ ] Secure — Would a nefarious party find some way to exploit this change? ie: everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities?
* [ ] Readable — Will your future self be able to understand this change months down the road?
* [ ] Elegant — Does the change fit aesthetically within the overall style and architecture?
