### PR TITLE
Fix update table header style for mobile display

### DIFF
--- a/assets/src/less/general.less
+++ b/assets/src/less/general.less
@@ -167,6 +167,10 @@ table.dokan-table {
       display: none;
     }
 
+    thead.dokan-show-thead {
+      display: contents;
+    }
+
     td.column-thumb,
     td.column-primary ~ td:not(.check-column) {
       display: none;

--- a/templates/orders/details.php
+++ b/templates/orders/details.php
@@ -24,7 +24,7 @@ $hide_customer_info = dokan_get_option( 'hide_customer_info', 'dokan_selling', '
                         } else {
                             ?>
                             <table class="dokan-table order-items">
-                                <thead>
+                                <thead class="dokan-show-thead">
                                 <tr>
                                     <th class="item" colspan="2"><?php esc_html_e( 'Item', 'dokan-lite' ); ?></th>
 

--- a/templates/withdraw/approved-request-listing.php
+++ b/templates/withdraw/approved-request-listing.php
@@ -11,7 +11,7 @@
 ?>
 
 <table class="dokan-table dokan-table-striped">
-    <thead>
+    <thead class="dokan-show-thead">
     <tr>
         <th><?php esc_html_e( 'Amount', 'dokan-lite' ); ?></th>
         <th><?php esc_html_e( 'Method', 'dokan-lite' ); ?></th>

--- a/templates/withdraw/cancelled-request-listing.php
+++ b/templates/withdraw/cancelled-request-listing.php
@@ -11,7 +11,7 @@
 ?>
 
 <table class="dokan-table dokan-table-striped">
-    <thead>
+    <thead class="dokan-show-thead">
     <tr>
         <th><?php esc_html_e( 'Amount', 'dokan-lite' ); ?></th>
         <th><?php esc_html_e( 'Method', 'dokan-lite' ); ?></th>


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [x] I've included related pull request(s) (optional)
* [x] I've included developer documentation (optional)
* [x] I've added proper labels to this pull request

### Changes proposed in this Pull Request:
Fixed order table style in vendor dashboard order details page item table, withdraw an approved list, withdraw canceled list.

### Changes proposed in this Pull Request:
* https://github.com/getdokan/dokan-pro/pull/4644

### Closes
* Closes https://github.com/getdokan/dokan-pro/issues/4555


### How to test the changes in this Pull Request:
* Order details page item list
* Withdraw approve request list 
* Withdraw pending request list 
* Withdraw cancel request list

### Changelog entry
```text
- **fix:** Update table header style for mobile display in order details page item list and withdraw approve, pending and cancel list.
```
