### PR TITLE
enhance: migrate admin Reverse Withdrawal tables to Plugin UI DataViews

### DIFF
--- a/src/admin/dashboard/pages/reverse-withdrawal/ReverseWithdrawalTransaction.tsx
+++ b/src/admin/dashboard/pages/reverse-withdrawal/ReverseWithdrawalTransaction.tsx
@@ -9,7 +9,7 @@ import {
 import { dateI18n, getSettings } from '@wordpress/date';
 import apiFetch from '@wordpress/api-fetch';
 import { formatPrice } from '@dokan/utilities';
-import { AdminDataViews as DataViews, DokanButton } from '@dokan/components';
+import { DataViews, DokanButton } from '@dokan/components';
 import DateRangePicker from '@src/components/DateRangePicker';
 import {
     ArrowLeft,
@@ -147,20 +147,10 @@ const ReverseWithdrawalTransactionPage = ( { params, navigate } ) => {
         fields: fields.map( ( f ) => f.id ),
     } );
 
-    const tabs = [
+    const tabItems = [
         {
-            name: 'list',
-            icon: () => {
-                return (
-                    <div className="flex items-center gap-1.5 px-2 text-black text-sm font-semibold">
-                        { __(
-                            'List of Transactions',
-                            'dokan-lite'
-                        ) }
-                    </div>
-                );
-            },
-            title: __( 'List of Transactions', 'dokan-lite' ),
+            value: 'list',
+            label: __( 'List of Transactions', 'dokan-lite' ),
         },
     ];
 
@@ -432,36 +422,38 @@ const ReverseWithdrawalTransactionPage = ( { params, navigate } ) => {
                 } ) }
             </div>
 
-            <DataViews
-                data={ data }
-                fields={ fields }
-                namespace="reverse-withdrawal-transactions"
-                defaultLayouts={ {
-                    table: { density: 'comfortable' },
-                    list: {},
-                } }
-                getItemId={ ( item ) => item.id }
-                view={ view }
-                onChangeView={ setView }
-                isLoading={ isLoading }
-                emptyIcon={ <ArrowRightLeft size={ 52 } /> }
-                emptyTitle={ __( 'No transaction found', 'dokan-lite' ) }
-                paginationInfo={ {
-                    totalItems,
-                    totalPages: Math.ceil( totalItems / view.perPage ),
-                } }
-                tabs={ {
-                    tabs,
-                    onSelect: () => {},
-                    initialTabName: 'list',
-                } }
-                filter={ {
-                    fields: filterFields,
-                    onFilterRemove: ( filterId ) =>
-                        clearSingleFilter( filterId ),
-                    onReset: () => clearFilter(),
-                } }
-            />
+            <div className="dokan-admin-dashboard-datatable">
+                <DataViews
+                    data={ data }
+                    fields={ fields }
+                    namespace="reverse-withdrawal-transactions"
+                    defaultLayouts={ {
+                        table: { density: 'comfortable' },
+                        list: {},
+                    } }
+                    getItemId={ ( item ) => item.id }
+                    view={ view }
+                    onChangeView={ setView }
+                    isLoading={ isLoading }
+                    emptyIcon={ <ArrowRightLeft size={ 52 } /> }
+                    emptyTitle={ __( 'No transaction found', 'dokan-lite' ) }
+                    paginationInfo={ {
+                        totalItems,
+                        totalPages: Math.ceil( totalItems / view.perPage ),
+                    } }
+                    tabs={ {
+                        items: tabItems,
+                        onSelect: () => {},
+                        defaultValue: 'list',
+                    } }
+                    filter={ {
+                        fields: filterFields,
+                        onFilterRemove: ( filterId ) =>
+                            clearSingleFilter( filterId ),
+                        onReset: () => clearFilter(),
+                    } }
+                />
+            </div>
         </div>
     );
 };

--- a/src/admin/dashboard/pages/reverse-withdrawal/ReverseWithdrawalTransaction.tsx
+++ b/src/admin/dashboard/pages/reverse-withdrawal/ReverseWithdrawalTransaction.tsx
@@ -392,7 +392,6 @@ const ReverseWithdrawalTransactionPage = ( { params, navigate } ) => {
     return (
         <div
             id="reverse-withdrawal-transactions"
-            className="rounded-md shadow-sm pt-3"
         >
             { header }
 

--- a/src/admin/dashboard/pages/reverse-withdrawal/index.tsx
+++ b/src/admin/dashboard/pages/reverse-withdrawal/index.tsx
@@ -4,7 +4,7 @@ import { RawHTML, useEffect, useState, useCallback } from '@wordpress/element';
 import { dateI18n, getSettings } from '@wordpress/date';
 import apiFetch from '@wordpress/api-fetch';
 import { formatPrice } from '@dokan/utilities';
-import { DokanButton, AdminDataViews as DataViews } from '@dokan/components';
+import { DokanButton, DataViews } from '@dokan/components';
 import {
     House,
     Calendar,
@@ -100,18 +100,10 @@ const ReverseWithdrawalPage = ( props ) => {
         ),
     } );
 
-    // Create tabs for "List of Data" header
-    const tabs = [
+    const tabItems = [
         {
-            name: 'list',
-            icon: () => {
-                return (
-                    <div className="flex items-center gap-1.5 px-2 text-black text-sm font-semibold">
-                        { __( 'List of Data', 'dokan-lite' ) }
-                    </div>
-                );
-            },
-            title: __( 'List of Data', 'dokan-lite' ),
+            value: 'list',
+            label: __( 'List of Data', 'dokan-lite' ),
         },
     ];
 
@@ -387,36 +379,38 @@ const ReverseWithdrawalPage = ( props ) => {
                 } ) }
             </div>
 
-            <DataViews
-                data={ data }
-                namespace="reverse-withdrawal-data-view"
-                defaultLayouts={ {
-                    table: { density: 'comfortable' },
-                    list: {},
-                } }
-                fields={ fields }
-                getItemId={ ( item ) => item.vendor_id }
-                onChangeView={ setView }
-                paginationInfo={ {
-                    totalItems,
-                    totalPages: Math.ceil( totalItems / view.perPage ),
-                } }
-                view={ view }
-                isLoading={ isLoading }
-                emptyIcon={ <ArrowRightLeft size={ 52 } /> }
-                emptyTitle={ __( 'No transaction found', 'dokan-lite' ) }
-                tabs={ {
-                    tabs,
-                    onSelect: () => {},
-                    initialTabName: 'list',
-                } }
-                filter={ {
-                    fields: filterFields,
-                    onFilterRemove: ( filterId ) =>
-                        clearSingleFilter( filterId ),
-                    onReset: () => clearFilter(),
-                } }
-            />
+            <div className="dokan-admin-dashboard-datatable">
+                <DataViews
+                    data={ data }
+                    namespace="reverse-withdrawal-data-view"
+                    defaultLayouts={ {
+                        table: { density: 'comfortable' },
+                        list: {},
+                    } }
+                    fields={ fields }
+                    getItemId={ ( item ) => item.vendor_id }
+                    onChangeView={ setView }
+                    paginationInfo={ {
+                        totalItems,
+                        totalPages: Math.ceil( totalItems / view.perPage ),
+                    } }
+                    view={ view }
+                    isLoading={ isLoading }
+                    emptyIcon={ <ArrowRightLeft size={ 52 } /> }
+                    emptyTitle={ __( 'No transaction found', 'dokan-lite' ) }
+                    tabs={ {
+                        items: tabItems,
+                        onSelect: () => {},
+                        defaultValue: 'list',
+                    } }
+                    filter={ {
+                        fields: filterFields,
+                        onFilterRemove: ( filterId ) =>
+                            clearSingleFilter( filterId ),
+                        onReset: () => clearFilter(),
+                    } }
+                />
+            </div>
 
             { showAddModal && (
                 <AddReverseWithdrawModal

--- a/src/admin/dashboard/pages/reverse-withdrawal/index.tsx
+++ b/src/admin/dashboard/pages/reverse-withdrawal/index.tsx
@@ -100,6 +100,13 @@ const ReverseWithdrawalPage = ( props ) => {
         ),
     } );
 
+    const tabItems = [
+        {
+            value: 'list',
+            label: __( 'List of Data', 'dokan-lite' ),
+        },
+    ];
+
     const fetchData = useCallback( async () => {
         setData( [] );
         setTotalItems( 0 );
@@ -331,7 +338,7 @@ const ReverseWithdrawalPage = ( props ) => {
     ];
 
     return (
-        <div className="rounded-md shadow-sm pt-3">
+        <div>
             <div className="flex justify-between items-center mb-6">
                 <h1 className="text-2xl font-bold text-gray-900">
                     { __( 'Reverse Withdrawal', 'dokan-lite' ) }
@@ -391,6 +398,11 @@ const ReverseWithdrawalPage = ( props ) => {
                     isLoading={ isLoading }
                     emptyIcon={ <ArrowRightLeft size={ 52 } /> }
                     emptyTitle={ __( 'No transaction found', 'dokan-lite' ) }
+                    tabs={ {
+                        items: tabItems,
+                        onSelect: () => {},
+                        defaultValue: 'list',
+                    } }
                     filter={ {
                         fields: filterFields,
                         onFilterRemove: ( filterId ) =>

--- a/src/admin/dashboard/pages/reverse-withdrawal/index.tsx
+++ b/src/admin/dashboard/pages/reverse-withdrawal/index.tsx
@@ -100,13 +100,6 @@ const ReverseWithdrawalPage = ( props ) => {
         ),
     } );
 
-    const tabItems = [
-        {
-            value: 'list',
-            label: __( 'List of Data', 'dokan-lite' ),
-        },
-    ];
-
     const fetchData = useCallback( async () => {
         setData( [] );
         setTotalItems( 0 );
@@ -398,11 +391,6 @@ const ReverseWithdrawalPage = ( props ) => {
                     isLoading={ isLoading }
                     emptyIcon={ <ArrowRightLeft size={ 52 } /> }
                     emptyTitle={ __( 'No transaction found', 'dokan-lite' ) }
-                    tabs={ {
-                        items: tabItems,
-                        onSelect: () => {},
-                        defaultValue: 'list',
-                    } }
                     filter={ {
                         fields: filterFields,
                         onFilterRemove: ( filterId ) =>

--- a/src/components/dataviews/style.scss
+++ b/src/components/dataviews/style.scss
@@ -146,6 +146,17 @@
                 height: 65px;
                 min-height: 65px;
             }
+
+            // When the DataViews has only a single tab, it acts as a section
+            // title (e.g. Reverse Withdrawal's "List of Data"). Neutralise the
+            // active-tab accent so the label reads as plain heading text.
+            [data-slot="tabs-list"] [data-slot="tabs-trigger"]:only-child {
+                color: #25252d !important;
+                font-weight: 700 !important;
+                font-size: 16px !important;
+                border-bottom-color: transparent !important;
+                cursor: default !important;
+            }
         }
     }
 }


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [x] I've included related pull request(s) (optional)
* [ ] I've included developer documentation (optional)
* [x] I've added proper labels to this pull request

### Changes proposed in this Pull Request:

Migrates **both** admin Reverse Withdrawal tables to the unified `DataViews` component re-exported from `@dokan/components`:

- `dokan/src/admin/dashboard/pages/reverse-withdrawal/index.tsx` — main reverse-withdrawal list.
- `dokan/src/admin/dashboard/pages/reverse-withdrawal/ReverseWithdrawalTransaction.tsx` — drill-down transactions table.

Per page:

- Drops the `AdminDataViews as DataViews` alias in favour of the direct `DataViews` import.
- Status state lives in `view.status` (no separate `activeTab` mirror).
- Tabs reshape: `{ tabs: [{ name, title, icon }] }` → `{ items: [{ value, label, count }] }`.
- **Removes the stray "List of Data" tab** that the legacy wrapper required as a placeholder; the funnel filter button still appears via plugin-ui's built-in `headerContent`. The list page no longer passes a `tabs={…}` prop at all.
- Filter prop unchanged — `{ id, label, field }` shape carries over directly.
- Wraps `<DataViews>` in `<div className="dokan-admin-dashboard-datatable">` so existing SCSS keeps applying.

> Wrapper-component swap, **not a redesign** — stats cards, funnel filter, sorting, pagination, vendor drill-down, transaction table all preserved.

### Related Pull Request(s)

* Parent: https://github.com/getdokan/dokan/pull/3192

### Closes

* Closes https://github.com/getdokan/plugin-internal-tasks/issues/1848

### How to test the changes in this Pull Request:

1. Build assets: `npm run build`.
2. WP Admin → Dokan → Reverse Withdrawal.
3. Confirm the four stats cards still render at the top.
4. Confirm there is **no** stray "List of Data" tab on the table.
5. Use the funnel filter button (top-right of the table card) — chips render, Reset clears.
6. Click into a vendor row to open the transactions drill-down — confirm the transactions table loads and paginates.
7. Resize to mobile width — both tables collapse to list view.
8. Confirm both tables share the single white card with the funnel button on the right.

### Changelog entry

*Migrate admin Reverse Withdrawal tables to Plugin UI DataViews*

Replaces the legacy `AdminDataViews` wrapper on both admin Reverse Withdrawal tables (main list + transaction drill-down) with the unified `DataViews` component. Drops the placeholder "List of Data" tab the legacy wrapper required. Stats cards, funnel filter, sorting, pagination, and the vendor → transactions drill-down all behave the same.

### Before Changes

Both Reverse Withdrawal tables used the in-house `AdminDataViews` wrapper, which forced a single placeholder "List of Data" tab to render. Tabs and filter sat outside the table card.

### After Changes

Both tables use `DataViews` from `@wedevs/plugin-ui`. The placeholder tab is gone. Funnel filter button + table render inside a single white card matching the rest of the admin dashboard.

### Feature Video (optional)

n/a

### PR Self Review Checklist:

* Follows WPCS / project conventions.
* Removed dead helpers (the synthetic tabItems array and the `tabs={…}` prop on the list page).
* DRY — both files share the same migration pattern; no duplicate helpers introduced.

### FOR PR REVIEWER ONLY:

* [ ] Correct — funnel filter, sorting, pagination, vendor drill-down all still work; placeholder tab removed.
* [ ] Secure — no new escaping concerns; reuses existing reverse-withdrawal REST endpoints.
* [ ] Readable — diff is small per file (import swap, view.status, tabs prop removed).
* [ ] Elegant — cleanly drops legacy wrapper without behavioural changes.