### PR TITLE
fix: register WC blockUI fallback on non-WC enqueue paths

### DIFF
--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -629,6 +629,13 @@ class Assets {
             ];
         }
 
+        if ( ! wp_script_is( $jquery_blockui, 'registered' ) ) {
+            $scripts[ $jquery_blockui ] = [
+                'src'  => WC()->plugin_url() . '/assets/js/jquery-blockui/jquery.blockUI' . $suffix . '.js',
+                'deps' => [ 'jquery' ],
+            ];
+        }
+
         $components_asset_file = DOKAN_DIR . '/assets/js/components.asset.php';
         if ( file_exists( $components_asset_file ) ) {
             $components_asset = require $components_asset_file;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

`dokan-jquery-blockui` is registered in `includes/Assets.php` as a passthrough alias (`src => false`) whose only dependency is WooCommerce's `jquery-blockui` (or `wc-jquery-blockui` on WC 10.3.0+).

The WC source handle is only registered by `WC_Frontend_Scripts::register_scripts()`, which is hooked to `wp_enqueue_scripts`. Custom enqueue pipelines — most notably the seller setup wizard (`includes/Vendor/SetupWizard.php`, `includes/Admin/SetupWizard.php`) which renders at `init:9999` and calls `enqueue_scripts()` directly — never fire `wp_enqueue_scripts`, so the WC handle never gets registered.

WordPress' recursive dependency resolver (`WP_Dependencies::all_deps()`) treats an unregistered leaf as a hard failure and **silently drops** any script that depends on it. As a result, every consumer of `dokan-jquery-blockui` (current or future) is broken on those pages.

This PR adds a small conditional registration next to the existing `dompurify` fallback in `Assets::get_scripts()`: if WC's blockUI handle isn't already registered, we register it ourselves from the WC plugin asset path. Guarded by `wp_script_is($jquery_blockui, 'registered')`, so it's a no-op on every page where WC's frontend chain already loaded blockUI.

### Related Pull Request(s)

* getdokan/dokan-pro#5649 — declares `dokan-jquery-blockui` as a dep on the vendor verification script and depends on this PR for the alias to resolve.

### Closes 
* https://github.com/getdokan/plugin-internal-tasks/issues/1886

### How to test the changes in this Pull Request:

1. Make sure WooCommerce, Dokan-Lite and Dokan-Pro (with the matching Pro PR applied) are active.
2. Log in as a vendor and visit `?page=dokan-seller-setup&step=verifications`.
3. Confirm in the browser dev tools console there is **no** `Uncaught TypeError: container.block is not a function`.
4. Confirm `jquery.blockUI.min.js` is in the Network tab.
5. Upload a proof file and click submit — the form should be overlay-blocked during the request.

### Changelog entry

*Title*

`fix: Register a fallback for WooCommerce's jQuery blockUI handle so dokan-jquery-blockui resolves on custom enqueue pipelines (seller setup wizard etc.).`

Previously, on the seller setup wizard's Verifications step, the Pro vendor-verification script silently failed to enqueue because its blockUI dependency could not be resolved — the underlying WC handle was unregistered. After this change, the alias is guaranteed to resolve everywhere.

### Before Changes

`$.fn.block` was undefined on the seller setup wizard verifications step; uploading a document threw `TypeError: container.block is not a function`.

### After Changes

`jquery.blockUI.min.js` loads automatically as part of the `dokan-jquery-blockui` dep chain. Submit / upload work as expected.

### PR Self Review Checklist:

* [x] My code follows the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved script dependency management to ensure proper loading and prevent conflicts with jQuery BlockUI library.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getdokan/dokan/pull/3201?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
