### PR TITLE
enhance: migrate admin Withdraw table to Plugin UI DataViews

### DIFF
--- a/src/admin/dashboard/pages/withdraw/index.tsx
+++ b/src/admin/dashboard/pages/withdraw/index.tsx
@@ -9,11 +9,10 @@ import {
     SimpleInput,
 } from '@getdokan/dokan-ui';
 import { DokanTooltip as Tooltip } from '@dokan/components';
-import * as LucideIcons from 'lucide-react';
 import { dateI18n, getSettings } from '@wordpress/date';
 // Import Dokan components
 import {
-    AdminDataViews as DataViews,
+    DataViews,
     DateTimeHtml,
     VendorAsyncSelect,
     DateRangePicker,
@@ -21,7 +20,18 @@ import {
     DokanModal,
 } from '@dokan/components';
 
-import { Trash, ArrowDown, Home, Calendar, CreditCard } from 'lucide-react';
+import {
+    Trash,
+    ArrowDown,
+    Home,
+    Calendar,
+    CreditCard,
+    Eye,
+    Check,
+    XCircle,
+    MessageSquare,
+    Download,
+} from 'lucide-react';
 
 // Define withdraw statuses for tab filtering
 const WITHDRAW_STATUSES = [
@@ -269,38 +279,11 @@ const WithdrawPage = () => {
         );
     };
 
-    const getActionLabel = ( iconName, label ) => {
-        if ( ! ( iconName && label ) ) {
-            return <></>;
-        }
-
-        const Icon = LucideIcons[ iconName ];
-        return (
-            <div className="dokan-layout">
-                <span className="inline-flex items-center gap-2.5">
-                    <Icon size={ 16 } className="!fill-none" />
-                    { label }
-                </span>
-            </div>
-        );
-    };
-
-    // Define actions for table rows
     const actions = [
         {
             id: 'view',
-            label: () => getActionLabel( 'Eye', __( 'View', 'dokan-lite' ) ),
-            icon: () => {
-                return (
-                    <span
-                        className={
-                            'px-3 py-2 inline-flex items-center rounded-md text-sm font-medium border border-[#E9E9E9]'
-                        }
-                    >
-                        { __( 'View', 'dokan-lite' ) }
-                    </span>
-                );
-            },
+            label: __( 'View', 'dokan-lite' ),
+            icon: <Eye size={ 16 } className="!fill-none" />,
             isPrimary: false,
             callback: ( items ) => {
                 openModal( 'view', items );
@@ -308,19 +291,8 @@ const WithdrawPage = () => {
         },
         {
             id: 'approved',
-            label: () =>
-                getActionLabel( 'Check', __( 'Approve', 'dokan-lite' ) ),
-            icon: () => {
-                return (
-                    <span
-                        className={
-                            'px-2 py-1.5 inline-flex items-center rounded-md border border-[#E9E9E9]'
-                        }
-                    >
-                        { __( 'Approve', 'dokan-lite' ) }
-                    </span>
-                );
-            },
+            label: __( 'Approve', 'dokan-lite' ),
+            icon: <Check size={ 16 } className="!fill-none" />,
             isPrimary: false,
             supportsBulk: true,
             isEligible: ( item ) => item?.status === 'pending',
@@ -328,16 +300,17 @@ const WithdrawPage = () => {
                 const failedItems = items.filter( ( item ) => {
                     const requestedAmount = parseFloat( item?.amount ) || 0;
                     const currentBalance = parseFloat( item?.user?.balance ) || 0;
-                    
+
                     return currentBalance < requestedAmount;
                 } );
 
                 if ( failedItems.length > 0 ) {
-                    // Extract the store names and save them to state
-                    const storeNames = failedItems.map( 
-                        ( item ) => item?.user?.store_name || __( 'Unknown Vendor', 'dokan-lite' ) 
+                    const storeNames = failedItems.map(
+                        ( item ) =>
+                            item?.user?.store_name ||
+                            __( 'Unknown Vendor', 'dokan-lite' )
                     );
-                    
+
                     setInsufficientVendors( storeNames );
                     setShowInsufficientBalanceModal( true );
                     return;
@@ -348,19 +321,8 @@ const WithdrawPage = () => {
         },
         {
             id: 'cancelled',
-            label: () =>
-                getActionLabel( 'XCircle', __( 'Cancel', 'dokan-lite' ) ),
-            icon: () => {
-                return (
-                    <span
-                        className={
-                            'px-2 py-1.5 inline-flex items-center rounded-md border border-[#E9E9E9]'
-                        }
-                    >
-                        { __( 'Cancel', 'dokan-lite' ) }
-                    </span>
-                );
-            },
+            label: __( 'Cancel', 'dokan-lite' ),
+            icon: <XCircle size={ 16 } className="!fill-none" />,
             isPrimary: false,
             supportsBulk: true,
             isEligible: ( item ) => item?.status === 'pending',
@@ -370,22 +332,8 @@ const WithdrawPage = () => {
         },
         {
             id: 'add-note',
-            label: () =>
-                getActionLabel(
-                    'MessageSquare',
-                    __( 'Add Note', 'dokan-lite' )
-                ),
-            icon: () => {
-                return (
-                    <span
-                        className={
-                            'px-2 py-1.5 inline-flex items-center rounded-md border border-[#E9E9E9]'
-                        }
-                    >
-                        { __( 'Add Note', 'dokan-lite' ) }
-                    </span>
-                );
-            },
+            label: __( 'Add Note', 'dokan-lite' ),
+            icon: <MessageSquare size={ 16 } className="!fill-none" />,
             isPrimary: false,
             isEligible: ( item ) => item?.status !== 'approved',
             callback: ( items ) => {
@@ -394,19 +342,8 @@ const WithdrawPage = () => {
         },
         {
             id: 'delete',
-            label: () =>
-                getActionLabel( 'Trash', __( 'Delete', 'dokan-lite' ) ),
-            icon: () => {
-                return (
-                    <span
-                        className={
-                            'px-2 py-1.5 inline-flex items-center rounded-md border border-[#E9E9E9]'
-                        }
-                    >
-                        { __( 'Delete', 'dokan-lite' ) }
-                    </span>
-                );
-            },
+            label: __( 'Delete', 'dokan-lite' ),
+            icon: <Trash size={ 16 } className="!fill-none" />,
             supportsBulk: true,
             isEligible: ( item ) => item?.status !== 'approved',
             callback: ( items ) => {
@@ -415,25 +352,8 @@ const WithdrawPage = () => {
         },
         {
             id: 'paypal',
-            label: () =>
-                getActionLabel(
-                    'Download',
-                    __( 'Download PayPal mass payment file', 'dokan-lite' )
-                ),
-            icon: () => {
-                return (
-                    <span
-                        className={
-                            'px-2 py-1.5 inline-flex items-center rounded-md border border-[#E9E9E9]'
-                        }
-                    >
-                        { __(
-                            'Download PayPal mass payment file',
-                            'dokan-lite'
-                        ) }
-                    </span>
-                );
-            },
+            label: __( 'Download PayPal mass payment file', 'dokan-lite' ),
+            icon: <Download size={ 16 } className="!fill-none" />,
             isPrimary: false,
             supportsBulk: true,
             isEligible: ( item ) => 'paypal' === item?.method,
@@ -555,18 +475,10 @@ const WithdrawPage = () => {
         } ) );
     };
 
-    // Create tabs with status counts
-    const tabs = WITHDRAW_STATUSES.map( ( status ) => ( {
-        name: status.value,
-        icon: (
-            <div className="flex items-center gap-1.5 px-2">
-                { status.label }
-                <span className="text-xs font-light text-[#A5A5AA]">
-                    ({ statusCounts[ status.value ] })
-                </span>
-            </div>
-        ),
-        title: status.label,
+    const tabItems = WITHDRAW_STATUSES.map( ( status ) => ( {
+        value: status.value,
+        label: status.label,
+        count: statusCounts[ status.value as keyof typeof statusCounts ],
     } ) );
 
     const tabsAdditionalContents = [
@@ -1039,35 +951,40 @@ const WithdrawPage = () => {
             </h2>
 
             { /* Data Table */ }
-            <DataViews
-                data={ data }
-                namespace="withdraw-admin-data-view"
-                defaultLayouts={ defaultLayouts }
-                fields={ fields }
-                getItemId={ ( item ) => item.id }
-                onChangeView={ setView }
-                paginationInfo={ {
-                    totalItems,
-                    totalPages: Math.ceil( totalItems / view.perPage ),
-                } }
-                view={ view }
-                selection={ selection }
-                onChangeSelection={ setSelection }
-                actions={ actions }
-                isLoading={ isLoading }
-                tabs={ {
-                    tabs,
-                    onSelect: handleTabSelect,
-                    initialTabName: activeStatus,
-                    additionalComponents: tabsAdditionalContents,
-                } }
-                filter={ {
-                    fields: filterFields,
-                    onFilterRemove: ( filterId ) =>
-                        clearSingleFilter( filterId ),
-                    onReset: () => clearFilter(),
-                } }
-            />
+            <div className="dokan-admin-dashboard-datatable">
+                <DataViews
+                    data={ data }
+                    namespace="withdraw-admin-data-view"
+                    defaultLayouts={ defaultLayouts }
+                    fields={ fields }
+                    getItemId={ ( item ) => item.id }
+                    onChangeView={ setView }
+                    paginationInfo={ {
+                        totalItems,
+                        totalPages: Math.ceil( totalItems / view.perPage ),
+                    } }
+                    view={ view }
+                    selection={ selection }
+                    onChangeSelection={ setSelection }
+                    actions={ actions }
+                    isLoading={ isLoading }
+                    tabs={ {
+                        items: tabItems,
+                        onSelect: ( name ) => {
+                            setSelection( [] );
+                            handleTabSelect( name );
+                        },
+                        defaultValue: activeStatus,
+                        headerContent: tabsAdditionalContents,
+                    } }
+                    filter={ {
+                        fields: filterFields,
+                        onFilterRemove: ( filterId ) =>
+                            clearSingleFilter( filterId ),
+                        onReset: () => clearFilter(),
+                    } }
+                />
+            </div>
 
             { /* DokanModal for approve, cancel, delete actions */ }
             { modalState.isOpen && modalState.type === 'approve' && (

--- a/src/admin/dashboard/pages/withdraw/index.tsx
+++ b/src/admin/dashboard/pages/withdraw/index.tsx
@@ -18,6 +18,7 @@ import {
     DateRangePicker,
     AsyncSelect,
     DokanModal,
+    getActionLabel,
 } from '@dokan/components';
 
 import {
@@ -282,7 +283,7 @@ const WithdrawPage = () => {
     const actions = [
         {
             id: 'view',
-            label: __( 'View', 'dokan-lite' ),
+            label: () => getActionLabel( <Eye size={ 16 } className="!fill-none" />, __( 'View', 'dokan-lite' ) ),
             icon: <Eye size={ 16 } className="!fill-none" />,
             isPrimary: false,
             callback: ( items ) => {
@@ -291,7 +292,7 @@ const WithdrawPage = () => {
         },
         {
             id: 'approved',
-            label: __( 'Approve', 'dokan-lite' ),
+            label: () => getActionLabel( <Check size={ 16 } className="!fill-none" />, __( 'Approve', 'dokan-lite' ) ),
             icon: <Check size={ 16 } className="!fill-none" />,
             isPrimary: false,
             supportsBulk: true,
@@ -321,7 +322,7 @@ const WithdrawPage = () => {
         },
         {
             id: 'cancelled',
-            label: __( 'Cancel', 'dokan-lite' ),
+            label: () => getActionLabel( <XCircle size={ 16 } className="!fill-none" />, __( 'Cancel', 'dokan-lite' ) ),
             icon: <XCircle size={ 16 } className="!fill-none" />,
             isPrimary: false,
             supportsBulk: true,
@@ -332,7 +333,7 @@ const WithdrawPage = () => {
         },
         {
             id: 'add-note',
-            label: __( 'Add Note', 'dokan-lite' ),
+            label: () => getActionLabel( <MessageSquare size={ 16 } className="!fill-none" />, __( 'Add Note', 'dokan-lite' ) ),
             icon: <MessageSquare size={ 16 } className="!fill-none" />,
             isPrimary: false,
             isEligible: ( item ) => item?.status !== 'approved',
@@ -342,7 +343,7 @@ const WithdrawPage = () => {
         },
         {
             id: 'delete',
-            label: __( 'Delete', 'dokan-lite' ),
+            label: () => getActionLabel( <Trash size={ 16 } className="!fill-none" />, __( 'Delete', 'dokan-lite' ) ),
             icon: <Trash size={ 16 } className="!fill-none" />,
             supportsBulk: true,
             isEligible: ( item ) => item?.status !== 'approved',
@@ -352,7 +353,7 @@ const WithdrawPage = () => {
         },
         {
             id: 'paypal',
-            label: __( 'Download PayPal mass payment file', 'dokan-lite' ),
+            label: () => getActionLabel( <Download size={ 16 } className="!fill-none" />, __( 'Download PayPal mass payment file', 'dokan-lite' ) ),
             icon: <Download size={ 16 } className="!fill-none" />,
             isPrimary: false,
             supportsBulk: true,


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [x] I've included related pull request(s) (optional)
* [ ] I've included developer documentation (optional)
* [x] I've added proper labels to this pull request

### Changes proposed in this Pull Request:

Migrates the admin **Withdraw** list table (`dokan/src/admin/dashboard/pages/withdraw/index.tsx`) from the legacy `AdminDataViews` wrapper to the unified `DataViews` component re-exported from `@dokan/components`.

- Drops the `AdminDataViews as DataViews` alias in favour of the existing `DataViews` import.
- Moves the `activeTab` mirror state into `view.status`; deletes the duplicate effect.
- Reshapes the `tabs` prop: `{ tabs: [{ name, title, icon: <span>(count)</span> }] }` → `{ items: [{ value, label, count }] }` (counts are now a clean field).
- Moves the **Export** button (PayPal mass payment file) and the export-progress polling out of `tabs.additionalComponents` and into `tabs.headerContent`. Polling logic and `pollExportStatus` stay verbatim.
- Wraps each row + bulk action label with the shared `getActionLabel` helper so the icon keeps rendering inside the dropdown menu and the desktop bulk-action button (the underlying `@wordpress/dataviews` `MenuItemTrigger` / `ActionTrigger` only render `action.label`).
- Preserves the per-tab eligibility for "Download PayPal mass payment file" — `isEligible: ( item ) => 'paypal' === item?.method` keeps the action hidden for non-PayPal rows in Approved.
- Wraps `<DataViews>` in `<div className="dokan-admin-dashboard-datatable">` so existing SCSS keeps applying.

> Wrapper-component swap, **not a redesign** — every existing feature is preserved (status counts, filter, search, pagination, sorting, Export polling, all 6 row + bulk actions with icons).

### Related Pull Request(s)

* Parent: https://github.com/getdokan/dokan/pull/3192

### Closes

* Closes https://github.com/getdokan/plugin-internal-tasks/issues/1847

### How to test the changes in this Pull Request:

1. Build assets: `npm run build`.
2. WP Admin → Dokan → Withdraw.
3. Switch tabs (Pending / Approved / Cancelled): URL syncs, counts refresh.
4. Filter by date / vendor / payment method — filter chips render, Reset clears.
5. Open the row action menu — Approve, Cancel, Delete, Note actions all show their icons + labels.
6. Bulk-select rows — bulk-action bar shows Approve / Cancel / Delete with icons + borders.
7. On the Approved tab, click "Download PayPal mass payment file" (PayPal-method rows only) and confirm export polling kicks in and the file downloads.
8. Resize to mobile width — table collapses to list view.
9. Confirm tabs + filter + table all share a single white card.

### Changelog entry

*Migrate admin Withdraw table to Plugin UI DataViews*

Replaces the legacy `AdminDataViews` wrapper on the admin Withdraw page with the unified `DataViews` component already used by the vendor dashboard. Tab counts move into the clean `count` field, status state lives in `view.status`, and the PayPal mass-payment Export button + polling moves to `tabs.headerContent`. Row + bulk action icons are preserved through the shared `getActionLabel` helper. No behavioural changes — every existing feature (filters, search, pagination, polling, all 6 actions, per-tab action eligibility) carries over.

### Before Changes

Withdraw used the in-house `AdminDataViews` wrapper. Tabs rendered counts inside an icon JSX hack. Export button lived in `tabs.additionalComponents`. Action icons were buried inside the `label` callback.

### After Changes

Withdraw uses `DataViews` from `@wedevs/plugin-ui`. Tabs use the clean `count` field. Export button sits in `tabs.headerContent`. Row + bulk action icons render via `getActionLabel` inside the label callback so `@wordpress/dataviews` keeps showing them in the dropdown menu and the desktop bulk-action button.

### Feature Video (optional)

n/a

### PR Self Review Checklist:

* Code follows WPCS / project conventions.
* Naming matches existing patterns (`getActionLabel`, `view.status`).
* KISS: per-page diff is concentrated in the `tabs` reshape + action label wrapping; everything else is mechanical.
* DRY: shared `getActionLabel` from the parent PR avoids duplicating icon-wrapping logic.

### FOR PR REVIEWER ONLY:

* [ ] Correct — tabs, filter, search, pagination, Export polling, per-row actions, bulk actions all still work; per-tab action eligibility (PayPal-only) preserved.
* [ ] Secure — no new escaping concerns; reuses the existing withdraw REST endpoint and export job.
* [ ] Readable — diff is concentrated in the `tabs` and `actions` blocks.
* [ ] Elegant — fits cleanly into the parent branch with no shared helper duplication.