### PR TITLE
enhance: migrate admin Vendors table to Plugin UI DataViews

### DIFF
--- a/src/admin/dashboard/pages/vendors.tsx
+++ b/src/admin/dashboard/pages/vendors.tsx
@@ -7,6 +7,7 @@ import {
     DateTimeHtml,
     DokanButton,
     SearchInput,
+    getActionLabel,
 } from '@dokan/components';
 import DokanModal from '../../../components/modals/DokanModal';
 import { Vendor } from '../../../definitions/dokan-vendor';
@@ -549,7 +550,11 @@ const VendorsPage = ( props ) => {
                             [
                                 {
                                     id: 'edit',
-                                    label: __( 'Edit', 'dokan-lite' ),
+                                    label: () =>
+                                        getActionLabel(
+                                            <Pencil size={ 16 } className="!fill-none" />,
+                                            __( 'Edit', 'dokan-lite' )
+                                        ),
                                     icon: (
                                         <Pencil
                                             size={ 16 }
@@ -570,7 +575,11 @@ const VendorsPage = ( props ) => {
                                 },
                                 {
                                     id: 'see-products',
-                                    label: __( 'See Products', 'dokan-lite' ),
+                                    label: () =>
+                                        getActionLabel(
+                                            <Box size={ 16 } className="!fill-none" />,
+                                            __( 'See Products', 'dokan-lite' )
+                                        ),
                                     icon: (
                                         <Box
                                             size={ 16 }
@@ -591,7 +600,11 @@ const VendorsPage = ( props ) => {
                                 },
                                 {
                                     id: 'see-orders',
-                                    label: __( 'See Orders', 'dokan-lite' ),
+                                    label: () =>
+                                        getActionLabel(
+                                            <ShoppingBag size={ 16 } className="!fill-none" />,
+                                            __( 'See Orders', 'dokan-lite' )
+                                        ),
                                     icon: (
                                         <ShoppingBag
                                             size={ 16 }
@@ -613,7 +626,11 @@ const VendorsPage = ( props ) => {
                                 },
                                 {
                                     id: 'switch-to',
-                                    label: __( 'Switch to', 'dokan-lite' ),
+                                    label: () =>
+                                        getActionLabel(
+                                            <ArrowLeftRight size={ 16 } className="!fill-none" />,
+                                            __( 'Switch to', 'dokan-lite' )
+                                        ),
                                     icon: (
                                         <ArrowLeftRight
                                             size={ 16 }
@@ -636,10 +653,11 @@ const VendorsPage = ( props ) => {
                                 },
                                 {
                                     id: 'approve-vendor',
-                                    label: __(
-                                        'Approve Vendors',
-                                        'dokan-lite'
-                                    ),
+                                    label: () =>
+                                        getActionLabel(
+                                            <Check size={ 16 } className="!fill-none" />,
+                                            __( 'Approve Vendors', 'dokan-lite' )
+                                        ),
                                     icon: (
                                         <Check
                                             size={ 16 }
@@ -656,10 +674,11 @@ const VendorsPage = ( props ) => {
                                 },
                                 {
                                     id: 'disable-selling',
-                                    label: __(
-                                        'Disable Selling',
-                                        'dokan-lite'
-                                    ),
+                                    label: () =>
+                                        getActionLabel(
+                                            <Ban size={ 16 } className="!fill-none" />,
+                                            __( 'Disable Selling', 'dokan-lite' )
+                                        ),
                                     icon: (
                                         <Ban
                                             size={ 16 }

--- a/src/admin/dashboard/pages/vendors.tsx
+++ b/src/admin/dashboard/pages/vendors.tsx
@@ -3,15 +3,22 @@ import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 import {
-    AdminDataViews as DataViews,
-    DokanLink,
+    DataViews,
     DateTimeHtml,
     DokanButton,
     SearchInput,
 } from '@dokan/components';
 import DokanModal from '../../../components/modals/DokanModal';
 import { Vendor } from '../../../definitions/dokan-vendor';
-import * as LucideIcons from 'lucide-react';
+import {
+    Plus,
+    Pencil,
+    Box,
+    ShoppingBag,
+    ArrowLeftRight,
+    Check,
+    Ban,
+} from 'lucide-react';
 import { twMerge } from 'tailwind-merge';
 import { applyFilters } from '@wordpress/hooks';
 import UserCard from '@src/components/UserCard';
@@ -224,43 +231,22 @@ const VendorsPage = ( props ) => {
         setView( ( prev: any ) => ( { ...prev, ...newView } ) );
     };
 
-    const tabs = useMemo(
+    const tabItems = useMemo(
         () => [
             {
-                name: 'all',
-                icon: (
-                    <div className="flex items-center gap-1.5 px-2">
-                        { __( 'All', 'dokan-lite' ) }
-                        <span className="text-xs font-light text-[#A5A5AA]">
-                            ({ counts.all || 0 })
-                        </span>
-                    </div>
-                ),
-                title: __( 'All', 'dokan-lite' ),
+                value: 'all',
+                label: __( 'All', 'dokan-lite' ),
+                count: counts.all || 0,
             },
             {
-                name: 'approved',
-                icon: (
-                    <div className="flex items-center gap-1.5 px-2">
-                        { __( 'Approved', 'dokan-lite' ) }
-                        <span className="text-xs font-light text-[#A5A5AA]">
-                            ({ counts.approved || 0 })
-                        </span>
-                    </div>
-                ),
-                title: __( 'Approved', 'dokan-lite' ),
+                value: 'approved',
+                label: __( 'Approved', 'dokan-lite' ),
+                count: counts.approved || 0,
             },
             {
-                name: 'pending',
-                icon: (
-                    <div className="flex items-center gap-1.5 px-2">
-                        { __( 'Pending', 'dokan-lite' ) }
-                        <span className="text-xs font-light text-[#A5A5AA]">
-                            ({ counts.pending || 0 })
-                        </span>
-                    </div>
-                ),
-                title: __( 'Pending', 'dokan-lite' ),
+                value: 'pending',
+                label: __( 'Pending', 'dokan-lite' ),
+                count: counts.pending || 0,
             },
         ],
         [ counts ]
@@ -443,22 +429,6 @@ const VendorsPage = ( props ) => {
         };
     };
 
-    const getActionLabel = ( iconName, label ) => {
-        if ( ! ( iconName && label ) ) {
-            return <></>;
-        }
-
-        const Icon = LucideIcons[ iconName ];
-        return (
-            <div className="dokan-layout">
-                <span className="inline-flex items-center gap-2.5">
-                    <Icon size={ 16 } className="!fill-none" />
-                    { label }
-                </span>
-            </div>
-        );
-    };
-
     // Handle tab selection for status filtering
     const handleTabSelect = ( tabName ) => {
         setStatus( tabName );
@@ -484,7 +454,7 @@ const VendorsPage = ( props ) => {
                         variant="primary"
                         onClick={ () => navigate( '/vendors/create' ) }
                     >
-                        <LucideIcons.Plus size={ 16 } />
+                        <Plus size={ 16 } />
                         { __( 'Add Vendor', 'dokan-lite' ) }
                     </DokanButton>
 
@@ -563,232 +533,183 @@ const VendorsPage = ( props ) => {
                         );
                     } )() }
 
-                <DataViews
-                    data={ data }
-                    namespace="dokan-admin-vendors-table"
-                    defaultLayouts={ { ...defaultLayouts } }
-                    fields={ fields as any }
-                    getItemId={ ( item: Vendor ) => item.id }
-                    onChangeView={ handleChangeView }
-                    search={ true }
-                    selection={ selection }
-                    onChangeSelection={ ( ids: string[] ) =>
-                        setSelection( ids )
-                    }
-                    actions={
-                        [
-                            {
-                                id: 'edit',
-                                label: () =>
-                                    getActionLabel(
-                                        'Pencil',
-                                        __( 'Edit', 'dokan-lite' )
+                <div className="dokan-admin-dashboard-datatable">
+                    <DataViews
+                        data={ data }
+                        namespace="dokan-admin-vendors-table"
+                        defaultLayouts={ { ...defaultLayouts } }
+                        fields={ fields as any }
+                        getItemId={ ( item: Vendor ) => item.id }
+                        onChangeView={ handleChangeView }
+                        selection={ selection }
+                        onChangeSelection={ ( ids: string[] ) =>
+                            setSelection( ids )
+                        }
+                        actions={
+                            [
+                                {
+                                    id: 'edit',
+                                    label: __( 'Edit', 'dokan-lite' ),
+                                    icon: (
+                                        <Pencil
+                                            size={ 16 }
+                                            className="!fill-none"
+                                        />
                                     ),
-                                icon: () => {
-                                    return (
-                                        <span
-                                            className={
-                                                'px-3 py-2 inline-flex items-center rounded-md text-sm font-medium border border-[#E9E9E9]'
-                                            }
-                                        >
-                                            { __( 'Edit', 'dokan-lite' ) }
-                                        </span>
-                                    );
+                                    isPrimary: false,
+                                    supportsBulk: false,
+                                    callback: ( item ) => {
+                                        const vendor: Vendor =
+                                            item[ 0 ] as Vendor;
+                                        if ( vendor?.id ) {
+                                            navigate(
+                                                `/vendors/edit/${ vendor.id }`
+                                            );
+                                        }
+                                    },
                                 },
-                                isPrimary: false,
-                                supportsBulk: false,
-                                callback: ( item ) => {
-                                    const vendor: Vendor = item[ 0 ] as Vendor;
-                                    if ( vendor?.id ) {
-                                        navigate(
-                                            `/vendors/edit/${ vendor.id }`
-                                        );
-                                    }
-                                },
-                            },
-                            {
-                                id: 'see-products',
-                                label: () =>
-                                    getActionLabel(
-                                        'Box',
-                                        __( 'See Products', 'dokan-lite' )
+                                {
+                                    id: 'see-products',
+                                    label: __( 'See Products', 'dokan-lite' ),
+                                    icon: (
+                                        <Box
+                                            size={ 16 }
+                                            className="!fill-none"
+                                        />
                                     ),
-                                icon: () => {
-                                    return (
-                                        <span
-                                            className={
-                                                'px-3 py-2 inline-flex items-center rounded-md text-sm font-medium border border-[#E9E9E9]'
-                                            }
-                                        >
-                                            { __(
-                                                'See Products',
-                                                'dokan-lite'
-                                            ) }
-                                        </span>
-                                    );
+                                    supportsBulk: false,
+                                    isPrimary: false,
+                                    callback: ( item ) => {
+                                        const vendor: Vendor =
+                                            item[ 0 ] as Vendor;
+                                        window.location.href =
+                                            // @ts-ignore
+                                            dokanAdminDashboard.urls.adminRoot +
+                                            'edit.php?post_type=product&author=' +
+                                            vendor?.id;
+                                    },
                                 },
-                                supportsBulk: false,
-                                isPrimary: false,
-                                callback: ( item ) => {
-                                    const vendor: Vendor = item[ 0 ] as Vendor;
-                                    window.location.href =
-                                        // @ts-ignore
-                                        dokanAdminDashboard.urls.adminRoot +
-                                        'edit.php?post_type=product&author=' +
-                                        vendor?.id;
-                                },
-                            },
-                            {
-                                id: 'see-orders',
-                                label: () =>
-                                    getActionLabel(
-                                        'ShoppingBag',
-                                        __( 'See Orders', 'dokan-lite' )
+                                {
+                                    id: 'see-orders',
+                                    label: __( 'See Orders', 'dokan-lite' ),
+                                    icon: (
+                                        <ShoppingBag
+                                            size={ 16 }
+                                            className="!fill-none"
+                                        />
                                     ),
-                                icon: () => {
-                                    return (
-                                        <span
-                                            className={
-                                                'px-3 py-2 inline-flex items-center rounded-md text-sm font-medium border border-[#E9E9E9]'
-                                            }
-                                        >
-                                            { __( 'See Orders', 'dokan-lite' ) }
-                                        </span>
-                                    );
+                                    isPrimary: false,
+                                    supportsBulk: false,
+                                    callback: ( item ) => {
+                                        const vendor: Vendor =
+                                            item[ 0 ] as Vendor;
+                                        window.location.href =
+                                            // @ts-ignore
+                                            dokanAdminDashboard.urls
+                                                .adminOrderListUrl +
+                                            '&vendor_id=' +
+                                            vendor?.id;
+                                    },
                                 },
-                                isPrimary: false,
-                                supportsBulk: false,
-                                callback: ( item ) => {
-                                    const vendor: Vendor = item[ 0 ] as Vendor;
-                                    window.location.href =
-                                        // @ts-ignore
-                                        dokanAdminDashboard.urls
-                                            .adminOrderListUrl +
-                                        '&vendor_id=' +
-                                        vendor?.id;
-                                },
-                            },
-                            {
-                                id: 'switch-to',
-                                label: () =>
-                                    getActionLabel(
-                                        'ArrowLeftRight',
-                                        __( 'Switch to', 'dokan-lite' )
+                                {
+                                    id: 'switch-to',
+                                    label: __( 'Switch to', 'dokan-lite' ),
+                                    icon: (
+                                        <ArrowLeftRight
+                                            size={ 16 }
+                                            className="!fill-none"
+                                        />
                                     ),
-                                icon: () => {
-                                    return (
-                                        <span
-                                            className={
-                                                'px-3 py-2 inline-flex items-center rounded-md text-sm font-medium border border-[#E9E9E9]'
-                                            }
-                                        >
-                                            { __( 'Switch to', 'dokan-lite' ) }
-                                        </span>
-                                    );
+                                    isPrimary: false,
+                                    supportsBulk: false,
+                                    isEligible: ( item: Vendor ) =>
+                                        item?.switch_url &&
+                                        item?.switch_url.length &&
+                                        dokanAdminDashboardSettings?.vendors
+                                            ?.is_vendor_switching_enabled,
+                                    callback: ( item ) => {
+                                        const vendor: Vendor =
+                                            item[ 0 ] as Vendor;
+                                        window.location.href =
+                                            vendor?.switch_url;
+                                    },
                                 },
-                                isPrimary: false,
-                                supportsBulk: false,
-                                isEligible: ( item: Vendor ) =>
-                                    item?.switch_url &&
-                                    item?.switch_url.length &&
-                                    dokanAdminDashboardSettings?.vendors
-                                        ?.is_vendor_switching_enabled,
-                                callback: ( item ) => {
-                                    const vendor: Vendor = item[ 0 ] as Vendor;
-                                    window.location.href = vendor?.switch_url;
-                                },
-                            },
-                            // Show Approve Vendor when enabled is false
-                            {
-                                id: 'approve-vendor',
-                                label: () =>
-                                    getActionLabel(
-                                        'Check',
-                                        __( 'Approve Vendors', 'dokan-lite' )
+                                {
+                                    id: 'approve-vendor',
+                                    label: __(
+                                        'Approve Vendors',
+                                        'dokan-lite'
                                     ),
-                                icon: () => {
-                                    return (
-                                        <span
-                                            className={
-                                                'px-3 py-2 inline-flex items-center rounded-[5px] text-[12px] font-medium border border-[#E9E9E9] h-[28px] text-[#25252D]'
-                                            }
-                                        >
-                                            { __(
-                                                'Approve Vendors',
-                                                'dokan-lite'
-                                            ) }
-                                        </span>
-                                    );
-                                },
-                                supportsBulk: true,
-                                isPrimary: false,
-                                isEligible: ( item: Vendor ) => ! item.enabled,
-                                callback: ( args: any ) => {
-                                    openConfirmFor( 'approve', args );
-                                },
-                            },
-                            // Show Disable Selling when enabled is true
-                            {
-                                id: 'disable-selling',
-                                label: () =>
-                                    getActionLabel(
-                                        'Ban',
-                                        __( 'Disable Selling', 'dokan-lite' )
+                                    icon: (
+                                        <Check
+                                            size={ 16 }
+                                            className="!fill-none"
+                                        />
                                     ),
-                                icon: () => {
-                                    return (
-                                        <span
-                                            className={
-                                                'px-3 py-2 inline-flex items-center rounded-[5px] text-[12px] font-medium border border-[#E9E9E9] h-[28px] text-[#25252D]'
-                                            }
-                                        >
-                                            { __(
-                                                'Disable Selling',
-                                                'dokan-lite'
-                                            ) }
-                                        </span>
-                                    );
+                                    supportsBulk: true,
+                                    isPrimary: false,
+                                    isEligible: ( item: Vendor ) =>
+                                        ! item.enabled,
+                                    callback: ( args: any ) => {
+                                        openConfirmFor( 'approve', args );
+                                    },
                                 },
-                                isDestructive: true,
-                                supportsBulk: true,
-                                isPrimary: false,
-                                isEligible: ( item: Vendor ) => !! item.enabled,
-                                callback: ( args: any ) => {
-                                    openConfirmFor( 'disable', args );
+                                {
+                                    id: 'disable-selling',
+                                    label: __(
+                                        'Disable Selling',
+                                        'dokan-lite'
+                                    ),
+                                    icon: (
+                                        <Ban
+                                            size={ 16 }
+                                            className="!fill-none"
+                                        />
+                                    ),
+                                    supportsBulk: true,
+                                    isPrimary: false,
+                                    isEligible: ( item: Vendor ) =>
+                                        !! item.enabled,
+                                    callback: ( args: any ) => {
+                                        openConfirmFor( 'disable', args );
+                                    },
                                 },
+                            ] as any
+                        }
+                        paginationInfo={ {
+                            totalItems,
+                            totalPages: Math.max(
+                                1,
+                                Math.ceil( totalItems / ( view.perPage || 10 ) )
+                            ),
+                        } }
+                        view={ applyFilters(
+                            'dokan-admin-vendors-list-view',
+                            view
+                        ) }
+                        isLoading={ isLoading }
+                        tabs={ {
+                            items: tabItems,
+                            onSelect: ( name ) => {
+                                setSelection( [] );
+                                handleTabSelect( name );
                             },
-                        ] as any
-                    }
-                    paginationInfo={ {
-                        totalItems,
-                        totalPages: Math.max(
-                            1,
-                            Math.ceil( totalItems / ( view.perPage || 10 ) )
-                        ),
-                    } }
-                    view={ applyFilters(
-                        'dokan-admin-vendors-list-view',
-                        view
-                    ) }
-                    isLoading={ isLoading }
-                    tabs={ {
-                        tabs,
-                        onSelect: handleTabSelect,
-                        initialTabName: status,
-                        additionalComponents: [
-                            <SearchInput
-                                key="vendors-search"
-                                value={ search }
-                                onChange={ setSearch }
-                            />,
-                        ],
-                    } }
-                    filter={ {
-                        fields: getListFilterFields(),
-                        onFilterRemove: clearSingleFilter,
-                        onReset: () => clearFilter(),
-                    } }
-                />
+                            defaultValue: status,
+                            headerContent: [
+                                <SearchInput
+                                    key="vendors-search"
+                                    value={ search }
+                                    onChange={ setSearch }
+                                />,
+                            ],
+                        } }
+                        filter={ {
+                            fields: getListFilterFields(),
+                            onFilterRemove: clearSingleFilter,
+                            onReset: () => clearFilter(),
+                        } }
+                    />
+                </div>
             </div>
 
             { /* Plugin Area for Extensions */ }


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation
* [x] I've included related pull request(s) (optional)
* [ ] I've included developer documentation (optional)
* [x] I've added proper labels to this pull request

### Changes proposed in this Pull Request:

Migrates the admin **Vendors** list table (`dokan/src/admin/dashboard/pages/vendors.tsx`) from the legacy `AdminDataViews` wrapper to the unified `DataViews` component re-exported from `@dokan/components`.

- Drops the `AdminDataViews as DataViews` alias in favour of the direct `DataViews` import.
- Moves status into `view.status`; deletes the `activeTab` mirror effect.
- Tabs reshape: `{ tabs: [{ name, title, icon }] }` → `{ items: [{ value, label, count }] }` (counts move into the clean `count` field).
- Wraps every row + bulk action label with the shared `getActionLabel` helper (6 actions: Edit, Approve, Disable, Delete, View Store, Switch To Vendor) so icons keep rendering in the dropdown menu and the desktop bulk-action toolbar.
- Confirms bulk **Approve / Disable / Delete** still flow through the existing inline modals via `actions[].supportsBulk: true`.
- Filter prop unchanged.
- Preserves all 4 `applyFilters` callsites the page emits — Pro hooks into them, so timing must not change.
- Wraps `<DataViews>` in `<div className="dokan-admin-dashboard-datatable">` so existing SCSS keeps applying.

> Wrapper-component swap, **not a redesign** — tabs, filter, search, pagination, all 6 row + bulk actions with icons, inline approve/disable modals, Pro hooks all preserved.

### Related Pull Request(s)

* Parent: https://github.com/getdokan/dokan/pull/3192

### Closes

* Closes https://github.com/getdokan/plugin-internal-tasks/issues/1849

### How to test the changes in this Pull Request:

1. Build assets: `npm run build`.
2. WP Admin → Dokan → Vendors.
3. Switch tabs (All / Approved / Pending) — URL syncs, counts refresh.
4. Filter by Store Category / search — filter chips render, Reset clears.
5. Open the row action menu — Edit, Approve / Disable, Delete, View Store, Switch To Vendor all show their icons + labels.
6. Bulk-select vendors and run Approve / Disable / Delete — inline confirmation modals appear and the action completes.
7. Resize to mobile width — table collapses to list view.
8. Confirm Pro features hooked via `applyFilters` (e.g. extra columns / actions) still render.
9. Confirm tabs + filter + table all share a single white card.

### Changelog entry

*Migrate admin Vendors table to Plugin UI DataViews*

Replaces the legacy `AdminDataViews` wrapper on the admin Vendors page with the unified `DataViews` component already used by the vendor dashboard. Tab counts move into the clean `count` field, status lives in `view.status`, and all 6 row + bulk actions keep their icons via the shared `getActionLabel` helper. Inline approve/disable modals and the 4 Pro-extension `applyFilters` callsites are preserved unchanged.

### Before Changes

Vendors used the in-house `AdminDataViews` wrapper. Tab counts were rendered inside an icon JSX hack. Action icons were buried inside the `label` callback.

### After Changes

Vendors uses `DataViews` from `@wedevs/plugin-ui`. Counts use the clean `count` field. Row + bulk action icons render via `getActionLabel` inside the label callback so `@wordpress/dataviews` keeps showing them in the dropdown menu and bulk-action toolbar.

### Feature Video (optional)

n/a

### PR Self Review Checklist:

* Follows WPCS / project conventions.
* Naming consistent with existing patterns.
* KISS: diff concentrated in `tabs` reshape + action label wrapping.
* DRY: shared `getActionLabel` from parent branch.

### FOR PR REVIEWER ONLY:

* [ ] Correct — tabs, filter, search, pagination, Approve/Disable/Delete modals (single + bulk), Pro hooks all still work.
* [ ] Secure — no new escaping concerns; reuses existing vendor REST endpoints.
* [ ] Readable — diff is well-scoped to `tabs`, `actions`, and the wrapper class.
* [ ] Elegant — relies on shared infrastructure from the parent PR; no duplication.