### PR TITLE
feat: add vendor earning field to order REST API response

### DIFF
--- a/includes/REST/OrderController.php
+++ b/includes/REST/OrderController.php
@@ -295,10 +295,10 @@ class OrderController extends DokanRESTController {
 
         $vendor_earning = dokan()->commission->get_earning_by_order( $object->get_id() );
 
-        if ( is_wp_error( $vendor_earning ) ) {
-            $vendor_earning = null;
+        $formatted_earning = null;
+        if ( ! is_wp_error( $vendor_earning ) && ! is_null( $vendor_earning ) ) {
+            $formatted_earning = wc_format_decimal( $vendor_earning );
         }
-        $vendor_earning = wc_format_decimal( $vendor_earning );
 
         return array(
             'id'                   => $object->get_id(),
@@ -319,7 +319,7 @@ class OrderController extends DokanRESTController {
             'shipping_tax'         => $data['shipping_tax'],
             'cart_tax'             => $data['cart_tax'],
             'total'                => $data['total'],
-            'earning'              => $vendor_earning,
+            'earning'              => $formatted_earning,
             'total_tax'            => $data['total_tax'],
             'prices_include_tax'   => $data['prices_include_tax'],
             'customer_id'          => $data['customer_id'],

--- a/includes/REST/OrderController.php
+++ b/includes/REST/OrderController.php
@@ -295,6 +295,11 @@ class OrderController extends DokanRESTController {
 
         $vendor_earning = dokan()->commission->get_earning_by_order( $object->get_id() );
 
+        if ( is_wp_error( $vendor_earning ) ) {
+            $vendor_earning = null;
+        }
+        $vendor_earning = wc_format_decimal( $vendor_earning );
+
         return array(
             'id'                   => $object->get_id(),
             'parent_id'            => $data['parent_id'],
@@ -314,7 +319,7 @@ class OrderController extends DokanRESTController {
             'shipping_tax'         => $data['shipping_tax'],
             'cart_tax'             => $data['cart_tax'],
             'total'                => $data['total'],
-            'earning'              => wc_format_decimal( $vendor_earning ),
+            'earning'              => $vendor_earning,
             'total_tax'            => $data['total_tax'],
             'prices_include_tax'   => $data['prices_include_tax'],
             'customer_id'          => $data['customer_id'],

--- a/includes/REST/OrderController.php
+++ b/includes/REST/OrderController.php
@@ -293,6 +293,8 @@ class OrderController extends DokanRESTController {
             );
         }
 
+        $vendor_earning = dokan()->commission->get_earning_by_order( $object->get_id() );
+
         return array(
             'id'                   => $object->get_id(),
             'parent_id'            => $data['parent_id'],
@@ -312,6 +314,7 @@ class OrderController extends DokanRESTController {
             'shipping_tax'         => $data['shipping_tax'],
             'cart_tax'             => $data['cart_tax'],
             'total'                => $data['total'],
+            'earning'              => wc_format_decimal( $vendor_earning ),
             'total_tax'            => $data['total_tax'],
             'prices_include_tax'   => $data['prices_include_tax'],
             'customer_id'          => $data['customer_id'],

--- a/includes/REST/OrderController.php
+++ b/includes/REST/OrderController.php
@@ -297,7 +297,7 @@ class OrderController extends DokanRESTController {
 
         $formatted_earning = null;
         if ( ! is_wp_error( $vendor_earning ) && ! is_null( $vendor_earning ) ) {
-            $formatted_earning = wc_format_decimal( $vendor_earning );
+            $formatted_earning = wc_format_decimal( $vendor_earning, '' );
         }
 
         return array(
@@ -319,7 +319,6 @@ class OrderController extends DokanRESTController {
             'shipping_tax'         => $data['shipping_tax'],
             'cart_tax'             => $data['cart_tax'],
             'total'                => $data['total'],
-            'earning'              => $formatted_earning,
             'total_tax'            => $data['total_tax'],
             'prices_include_tax'   => $data['prices_include_tax'],
             'customer_id'          => $data['customer_id'],
@@ -344,6 +343,7 @@ class OrderController extends DokanRESTController {
             'coupon_lines'         => $data['coupon_lines'],
             'refunds'              => $data['refunds'],
             'order_shipment'       => $data['order_shipment'],
+            'earning'              => $formatted_earning,
         );
     }
 
@@ -1747,6 +1747,12 @@ class OrderController extends DokanRESTController {
                     'type'        => 'boolean',
                     'default'     => false,
                     'context'     => array( 'edit' ),
+                ),
+                'earning'              => array(
+                    'description' => __( 'Vendor earning for the order.', 'dokan-lite' ),
+                    'type'        => array( 'string', 'null' ),
+                    'context'     => array( 'view' ),
+                    'readonly'    => true,
                 ),
             ),
         );


### PR DESCRIPTION
## Summary
- Adds a new `earning` field to the order REST API response that returns the vendor's earning for the order
- Uses `dokan()->commission->get_earning_by_order()` to calculate the earning and formats it with `wc_format_decimal()`

## Closes
* https://github.com/getdokan/plugin-internal-tasks/issues/1558

## Test plan
- [ ] Make a GET request to `dokan/v1/orders/{id}` as a vendor
- [ ] Verify the response contains an `earning` field with the correct decimal value
- [ ] Confirm the earning matches what is shown in the vendor dashboard for that order

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Order API responses now include a new "earning" field showing vendor earnings directly in order data.
* **Bug Fixes**
  * Earnings are now formatted consistently and safely handled when unavailable, preventing incorrect or missing values in responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->