### PR TITLE
Missing Translation for "Actions" and "No Results" Strings on `DataViews`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ phpcs-report.txt
 !/assets/css/vue-vendor.css
 !/assets/css/vue-frontend.css
 !/assets/css/wp-version-before-5-3.css
+.vscode

--- a/src/components/dataviews/AdminDataViewTable.tsx
+++ b/src/components/dataviews/AdminDataViewTable.tsx
@@ -18,7 +18,7 @@ import { twMerge } from 'tailwind-merge';
 import { Funnel } from 'lucide-react';
 import { Item } from '@wordpress/components/build-types/navigation/types';
 import ListEmpty from '@src/components/dataviews/ListEmpty';
-import { translatedStrings } from './DataViewTable';
+import { getTranslatedStrings } from './DataViewTable';
 
 type ItemWithId = { id: string };
 
@@ -153,7 +153,7 @@ const AdminDataViewTable = ( props: DataViewsProps< Item > ) => {
     }
 
     useEffect( () => {
-        setLocaleData( translatedStrings, 'default' );
+        setLocaleData( getTranslatedStrings(), 'default' );
     }, [] );
 
     // Auto-hide filter area when there are no active filters

--- a/src/components/dataviews/AdminDataViewTable.tsx
+++ b/src/components/dataviews/AdminDataViewTable.tsx
@@ -13,11 +13,12 @@ import './style.scss';
 import { AdminFilterProps } from '@src/components/AdminFilter';
 import { AdminTabProps } from '@src/components/AdminTab';
 import { AdminTab, AdminFilter } from '@src/components';
-import { __ } from '@wordpress/i18n';
+import { __, setLocaleData } from '@wordpress/i18n';
 import { twMerge } from 'tailwind-merge';
 import { Funnel } from 'lucide-react';
 import { Item } from '@wordpress/components/build-types/navigation/types';
 import ListEmpty from '@src/components/dataviews/ListEmpty';
+import { translatedStrings } from './DataViewTable';
 
 type ItemWithId = { id: string };
 
@@ -150,6 +151,10 @@ const AdminDataViewTable = ( props: DataViewsProps< Item > ) => {
             [ windowWidth ]
         );
     }
+
+    useEffect( () => {
+        setLocaleData( translatedStrings, 'default' );
+    }, [] );
 
     // Auto-hide filter area when there are no active filters
     useEffect( () => {

--- a/src/components/dataviews/DataViewTable.tsx
+++ b/src/components/dataviews/DataViewTable.tsx
@@ -10,6 +10,7 @@ import type {
 import { kebabCase, snakeCase } from '@dokan/utilities';
 import { useEffect } from '@wordpress/element';
 import { useWindowDimensions } from '@dokan/hooks';
+import { __, setLocaleData } from '@wordpress/i18n';
 import './style.scss';
 
 type ItemWithId = { id: string };
@@ -52,6 +53,12 @@ const applyFiltersToTableElements = (
         element,
         { ...props }
     );
+};
+
+export const translatedStrings = {
+    '': { domain: 'default', 'plural-forms': 'nplurals=1; plural=0;' },
+    Actions: [ __( 'Actions', 'dokan-lite' ) ],
+    'No results': [ __( 'No results', 'dokan-lite' ) ],
 };
 
 const DataViewTable = ( props: DataViewsProps< Item > ) => {
@@ -137,6 +144,10 @@ const DataViewTable = ( props: DataViewsProps< Item > ) => {
             type: windowWidth <= 768 ? 'list' : 'table',
         }), [ windowWidth ]);
     }
+
+    useEffect( () => {
+        setLocaleData( translatedStrings, 'default' );
+    }, [] );
 
     return (
         <div id={ tableNameSpace } className={ `dokan-dashboard-datatable` }

--- a/src/components/dataviews/DataViewTable.tsx
+++ b/src/components/dataviews/DataViewTable.tsx
@@ -55,11 +55,10 @@ const applyFiltersToTableElements = (
     );
 };
 
-export const translatedStrings = {
-    '': { domain: 'default', 'plural-forms': 'nplurals=1; plural=0;' },
+export const getTranslatedStrings = () => ( {
     Actions: [ __( 'Actions', 'dokan-lite' ) ],
     'No results': [ __( 'No results', 'dokan-lite' ) ],
-};
+} );
 
 const DataViewTable = ( props: DataViewsProps< Item > ) => {
     if ( ! props.namespace ) {
@@ -146,7 +145,7 @@ const DataViewTable = ( props: DataViewsProps< Item > ) => {
     }
 
     useEffect( () => {
-        setLocaleData( translatedStrings, 'default' );
+        setLocaleData( getTranslatedStrings(), 'default' );
     }, [] );
 
     return (


### PR DESCRIPTION
Export and register frontend i18n strings for data view tables and add .vscode to .gitignore. DataViewTable now exports translatedStrings and imports __ and setLocaleData; both DataViewTable and AdminDataViewTable call setLocaleData in useEffect to register those strings (e.g. 'Actions', 'No results') for the default domain. Also updated imports accordingly to ensure these UI strings are available for JS translations.

### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [x] I've included related pull request(s) (optional)
* [x] I've included developer documentation (optional)
* [x] I've added proper labels to this pull request

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Related Pull Request(s)

* Full PR Link


### Closes 

* Closes https://github.com/getdokan/client-issue/issues/374


### How to test the changes in this Pull Request:

* Steps or issue link


### Changelog entry

```md
- **fix:** Resolved missing translations for the "Actions" and "No results" strings on the "DataViews", ensuring frontend text now reflects the selected language correctly.
```


### Before Changes

Describe the issue before changes with screenshots(s).


### After Changes

Describe the issue after changes with screenshot(s).


### Feature Video (optional)

Link of detailed video if this PR is for a feature.


### PR Self Review Checklist:

* Code is not following code style guidelines
* Bad naming: make sure you would understand your code if you read it a few months from now.
* KISS: Keep it simple, Sweetie (not stupid!).
* DRY: Don't Repeat Yourself.
* Code that is not readable: too many nested 'if's are a bad sign.
* Performance issues
* Complicated constructions that need refactoring or comments: code should almost always be self-explanatory.
* Grammar errors.


### FOR PR REVIEWER ONLY:

> As a reviewer, your feedback should be focused on the idea, not the person. Seek to understand, be respectful, and focus on constructive dialog.

> As a contributor, your responsibility is to learn from suggestions and iterate your pull request should it be needed based on feedback. Seek to collaborate and produce the best possible contribution to the greater whole.

* [ ] Correct — Does the change do what it’s supposed to? ie: code 100% fulfilling the requirements?
* [ ] Secure — Would a nefarious party find some way to exploit this change? ie: everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities?
* [ ] Readable — Will your future self be able to understand this change months down the road?
* [ ] Elegant — Does the change fit aesthetically within the overall style and architecture?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Implemented internationalization support for data view components, enabling localized text and translation capabilities across the interface.

* **Chores**
  * Updated development environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->