### PR TITLE
fix: add support for including product variations in manual order requests

### DIFF
--- a/includes/REST/ProductControllerV2.php
+++ b/includes/REST/ProductControllerV2.php
@@ -322,9 +322,18 @@ class ProductControllerV2 extends ProductController {
             );
         }
 
-        // Product stock status.
+        // Include variations but exclude parent variable products when requested.
         if ( isset( $request['include_variations'] ) && true === wc_string_to_bool( $request['include_variations'] ) ) {
             $args['post_type'] = [ $this->post_type, 'product_variation' ];
+
+            // Exclude parent variable products so only variations (and other non-variable products) are included.
+            // Variations are a different post type and won't be affected by this taxonomy filter.
+            $args['tax_query'][] = array(
+                'taxonomy' => 'product_type',
+                'field'    => 'slug',
+                'terms'    => array( 'variable' ),
+                'operator' => 'NOT IN',
+            );
         }
 
         return apply_filters( 'dokan_rest_pre_product_listing_args', $args, $request );

--- a/includes/REST/ProductControllerV2.php
+++ b/includes/REST/ProductControllerV2.php
@@ -199,6 +199,15 @@ class ProductControllerV2 extends ProductController {
             'default'           => array(),
             'sanitize_callback' => 'wp_parse_id_list',
         );
+        $params['exclude'] = array(
+            'description'       => __( 'Ensure result set excludes specific IDs.', 'dokan-lite' ),
+            'type'              => 'array',
+            'items'             => array(
+                'type' => 'integer',
+            ),
+            'default'           => array(),
+            'sanitize_callback' => 'wp_parse_id_list',
+        );
         $params['include_variations'] = array(
             'description' => __( 'If true matched product variations will be added to the collection', 'dokan-lite' ),
             'type'        => 'boolean',

--- a/includes/REST/ProductControllerV2.php
+++ b/includes/REST/ProductControllerV2.php
@@ -199,14 +199,10 @@ class ProductControllerV2 extends ProductController {
             'default'           => array(),
             'sanitize_callback' => 'wp_parse_id_list',
         );
-        $params['exclude'] = array(
-            'description'       => __( 'Ensure result set excludes specific IDs.', 'dokan-lite' ),
-            'type'              => 'array',
-            'items'             => array(
-                'type' => 'integer',
-            ),
-            'default'           => array(),
-            'sanitize_callback' => 'wp_parse_id_list',
+        $params['include_variations'] = array(
+            'description' => __( 'If true matched product variations will be added to the collection', 'dokan-lite' ),
+            'type'        => 'boolean',
+            'default'     => false,
         );
 
         return $params;
@@ -315,6 +311,11 @@ class ProductControllerV2 extends ProductController {
                 'value'   => sanitize_text_field( wp_unslash( $request['stock_status'] ) ),
                 'compare' => ' = ',
             );
+        }
+
+        // Product stock status.
+        if ( isset( $request['include_variations'] ) && true === wc_string_to_bool( $request['include_variations'] ) ) {
+            $args['post_type'] = [ $this->post_type, 'product_variation' ];
         }
 
         return apply_filters( 'dokan_rest_pre_product_listing_args', $args, $request );


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [x] I've included related pull request(s) (optional)
* [x] I've included developer documentation (optional)
* [x] I've added proper labels to this pull request

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Related Pull Request(s)

* https://github.com/getdokan/dokan-pro/pull/5206

### Closes 

* Closes https://github.com/getdokan/dokan-pro/issues/5147


### How to test the changes in this Pull Request:

* Test as mentioned in the issue.


### Changelog entry
```text
- **fix:** Added support for including product variations in products rest api requests.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a REST API query parameter (include_variations, default false) to optionally include product variations in product collection responses.
  * When enabled, responses include matched variations and non-variable products while excluding parent variable products; existing exclusion behavior remains unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->