### PR TITLE
enhance: use dokan_get_template_part for download permissions

### DIFF
--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -266,10 +266,10 @@ class Ajax {
 
                         $template_args = apply_filters(
                             'dokan_order_download_permission_args', [
-                                'download'         => $download,
-                                'product'           => $product,
-                                'file_count'           => $file_count,
-                                'loop' => $loop,
+                                'download'    => $download,
+                                'product'     => $product,
+                                'file_count'  => $file_count,
+                                'loop'        => $loop,
                             ]
                         );
 

--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -264,7 +264,16 @@ class Ajax {
                     if ( $inserted_id ) {
                         $download = new \WC_Customer_Download( $inserted_id );
 
-                        include dirname( __DIR__ ) . '/templates/orders/order-download-permission-html.php';
+                        $template_args = apply_filters(
+                            'dokan_order_download_permission_args', [
+                                'download'         => $download,
+                                'product'           => $product,
+                                'file_count'           => $file_count,
+                                'loop' => $loop,
+                            ]
+                        );
+
+                        dokan_get_template_part( 'orders/order-download-permission-html', false, $template_args );
 
                         ++$loop;
                         ++$file_count;


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [ ] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [ ] My code has proper inline documentation
* [ ] I've included related pull request(s) (optional)
* [ ] I've included developer documentation (optional)
* [x] I've added proper labels to this pull request

### Changes proposed in this Pull Request:
Refactored the `grant_access_to_download()` AJAX method to use the standard `dokan_get_template_part()` function instead of direct include for loading the download permission template, improving consistency with Dokan's template loading conventions.

### How to test the changes in this Pull Request:
1. Log in as a vendor
2. Navigate to **Dokan Dashboard → Orders**
3. Create or select an order containing a downloadable product
4. Click on the order to view details
5. Scroll to the **Downloadable Product Permissions** section
6. Click **"Grant Access"** button
7. **Expected**: Download permission should be granted successfully and displayed in the list through Ajax response.

### Changelog entry
#### Changes Made
- **Replaced direct `include`** with [dokan_get_template_part()](cci:1://file:///Users/aiarnob/Herd/seco-system/wp-content/plugins/dokan-lite/includes/functions.php:837:0-881:1) in `Ajax::grant_access_to_download()`
- **Added template arguments array** with proper filtering via `dokan_order_download_permission_args` hook
- **Improved template variable passing** using the standardized `$template_args` pattern
- **Enhanced extensibility** by allowing theme/plugin developers to filter template arguments
#### Benefits
1. **Consistency**: Aligns with Dokan's established template loading patterns used throughout the codebase
2. **Theme Override Support**: Enables theme developers to override the template by placing it in `{theme}/dokan/orders/order-download-permission-html.php`
3. **Extensibility**: The new filter hook allows developers to modify template data before rendering
4. **Maintainability**: Follows the same pattern as other AJAX handlers like [seller_listing_search()]


### Before Changes
`include dirname( __DIR__ ) . '/templates/orders/order-download-permission-html.php';`


### After Changes
```
$template_args = apply_filters(
    'dokan_order_download_permission_args', [
        'download'   => $download,
        'product'    => $product,
        'file_count' => $file_count,
        'loop'       => $loop,
    ]
);

dokan_get_template_part( 'orders/order-download-permission-html', false, $template_args );
```


### FOR PR REVIEWER ONLY:

> As a reviewer, your feedback should be focused on the idea, not the person. Seek to understand, be respectful, and focus on constructive dialog.

> As a contributor, your responsibility is to learn from suggestions and iterate your pull request should it be needed based on feedback. Seek to collaborate and produce the best possible contribution to the greater whole.

* [ ] Correct — Does the change do what it’s supposed to? ie: code 100% fulfilling the requirements?
* [ ] Secure — Would a nefarious party find some way to exploit this change? ie: everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities?
* [ ] Readable — Will your future self be able to understand this change months down the road?
* [ ] Elegant — Does the change fit aesthetically within the overall style and architecture?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved order download display by switching to a template-rendering approach and introducing a filterable data payload for the template, enabling easier customization of download/product/count/loop information without altering core templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->