### PR TITLE
chore: add dokan prefix rule for hooks in code review skill

### DIFF
--- a/.claude/skills/dokan-code-review/SKILL.md
+++ b/.claude/skills/dokan-code-review/SKILL.md
@@ -27,6 +27,7 @@ Review code changes against Dokan coding standards and project conventions. Cons
 -   **camelCase methods** — Must use `snake_case` for methods, variables, and hooks (WordPress convention).
 -   **Wrong namespace** — Must follow `WeDevs\Dokan\{Domain}\{Class}` pattern with matching file path.
 -   **Wrong text domain** — Must use `dokan-lite` for all translatable strings.
+-   **Missing `dokan` prefix on hooks** — All `apply_filters()` and `do_action()` hook names must start with `dokan_` (e.g., `dokan_order_created`, `dokan_vendor_updated`). Never use unprefixed or generic hook names to avoid conflicts with other plugins.
 
 **Security:**
 

--- a/.claude/skills/dokan-code-review/SKILL.md
+++ b/.claude/skills/dokan-code-review/SKILL.md
@@ -50,6 +50,7 @@ Review code changes against Dokan coding standards and project conventions. Cons
 -   **Inline styles instead of Tailwind** — Use Tailwind classes with `twMerge()` for conditional composition.
 -   **Direct state mutation** — Use `@wordpress/data` store actions, not direct state changes.
 -   **Missing hook exports** — New hooks in `src/hooks/` must be exported from `src/hooks/index.tsx`.
+-   **Missing `dokan` prefix on JS hooks** — All `@wordpress/hooks` hook names (`addFilter`, `applyFilters`, `addAction`, `doAction`) must start with `dokan_` (e.g., `dokan_order_list_columns`, `dokan_dashboard_init`). Never use unprefixed or generic hook names to avoid conflicts with other plugins.
 
 ### Testing
 


### PR DESCRIPTION
## Summary
- Added a rule to the code review skill requiring all `apply_filters()` and `do_action()` hook names to start with `dokan_`
- Prevents namespace conflicts with other plugins

## Test plan
- [ ] Verify the code review skill correctly flags hooks missing the `dokan_` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated code review guidelines: all hook names must use the `dokan_` prefix.
  * Clarified that backend PHP hooks (filters/actions) and frontend JS hooks must follow the `dokan_` prefix to prevent naming conflicts; unprefixed or generic hook names are disallowed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->