### PR TITLE
feat(settings): LegacySettingsRepository for per-section dokan_* options

### DIFF
--- a/docs/superpowers/README.md
+++ b/docs/superpowers/README.md
@@ -1,0 +1,43 @@
+# `docs/superpowers/` — transient planning artifacts
+
+This directory holds **per-feature scaffolding**, not permanent developer
+documentation. The files under `plans/` and `specs/` are written before and
+during a feature's implementation to align on scope, design, and execution
+order. Once the feature ships and the relevant runtime / test code has been
+merged to `develop`, the files are **archived (deleted from the tree)** —
+the merged commits + PR descriptions + canonical user-facing docs become
+the lasting record.
+
+## Lifecycle
+
+| Phase              | Location                                            | Lifetime                                         |
+| ------------------ | --------------------------------------------------- | ------------------------------------------------ |
+| Discovery / design | `specs/<YYYY-MM-DD>-<slug>-design.md` (etc.)        | Lives on the feature branch                      |
+| Implementation     | `plans/<YYYY-MM-DD>-<slug>.md`                      | Lives on the feature branch                      |
+| Feature merged     | Files removed in a cleanup commit before the next release | Deleted — see commit history for the trail |
+
+The cleanup commit is conventionally titled
+`chore(docs): archive <feature> plan + spec` and removes the matching pair
+of files for a closed feature.
+
+## What lives where (permanent vs. transient)
+
+- **Permanent** — developer-facing reference docs that survive across
+  features:
+  - `CLAUDE.md` (root) — codebase orientation for AI / new contributors
+  - `docs/` (subdirs other than `superpowers/`) — architectural references
+  - In-code docblocks, README files, `@since` annotations
+- **Transient** — `docs/superpowers/{plans,specs}/` — pre-merge scaffolding
+  only; never depend on these from runtime code or other docs.
+
+## For reviewers
+
+If a PR touches a file under `docs/superpowers/`, it's expected to be either:
+
+1. **Add / update** — feature is in flight; the doc reflects the active
+   plan or design. Read it for context but treat it as draft.
+2. **Delete** — feature has landed; the doc is being archived. No code
+   should still reference it.
+
+Anything else (e.g. a settled-feature plan file growing new content months
+later) is a smell — flag it.

--- a/docs/superpowers/plans/2026-05-19-legacy-settings-repository.md
+++ b/docs/superpowers/plans/2026-05-19-legacy-settings-repository.md
@@ -1,0 +1,1182 @@
+# LegacySettingsRepository Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `LegacySettingsRepository` that becomes the only sanctioned read/write seam for the legacy per-section `dokan_*` wp_options, with per-section caching, read overlay via `LegacySettingsBridge`, and a write mirror to `dokan_admin_settings` via the existing `SettingsRepository`.
+
+**Architecture:** Section-aware repository wraps `get_option('dokan_<section>')` calls and composes the existing `LegacySettingsBridge` (for overlay + legacy→new key mapping) with the existing `SettingsRepository` (for the flat-option write mirror). `dokan_get_option()` becomes a thin adapter; a handful of direct `get_option`/`update_option` callers migrate.
+
+**Tech Stack:** PHP 7.4+, WordPress, PHPUnit 9.6, Brain Monkey/Mockery, League Container. Lives under `WeDevs\Dokan\Admin\Settings\Repository`.
+
+---
+
+## File Structure
+
+**New files:**
+
+- `includes/Admin/Settings/Repository/LegacySettingsRepositoryInterface.php` — contract (5 methods, section-aware).
+- `includes/Admin/Settings/Repository/LegacySettingsRepository.php` — concrete repository.
+- `tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php` — unit tests.
+
+**Modified files:**
+
+- `includes/DependencyManagement/Providers/AdminSettingsServiceProvider.php` — register the repository alongside `SettingsRepository` / `LegacySettingsBridge`.
+- `includes/functions.php` — `dokan_get_option()` delegates to the repository (with the existing container-missing fallback preserved).
+- A handful of direct `get_option('dokan_*')` / `update_option('dokan_*')` call sites in `includes/functions.php`, `includes/Rewrites.php`, `includes/Fees.php`, `includes/wc-functions.php`, `includes/wc-template.php`, `includes/store-functions.php` — migrate to the repository.
+
+**Out of scope (do not touch):**
+
+- `includes/Admin/Settings/Repository/SettingsRepository.php` and its interface.
+- `includes/Admin/Settings/Migration/LegacySettingsBridge.php` — no new methods; reuse existing `hydrate_legacy_from_new()`, `transform_legacy_payload_to_new()`, `get_mapping()`.
+- PHPCS sniffs.
+
+---
+
+## Conventions used throughout this plan
+
+- Namespace: `WeDevs\Dokan\Admin\Settings\Repository`.
+- `@since DOKAN_SINCE` on every new symbol — matches the existing files in the directory.
+- Tests extend `WeDevs\Dokan\Test\DokanTestCase` and live under `tests/php/src/...` mirroring the production namespace. `@group admin-settings` annotation.
+- Run a single PHPUnit test class with: `npm run phpunit -- --filter=LegacySettingsRepositoryTest`.
+- Each task ends with one commit. Commit subject matches existing style (`refactor(settings): …` / `feat(settings): …` / `test(settings): …`).
+- Always quote tab-indented file content exactly as it appears in the existing codebase (the provider uses tab indentation in one section — see Task 2).
+
+---
+
+## Task 1 — Create the interface
+
+**Files:**
+- Create: `includes/Admin/Settings/Repository/LegacySettingsRepositoryInterface.php`
+
+- [ ] **Step 1: Write the interface file**
+
+```php
+<?php
+
+namespace WeDevs\Dokan\Admin\Settings\Repository;
+
+/**
+ * Legacy Settings Repository contract.
+ *
+ * Single sanctioned read/write surface for the legacy per-section `dokan_*`
+ * wp_options (`dokan_general`, `dokan_selling`, `dokan_appearance`,
+ * `dokan_pages`, `dokan_privacy`, `dokan_withdraw`, …).
+ *
+ * Reads apply the new-flat overlay via {@see \WeDevs\Dokan\Admin\Settings\Migration\LegacySettingsBridge}.
+ * Writes persist to the legacy section option AND mirror mapped keys to the
+ * new flat option via {@see SettingsRepositoryInterface}.
+ *
+ * @since DOKAN_SINCE
+ */
+interface LegacySettingsRepositoryInterface {
+
+    /**
+     * Full overlay-applied view of one legacy section.
+     *
+     * @param string $section Legacy wp_option name (e.g. `dokan_general`).
+     *
+     * @return array<string,mixed>
+     */
+    public function all( string $section ): array;
+
+    /**
+     * Single-key overlay-applied read.
+     *
+     * @param string $section       Legacy wp_option name.
+     * @param string $key           Field id inside that section.
+     * @param mixed  $default_value Returned when the key is absent.
+     *
+     * @return mixed
+     */
+    public function get( string $section, string $key, $default_value = null );
+
+    /**
+     * Batch upsert: merges `$slice` into the legacy section option and
+     * mirrors mapped keys to `dokan_admin_settings`.
+     *
+     * Fires:
+     *  - `dokan_legacy_settings_pre_save` filter — subscribers may mutate `$slice`.
+     *  - `dokan_legacy_settings_changed` action — fires on non-empty diff.
+     *
+     * @param string              $section Legacy wp_option name.
+     * @param array<string,mixed> $slice
+     *
+     * @return array<string,mixed> Added/changed entries actually written.
+     */
+    public function update( string $section, array $slice ): array;
+
+    /**
+     * Full replacement of one section's payload. Returns a deletion-aware
+     * diff (removed keys appear as `null`). Mirrors mapped keys to the new
+     * flat option.
+     *
+     * @param string              $section Legacy wp_option name.
+     * @param array<string,mixed> $payload
+     *
+     * @return array<string,mixed>
+     */
+    public function replace( string $section, array $payload ): array;
+
+    /**
+     * Drop the in-request snapshot. Pass null to flush every section.
+     *
+     * @param string|null $section
+     *
+     * @return void
+     */
+    public function flush_cache( ?string $section = null ): void;
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add includes/Admin/Settings/Repository/LegacySettingsRepositoryInterface.php
+git commit -m "feat(settings): introduce LegacySettingsRepositoryInterface"
+```
+
+---
+
+## Task 2 — Skeleton class + DI registration (no logic yet)
+
+The skeleton lets us register the class and run a smoke test before writing real logic.
+
+**Files:**
+- Create: `includes/Admin/Settings/Repository/LegacySettingsRepository.php`
+- Modify: `includes/DependencyManagement/Providers/AdminSettingsServiceProvider.php` (add to `$services` list)
+- Create: `tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php`:
+
+```php
+<?php
+
+namespace WeDevs\Dokan\Test\Admin\Settings\Repository;
+
+use WeDevs\Dokan\Admin\Settings\Repository\LegacySettingsRepository;
+use WeDevs\Dokan\Admin\Settings\Repository\LegacySettingsRepositoryInterface;
+use WeDevs\Dokan\Test\DokanTestCase;
+
+/**
+ * @group admin-settings
+ */
+class LegacySettingsRepositoryTest extends DokanTestCase {
+
+    public function test_class_implements_interface(): void {
+        $repo = new LegacySettingsRepository();
+        $this->assertInstanceOf( LegacySettingsRepositoryInterface::class, $repo );
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run phpunit -- --filter=LegacySettingsRepositoryTest`
+Expected: FAIL — `Class "WeDevs\Dokan\Admin\Settings\Repository\LegacySettingsRepository" not found`
+
+- [ ] **Step 3: Write the skeleton class**
+
+Create `includes/Admin/Settings/Repository/LegacySettingsRepository.php`:
+
+```php
+<?php
+
+namespace WeDevs\Dokan\Admin\Settings\Repository;
+
+use WeDevs\Dokan\Admin\Settings\Migration\LegacySettingsBridge;
+
+/**
+ * Default legacy settings repository.
+ *
+ * Reads/writes legacy per-section `dokan_*` wp_options with overlay + mirror.
+ *
+ * @since DOKAN_SINCE
+ */
+final class LegacySettingsRepository implements LegacySettingsRepositoryInterface {
+
+    private SettingsRepositoryInterface $new_repo;
+
+    private LegacySettingsBridge $bridge;
+
+    /**
+     * Per-section in-request snapshot cache.
+     *
+     * @var array<string, array<string, mixed>>
+     */
+    private array $snapshots = [];
+
+    public function __construct(
+        ?SettingsRepositoryInterface $new_repo = null,
+        ?LegacySettingsBridge $bridge = null
+    ) {
+        $this->new_repo = $new_repo ?? new SettingsRepository();
+        $this->bridge   = $bridge ?? new LegacySettingsBridge();
+    }
+
+    public function all( string $section ): array {
+        return [];
+    }
+
+    public function get( string $section, string $key, $default_value = null ) {
+        return $default_value;
+    }
+
+    public function update( string $section, array $slice ): array {
+        return [];
+    }
+
+    public function replace( string $section, array $payload ): array {
+        return [];
+    }
+
+    public function flush_cache( ?string $section = null ): void {
+        if ( null === $section ) {
+            $this->snapshots = [];
+            return;
+        }
+        unset( $this->snapshots[ $section ] );
+    }
+}
+```
+
+- [ ] **Step 4: Register the class in the service provider**
+
+Open `includes/DependencyManagement/Providers/AdminSettingsServiceProvider.php` and add the new class to the imports and the `$services` array. The full file becomes:
+
+```php
+<?php
+
+namespace WeDevs\Dokan\DependencyManagement\Providers;
+
+use WeDevs\Dokan\Admin\Settings\Migration\BridgeBootstrap;
+use WeDevs\Dokan\Admin\Settings\Migration\LegacySettingsBridge;
+use WeDevs\Dokan\Admin\Settings\Repository\LegacySettingsRepository;
+use WeDevs\Dokan\Admin\Settings\Repository\SettingsRepository;
+use WeDevs\Dokan\Admin\Settings\Schema\SchemaValidator;
+use WeDevs\Dokan\Admin\Settings\Schema\SettingsRegistry;
+use WeDevs\Dokan\DependencyManagement\BaseServiceProvider;
+
+class AdminSettingsServiceProvider extends BaseServiceProvider {
+    /**
+     * Tag for services added to the container.
+     */
+    protected $tags = [ 'admin-settings-service' ];
+
+    /**
+     * Services to register.
+     */
+    protected $services = [
+        SettingsRegistry::class,
+        SchemaValidator::class,
+        SettingsRepository::class,
+        LegacySettingsBridge::class,
+        LegacySettingsRepository::class,
+        BridgeBootstrap::class,
+    ];
+
+	/**
+     * Register the classes.
+     */
+	public function register(): void {
+        foreach ( $this->services as $service ) {
+            $definition = $this->share_with_implements_tags( $service );
+            $this->add_tags( $definition, $this->tags );
+        }
+    }
+}
+```
+
+Note: keep the existing tab indentation on the `register()` doc-block lines exactly as shown — the file uses mixed indentation that PHPCS currently accepts.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npm run phpunit -- --filter=LegacySettingsRepositoryTest`
+Expected: PASS — 1 test.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add includes/Admin/Settings/Repository/LegacySettingsRepository.php \
+        includes/DependencyManagement/Providers/AdminSettingsServiceProvider.php \
+        tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php
+git commit -m "feat(settings): scaffold LegacySettingsRepository + DI binding"
+```
+
+---
+
+## Task 3 — Reads with per-section snapshot cache + overlay
+
+**Files:**
+- Modify: `includes/Admin/Settings/Repository/LegacySettingsRepository.php`
+- Modify: `tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php`
+
+- [ ] **Step 1: Write failing tests for read paths**
+
+Append to `LegacySettingsRepositoryTest.php` (inside the class):
+
+```php
+public function test_all_returns_empty_array_when_option_missing(): void {
+    delete_option( 'dokan_general' );
+
+    $repo = new LegacySettingsRepository();
+    $this->assertSame( [], $repo->all( 'dokan_general' ) );
+}
+
+public function test_all_returns_raw_section_when_no_overlay(): void {
+    update_option( 'dokan_general', [ 'custom_store_url' => 'shop' ] );
+    delete_option( 'dokan_admin_settings' );
+
+    $repo = new LegacySettingsRepository();
+    $this->assertSame(
+        [ 'custom_store_url' => 'shop' ],
+        $repo->all( 'dokan_general' )
+    );
+}
+
+public function test_get_returns_default_when_key_absent(): void {
+    update_option( 'dokan_general', [ 'other' => 'value' ] );
+    delete_option( 'dokan_admin_settings' );
+
+    $repo = new LegacySettingsRepository();
+    $this->assertSame( 'fallback', $repo->get( 'dokan_general', 'custom_store_url', 'fallback' ) );
+}
+
+public function test_overlay_from_new_option_wins_over_raw_section(): void {
+    update_option( 'dokan_general', [ 'custom_store_url' => 'shop' ] );
+    update_option( 'dokan_admin_settings', [ 'vendor_store_url' => 'marketplace' ] );
+
+    $repo = new LegacySettingsRepository();
+    $this->assertSame(
+        'marketplace',
+        $repo->get( 'dokan_general', 'custom_store_url' )
+    );
+}
+
+public function test_second_read_uses_in_request_cache(): void {
+    update_option( 'dokan_general', [ 'custom_store_url' => 'shop' ] );
+
+    $repo = new LegacySettingsRepository();
+    $this->assertSame( 'shop', $repo->get( 'dokan_general', 'custom_store_url' ) );
+
+    // Tamper with the option directly; repository should still serve the cached snapshot.
+    global $wpdb;
+    $wpdb->update(
+        $wpdb->options,
+        [ 'option_value' => serialize( [ 'custom_store_url' => 'TAMPERED' ] ) ],
+        [ 'option_name' => 'dokan_general' ]
+    );
+    wp_cache_delete( 'dokan_general', 'options' );
+    wp_cache_delete( 'notoptions', 'options' );
+
+    $this->assertSame( 'shop', $repo->get( 'dokan_general', 'custom_store_url' ) );
+}
+```
+
+Note: `test_overlay_from_new_option_wins_over_raw_section` relies on the schema mapping `vendor_store_url` → `dokan_general.custom_store_url` (verified at `SettingsSchema.php:165`). If that mapping ever moves, update the test fixture along with it.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm run phpunit -- --filter=LegacySettingsRepositoryTest`
+Expected: FAIL — assertions fail because `all()`/`get()` return `[]`/null defaults.
+
+- [ ] **Step 3: Implement the read path**
+
+Replace the `all()` and `get()` methods in `LegacySettingsRepository.php`:
+
+```php
+public function all( string $section ): array {
+    if ( ! array_key_exists( $section, $this->snapshots ) ) {
+        $raw = get_option( $section, [] );
+        $raw = is_array( $raw ) ? $raw : [];
+
+        $this->snapshots[ $section ] = $this->bridge->hydrate_legacy_from_new( $section, $raw );
+    }
+    return $this->snapshots[ $section ];
+}
+
+public function get( string $section, string $key, $default_value = null ) {
+    $all = $this->all( $section );
+    return array_key_exists( $key, $all ) ? $all[ $key ] : $default_value;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm run phpunit -- --filter=LegacySettingsRepositoryTest`
+Expected: PASS — 6 tests (1 from Task 2 + 5 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add includes/Admin/Settings/Repository/LegacySettingsRepository.php \
+        tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php
+git commit -m "feat(settings): legacy repo reads with per-section cache + overlay"
+```
+
+---
+
+## Task 4 — Cache invalidation on foreign writes
+
+**Files:**
+- Modify: `includes/Admin/Settings/Repository/LegacySettingsRepository.php`
+- Modify: `tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php`
+
+The repository must invalidate its snapshot when third-party code calls raw `update_option('dokan_general', …)` or when the new flat option is written outside the legacy repo.
+
+`known_sections()` derives from the bridge's mapping — collect unique `option` values from `LegacySettingsBridge::get_mapping()` (each entry is shaped `[ 'option' => 'dokan_general', 'field' => '…' ]`, verified at `LegacySettingsBridgeTest.php:48-55`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `LegacySettingsRepositoryTest.php`:
+
+```php
+public function test_foreign_legacy_write_flushes_only_that_section(): void {
+    update_option( 'dokan_general',    [ 'custom_store_url' => 'shop' ] );
+    update_option( 'dokan_appearance', [ 'store_banner_width' => 600 ] );
+
+    $repo = new LegacySettingsRepository();
+    // Warm both snapshots.
+    $repo->all( 'dokan_general' );
+    $repo->all( 'dokan_appearance' );
+
+    // Foreign write to dokan_general should trigger update_option_dokan_general.
+    update_option( 'dokan_general', [ 'custom_store_url' => 'market' ] );
+
+    $this->assertSame( 'market', $repo->get( 'dokan_general', 'custom_store_url' ) );
+    // The other section's snapshot should remain cached — tamper to verify.
+    global $wpdb;
+    $wpdb->update(
+        $wpdb->options,
+        [ 'option_value' => serialize( [ 'store_banner_width' => 9999 ] ) ],
+        [ 'option_name' => 'dokan_appearance' ]
+    );
+    wp_cache_delete( 'dokan_appearance', 'options' );
+    $this->assertSame( 600, $repo->get( 'dokan_appearance', 'store_banner_width' ) );
+}
+
+public function test_new_flat_option_write_flushes_every_section(): void {
+    update_option( 'dokan_general',    [ 'custom_store_url' => 'shop' ] );
+    update_option( 'dokan_appearance', [ 'store_banner_width' => 600 ] );
+
+    $repo = new LegacySettingsRepository();
+    $repo->all( 'dokan_general' );
+    $repo->all( 'dokan_appearance' );
+
+    update_option( 'dokan_admin_settings', [ 'vendor_store_url' => 'marketplace' ] );
+
+    // After flush, the next read should reflect the overlay from the new flat option.
+    $this->assertSame( 'marketplace', $repo->get( 'dokan_general', 'custom_store_url' ) );
+}
+
+public function test_flush_cache_null_clears_all_sections(): void {
+    update_option( 'dokan_general', [ 'custom_store_url' => 'shop' ] );
+
+    $repo = new LegacySettingsRepository();
+    $repo->all( 'dokan_general' );
+
+    $repo->flush_cache( null );
+
+    update_option( 'dokan_general', [ 'custom_store_url' => 'cleared' ] );
+    // Bypass the WP hook by re-flushing manually (the hook already flushed once but
+    // we want to assert the public method works independently of the listener).
+    $repo->flush_cache( null );
+
+    $this->assertSame( 'cleared', $repo->get( 'dokan_general', 'custom_store_url' ) );
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm run phpunit -- --filter=LegacySettingsRepositoryTest`
+Expected: FAIL — stale snapshot served after foreign write.
+
+- [ ] **Step 3: Subscribe to WP option hooks in the constructor**
+
+Replace the constructor and add a private helper in `LegacySettingsRepository.php`:
+
+```php
+public function __construct(
+    ?SettingsRepositoryInterface $new_repo = null,
+    ?LegacySettingsBridge $bridge = null
+) {
+    $this->new_repo = $new_repo ?? new SettingsRepository();
+    $this->bridge   = $bridge ?? new LegacySettingsBridge();
+
+    foreach ( $this->known_sections() as $section ) {
+        add_action( "update_option_{$section}", [ $this, 'on_section_changed' ] );
+        add_action( "add_option_{$section}",    [ $this, 'on_section_changed' ] );
+    }
+
+    // The new flat option participates in every overlay — its writes invalidate
+    // every snapshot. Use named callbacks so the same listener isn't bound twice
+    // if the repository is instantiated more than once in a request.
+    $new_option = SettingsRepository::OPTION_KEY;
+    add_action( "update_option_{$new_option}", [ $this, 'flush_all_snapshots' ] );
+    add_action( "add_option_{$new_option}",    [ $this, 'flush_all_snapshots' ] );
+}
+
+/**
+ * WP hook listener — receives `($option, …)` from add_option / `($old, $new, $option)` from update_option.
+ * We only need the option name, which we derive from the current filter name.
+ *
+ * @return void
+ */
+public function on_section_changed(): void {
+    $option = current_action();
+    foreach ( [ 'update_option_', 'add_option_' ] as $prefix ) {
+        if ( 0 === strpos( $option, $prefix ) ) {
+            $section = substr( $option, strlen( $prefix ) );
+            $this->flush_cache( $section );
+            return;
+        }
+    }
+}
+
+/**
+ * Listener for the new flat option — every section snapshot must be flushed
+ * because the overlay source changed.
+ *
+ * @return void
+ */
+public function flush_all_snapshots(): void {
+    $this->flush_cache( null );
+}
+
+/**
+ * Unique legacy wp_option names that the bridge currently knows about.
+ *
+ * @return array<int,string>
+ */
+private function known_sections(): array {
+    $map      = $this->bridge->get_mapping();
+    $sections = [];
+    foreach ( $map as $entry ) {
+        if ( is_array( $entry ) && isset( $entry['option'] ) && is_string( $entry['option'] ) ) {
+            $sections[ $entry['option'] ] = true;
+        }
+    }
+    return array_keys( $sections );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm run phpunit -- --filter=LegacySettingsRepositoryTest`
+Expected: PASS — 9 tests total.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add includes/Admin/Settings/Repository/LegacySettingsRepository.php \
+        tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php
+git commit -m "feat(settings): legacy repo cache invalidation on foreign writes"
+```
+
+---
+
+## Task 5 — Writes (legacy persist + mirror to new flat option)
+
+**Files:**
+- Modify: `includes/Admin/Settings/Repository/LegacySettingsRepository.php`
+- Modify: `tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php`
+
+Write semantics (from the spec):
+1. Compute diff against the overlay-applied view.
+2. Persist `array_merge(raw, slice)` to the legacy section option.
+3. Mirror mapped keys to `dokan_admin_settings` via `SettingsRepository::update()` — the bridge's existing `transform_legacy_payload_to_new()` does the legacy→new translation.
+4. Mirror failures are caught + logged; legacy write is not rolled back.
+5. Fire `dokan_legacy_settings_pre_save` filter and `dokan_legacy_settings_changed` action.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `LegacySettingsRepositoryTest.php`:
+
+```php
+public function test_update_persists_to_legacy_section_option(): void {
+    update_option( 'dokan_general', [ 'other' => 'preserved' ] );
+    delete_option( 'dokan_admin_settings' );
+
+    $repo    = new LegacySettingsRepository();
+    $changed = $repo->update( 'dokan_general', [ 'custom_store_url' => 'shop' ] );
+
+    $this->assertSame( [ 'custom_store_url' => 'shop' ], $changed );
+    $this->assertSame(
+        [ 'other' => 'preserved', 'custom_store_url' => 'shop' ],
+        get_option( 'dokan_general' )
+    );
+}
+
+public function test_update_mirrors_mapped_keys_to_new_flat_option(): void {
+    delete_option( 'dokan_general' );
+    delete_option( 'dokan_admin_settings' );
+
+    $repo = new LegacySettingsRepository();
+    $repo->update( 'dokan_general', [ 'custom_store_url' => 'marketplace' ] );
+
+    $new = get_option( 'dokan_admin_settings' );
+    $this->assertIsArray( $new );
+    // Schema maps vendor_store_url → dokan_general.custom_store_url (SettingsSchema.php:153-165).
+    $this->assertSame( 'marketplace', $new['vendor_store_url'] );
+}
+
+public function test_update_with_no_change_is_a_noop(): void {
+    update_option( 'dokan_general', [ 'custom_store_url' => 'shop' ] );
+
+    $repo = new LegacySettingsRepository();
+    // Warm the snapshot first so $current matches the on-disk value.
+    $repo->all( 'dokan_general' );
+
+    $changed = $repo->update( 'dokan_general', [ 'custom_store_url' => 'shop' ] );
+    $this->assertSame( [], $changed );
+}
+
+public function test_update_fires_pre_save_filter_and_changed_action(): void {
+    delete_option( 'dokan_general' );
+    delete_option( 'dokan_admin_settings' );
+
+    $filter_received = null;
+    $action_payload  = null;
+
+    add_filter(
+        'dokan_legacy_settings_pre_save',
+        static function ( $slice, $section, $current ) use ( &$filter_received ) {
+            $filter_received = [ 'slice' => $slice, 'section' => $section, 'current' => $current ];
+            return $slice;
+        },
+        10,
+        3
+    );
+
+    add_action(
+        'dokan_legacy_settings_changed',
+        static function ( $section, $changed, $before, $after ) use ( &$action_payload ) {
+            $action_payload = compact( 'section', 'changed', 'before', 'after' );
+        },
+        10,
+        4
+    );
+
+    $repo = new LegacySettingsRepository();
+    $repo->update( 'dokan_general', [ 'custom_store_url' => 'shop' ] );
+
+    $this->assertSame( 'dokan_general', $filter_received['section'] );
+    $this->assertSame( [ 'custom_store_url' => 'shop' ], $filter_received['slice'] );
+    $this->assertSame( 'dokan_general', $action_payload['section'] );
+    $this->assertSame( [ 'custom_store_url' => 'shop' ], $action_payload['changed'] );
+}
+
+public function test_pre_save_filter_can_mutate_slice(): void {
+    delete_option( 'dokan_general' );
+
+    add_filter(
+        'dokan_legacy_settings_pre_save',
+        static function ( $slice ) {
+            $slice['custom_store_url'] = 'overridden';
+            return $slice;
+        }
+    );
+
+    $repo = new LegacySettingsRepository();
+    $repo->update( 'dokan_general', [ 'custom_store_url' => 'original' ] );
+
+    $this->assertSame( 'overridden', get_option( 'dokan_general' )['custom_store_url'] );
+}
+
+public function test_update_returns_only_changed_entries(): void {
+    update_option( 'dokan_general', [
+        'custom_store_url' => 'shop',
+        'admin_access'     => 'on',
+    ] );
+
+    $repo = new LegacySettingsRepository();
+    $repo->all( 'dokan_general' );
+
+    $changed = $repo->update( 'dokan_general', [
+        'custom_store_url' => 'shop',    // unchanged
+        'admin_access'     => 'off',     // changed
+    ] );
+
+    $this->assertSame( [ 'admin_access' => 'off' ], $changed );
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm run phpunit -- --filter=LegacySettingsRepositoryTest`
+Expected: FAIL — `update()` still returns `[]`.
+
+- [ ] **Step 3: Implement `update()` and the diff helper**
+
+Replace the stub `update()` in `LegacySettingsRepository.php` and add the private `diff()` helper at the bottom of the class:
+
+```php
+public function update( string $section, array $slice ): array {
+    $current = $this->all( $section );
+
+    /**
+     * Filter the slice about to be merged into a legacy section option.
+     *
+     * Subscribers may add, remove, or normalize keys. Returning an empty
+     * array effectively blocks the write (the diff becomes empty and
+     * neither the legacy option nor the new-flat mirror is touched).
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param array<string,mixed> $slice   Incoming change set.
+     * @param string              $section Legacy wp_option name.
+     * @param array<string,mixed> $current Overlay-applied view before the write.
+     */
+    $slice = (array) apply_filters( 'dokan_legacy_settings_pre_save', $slice, $section, $current );
+
+    $changed = self::diff( $current, $slice );
+    if ( empty( $changed ) ) {
+        return [];
+    }
+
+    $raw    = get_option( $section, [] );
+    $raw    = is_array( $raw ) ? $raw : [];
+    $merged = array_merge( $raw, $slice );
+
+    update_option( $section, $merged, true );
+    // Refresh our snapshot now — the WP hook already flushed it, but we want
+    // the next read in *this* request to skip a get_option round-trip.
+    $this->snapshots[ $section ] = $this->bridge->hydrate_legacy_from_new( $section, $merged );
+
+    // Mirror mapped keys into the new flat option. Best-effort: a thrown
+    // exception from the bridge or new repo is caught and logged so the
+    // legacy write that already landed is not silently rolled back.
+    try {
+        $flat_slice = $this->bridge->transform_legacy_payload_to_new( $section, $slice );
+        if ( ! empty( $flat_slice ) ) {
+            $this->new_repo->update( $flat_slice );
+        }
+    } catch ( \Throwable $e ) {
+        if ( function_exists( 'dokan_log' ) ) {
+            dokan_log( '[LegacySettingsRepository] mirror write failed: ' . $e->getMessage() );
+        }
+    }
+
+    /**
+     * Fired after a successful write to a legacy section option.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param string              $section Legacy wp_option name.
+     * @param array<string,mixed> $changed Added/changed entries.
+     * @param array<string,mixed> $current Overlay-applied view before the write.
+     * @param array<string,mixed> $merged  Raw section payload after the write.
+     */
+    do_action( 'dokan_legacy_settings_changed', $section, $changed, $current, $merged );
+
+    return $changed;
+}
+
+/**
+ * Strict-equality diff: returns added or modified entries only.
+ *
+ * @param array<string,mixed> $old
+ * @param array<string,mixed> $new_payload
+ *
+ * @return array<string,mixed>
+ */
+private static function diff( array $old, array $new_payload ): array {
+    $out = [];
+    foreach ( $new_payload as $k => $v ) {
+        if ( ! array_key_exists( $k, $old ) || $old[ $k ] !== $v ) {
+            $out[ $k ] = $v;
+        }
+    }
+    return $out;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm run phpunit -- --filter=LegacySettingsRepositoryTest`
+Expected: PASS — 15 tests total.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add includes/Admin/Settings/Repository/LegacySettingsRepository.php \
+        tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php
+git commit -m "feat(settings): legacy repo update() with legacy persist + new-flat mirror"
+```
+
+---
+
+## Task 6 — `replace()` with deletion-aware diff
+
+**Files:**
+- Modify: `includes/Admin/Settings/Repository/LegacySettingsRepository.php`
+- Modify: `tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `LegacySettingsRepositoryTest.php`:
+
+```php
+public function test_replace_writes_payload_whole(): void {
+    update_option( 'dokan_general', [ 'a' => 1, 'b' => 2 ] );
+    delete_option( 'dokan_admin_settings' );
+
+    $repo = new LegacySettingsRepository();
+    $repo->replace( 'dokan_general', [ 'c' => 3 ] );
+
+    $this->assertSame( [ 'c' => 3 ], get_option( 'dokan_general' ) );
+}
+
+public function test_replace_returns_diff_with_removed_keys_as_null(): void {
+    update_option( 'dokan_general', [ 'a' => 1, 'b' => 2 ] );
+
+    $repo = new LegacySettingsRepository();
+    $repo->all( 'dokan_general' );
+
+    $diff = $repo->replace( 'dokan_general', [ 'a' => 1, 'c' => 3 ] );
+
+    // `b` removed, `c` added, `a` unchanged.
+    $this->assertArrayHasKey( 'b', $diff );
+    $this->assertNull( $diff['b'] );
+    $this->assertSame( 3, $diff['c'] );
+    $this->assertArrayNotHasKey( 'a', $diff );
+}
+
+public function test_replace_mirrors_mapped_keys_to_new_option(): void {
+    delete_option( 'dokan_general' );
+    delete_option( 'dokan_admin_settings' );
+
+    $repo = new LegacySettingsRepository();
+    $repo->replace( 'dokan_general', [ 'custom_store_url' => 'marketplace' ] );
+
+    $this->assertSame( 'marketplace', get_option( 'dokan_admin_settings' )['vendor_store_url'] );
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm run phpunit -- --filter=LegacySettingsRepositoryTest`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `replace()`**
+
+Replace the stub `replace()` in `LegacySettingsRepository.php`:
+
+```php
+public function replace( string $section, array $payload ): array {
+    $current = $this->all( $section );
+
+    /** This filter is documented in includes/Admin/Settings/Repository/LegacySettingsRepository.php */
+    $payload = (array) apply_filters( 'dokan_legacy_settings_pre_save', $payload, $section, $current );
+
+    $diff = self::diff( $current, $payload );
+    foreach ( $current as $k => $_ ) {
+        if ( ! array_key_exists( $k, $payload ) ) {
+            $diff[ $k ] = null;
+        }
+    }
+
+    update_option( $section, $payload, true );
+    $this->snapshots[ $section ] = $this->bridge->hydrate_legacy_from_new( $section, $payload );
+
+    try {
+        $flat_slice = $this->bridge->transform_legacy_payload_to_new( $section, $payload );
+        if ( ! empty( $flat_slice ) ) {
+            $this->new_repo->update( $flat_slice );
+        }
+    } catch ( \Throwable $e ) {
+        if ( function_exists( 'dokan_log' ) ) {
+            dokan_log( '[LegacySettingsRepository] mirror replace failed: ' . $e->getMessage() );
+        }
+    }
+
+    if ( ! empty( $diff ) ) {
+        /** This action is documented in includes/Admin/Settings/Repository/LegacySettingsRepository.php */
+        do_action( 'dokan_legacy_settings_changed', $section, $diff, $current, $payload );
+    }
+
+    return $diff;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm run phpunit -- --filter=LegacySettingsRepositoryTest`
+Expected: PASS — 18 tests total.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add includes/Admin/Settings/Repository/LegacySettingsRepository.php \
+        tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php
+git commit -m "feat(settings): legacy repo replace() with deletion-aware diff"
+```
+
+---
+
+## Task 7 — `dokan_get_option()` adapter
+
+**Files:**
+- Modify: `includes/functions.php` — function `dokan_get_option` at line 1066.
+
+The adapter delegates to the repository when the container is available. The container-missing fallback path is preserved verbatim from today's behavior.
+
+- [ ] **Step 1: Write a failing test**
+
+Append to `LegacySettingsRepositoryTest.php`:
+
+```php
+public function test_dokan_get_option_reads_through_repository(): void {
+    update_option( 'dokan_general', [ 'custom_store_url' => 'shop' ] );
+    update_option( 'dokan_admin_settings', [ 'vendor_store_url' => 'marketplace' ] );
+
+    // Flush repo cache so the next read sees the freshly-set options.
+    dokan_get_container()
+        ->get( LegacySettingsRepository::class )
+        ->flush_cache( null );
+
+    $this->assertSame( 'marketplace', dokan_get_option( 'custom_store_url', 'dokan_general' ) );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails (or passes incidentally)**
+
+Run: `npm run phpunit -- --filter=LegacySettingsRepositoryTest`
+Expected: PASS today, because `dokan_get_option()` already applies the overlay manually. We want the same observable behavior *after* the refactor — this test acts as a regression guard.
+
+- [ ] **Step 3: Refactor `dokan_get_option()` to delegate**
+
+Open `includes/functions.php` and replace the function body at line 1066. Current implementation (lines 1066–1087) inlines the overlay logic. Replace with:
+
+```php
+function dokan_get_option( $option, $section, $default_value = '' ) {
+    [ $option, $section ] = dokan_admin_settings_rearrange_map( $option, $section );
+
+    if ( function_exists( 'dokan_get_container' ) ) {
+        try {
+            return dokan_get_container()
+                ->get( \WeDevs\Dokan\Admin\Settings\Repository\LegacySettingsRepository::class )
+                ->get( $section, $option, $default_value );
+        } catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+            // Container not booted — fall back to raw legacy read (no overlay).
+        }
+    }
+
+    $options = get_option( $section );
+    $options = is_array( $options ) ? $options : [];
+
+    if ( isset( $options[ $option ] ) ) {
+        return $options[ $option ];
+    }
+
+    return $default_value;
+}
+```
+
+- [ ] **Step 4: Run the full settings test suite**
+
+Run: `npm run phpunit -- --group=admin-settings`
+Expected: PASS — the new repo test, the existing `DokanGetOptionReflectsNewSettingsTest`, `LegacySettingsBridgeTest`, etc. The existing tests prove the observable contract of `dokan_get_option()` is unchanged.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add includes/functions.php \
+        tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php
+git commit -m "refactor(settings): dokan_get_option() delegates to LegacySettingsRepository"
+```
+
+---
+
+## Task 8 — Migrate direct `get_option('dokan_*')` callers
+
+**Files:**
+- Modify: `includes/functions.php` — lines 3227 (`$pages = get_option( 'dokan_pages' );`) and 3606 (`$dokan_appearance = get_option( 'dokan_appearance', [] );`).
+
+These two direct reads bypass the overlay today (a pre-existing latent inconsistency). Routing them through the repository fixes that AND establishes the seam.
+
+- [ ] **Step 1: Inspect the call sites**
+
+Run: `grep -n "get_option( 'dokan_pages' )\|get_option( 'dokan_appearance'" includes/functions.php`
+Expected: lines 3227 and 3606.
+
+- [ ] **Step 2: Replace line 3227**
+
+Open `includes/functions.php` line 3227. Replace:
+
+```php
+    $pages = get_option( 'dokan_pages' );
+```
+
+With:
+
+```php
+    $pages = dokan_get_container()
+        ->get( \WeDevs\Dokan\Admin\Settings\Repository\LegacySettingsRepository::class )
+        ->all( 'dokan_pages' );
+```
+
+- [ ] **Step 3: Replace line 3606**
+
+Open `includes/functions.php` line 3606. Replace:
+
+```php
+    $dokan_appearance = get_option( 'dokan_appearance', [] );
+```
+
+With:
+
+```php
+    $dokan_appearance = dokan_get_container()
+        ->get( \WeDevs\Dokan\Admin\Settings\Repository\LegacySettingsRepository::class )
+        ->all( 'dokan_appearance' );
+```
+
+`all()` already coerces to array; the explicit `[]` default is no longer needed.
+
+- [ ] **Step 4: Run the full PHPUnit suite**
+
+Run: `npm run phpunit`
+Expected: PASS — no regressions. (If `npm run phpunit` is too slow, narrow to `--group=admin-settings` plus any other groups the affected functions belong to.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add includes/functions.php
+git commit -m "refactor(settings): direct get_option('dokan_*') reads go through LegacySettingsRepository"
+```
+
+---
+
+## Task 9 — Audit & migrate any direct `update_option('dokan_*')` writes
+
+**Files:**
+- Modify: any file under `includes/` that calls `update_option( 'dokan_general' | 'dokan_selling' | 'dokan_appearance' | 'dokan_pages' | 'dokan_privacy' | 'dokan_withdraw' | ... )` outside the new repository class.
+
+- [ ] **Step 1: List the direct writes**
+
+Run: `grep -rn "update_option(\s*'dokan_" includes --include="*.php" | grep -v "Admin/Settings/Repository"`
+
+Triage each match:
+
+- If the file is part of the new-side flow (e.g. `LegacySettingsBridge::write_new_to_legacy`) and already lives behind a sanctioned surface — leave it.
+- If it's an installer / migration / activation handler — leave it (these run once, outside the request cycle that needs the seam).
+- Otherwise — migrate to `dokan_get_container()->get( LegacySettingsRepository::class )->update( $section, $slice )`.
+
+- [ ] **Step 2: For each call site requiring migration, replace inline**
+
+Pattern:
+
+```php
+update_option( 'dokan_general', $merged );
+```
+
+Becomes:
+
+```php
+dokan_get_container()
+    ->get( \WeDevs\Dokan\Admin\Settings\Repository\LegacySettingsRepository::class )
+    ->update( 'dokan_general', $slice );
+```
+
+Note: pass the *slice* (the keys you intend to change), not the pre-merged array — the repository handles the merge.
+
+- [ ] **Step 3: If the audit finds no migration-eligible writes, skip the commit and proceed to Task 10**
+
+The current grep at plan-write time found `LegacySettingsBridge::write_new_to_legacy` (sanctioned) and a couple of `_dokan_aff_ref` / `dokan_rewrite_rules_needs_flashing` (not settings options) — none required migration. Re-run the grep on a fresh checkout in case the surface has changed.
+
+- [ ] **Step 4: Run the full PHPUnit suite**
+
+Run: `npm run phpunit`
+Expected: PASS.
+
+- [ ] **Step 5: Commit (only if any files changed)**
+
+```bash
+git add -p   # review hunk-by-hunk
+git commit -m "refactor(settings): direct update_option('dokan_*') writes go through LegacySettingsRepository"
+```
+
+---
+
+## Task 10 — Integration smoke test
+
+**Files:**
+- Modify: `tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php`
+
+- [ ] **Step 1: Write the integration test**
+
+Append:
+
+```php
+public function test_integration_round_trip_through_container(): void {
+    delete_option( 'dokan_general' );
+    delete_option( 'dokan_admin_settings' );
+
+    $repo = dokan_get_container()
+        ->get( \WeDevs\Dokan\Admin\Settings\Repository\LegacySettingsRepository::class );
+
+    $repo->update( 'dokan_general', [ 'custom_store_url' => 'marketplace' ] );
+
+    // Legacy storage updated.
+    $this->assertSame( 'marketplace', get_option( 'dokan_general' )['custom_store_url'] );
+    // New flat storage updated via mirror.
+    $this->assertSame( 'marketplace', get_option( 'dokan_admin_settings' )['vendor_store_url'] );
+    // dokan_get_option() resolves through the repo and sees the overlay.
+    $this->assertSame( 'marketplace', dokan_get_option( 'custom_store_url', 'dokan_general' ) );
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `npm run phpunit -- --filter=test_integration_round_trip_through_container`
+Expected: PASS.
+
+- [ ] **Step 3: Run lint + full settings group**
+
+Run:
+```
+composer phpcs -- includes/Admin/Settings/Repository
+npm run phpunit -- --group=admin-settings
+```
+Expected: PASS on both.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php
+git commit -m "test(settings): integration smoke test for LegacySettingsRepository"
+```
+
+---
+
+## Self-Review Notes
+
+**Spec coverage:**
+
+| Spec section | Plan task(s) |
+|---|---|
+| Files (interface + class) | Tasks 1, 2 |
+| Interface API | Task 1 |
+| Read path + cache | Task 3 |
+| Write path + mirror | Task 5 |
+| `replace()` | Task 6 |
+| Cache invalidation hooks | Task 4 |
+| `known_sections()` from bridge mapping | Task 4 |
+| `dokan_legacy_settings_pre_save` filter | Task 5 |
+| `dokan_legacy_settings_changed` action | Tasks 5, 6 |
+| DI wiring | Task 2 |
+| `dokan_get_option()` adapter | Task 7 |
+| Call-site migration (reads) | Task 8 |
+| Call-site migration (writes) | Task 9 |
+| Integration smoke test | Task 10 |
+| Failure mode (bridge throws → log, no propagate) | Task 5 (try/catch) — explicit test deferred (would require a bridge double; existing `Throwable` swallow is exercised path-wise by the surrounding tests). |
+
+**Plan-time spec adjustments (already noted to the user):**
+- Spec mentions a new `map_legacy_section_to_new` method on the bridge; the bridge already has `transform_legacy_payload_to_new()` doing exactly that. Plan uses the existing method — no bridge changes.
+- Spec says `known_sections()` derives from `SettingsSchema` group ids; the actual derivation is from `LegacySettingsBridge::get_mapping()` (unique `option` values) since legacy section names live in `legacy_key` strings, not schema group ids. Plan reflects this.
+
+**Type consistency:** all method signatures referenced across Tasks 1–10 match the interface in Task 1. `transform_legacy_payload_to_new`, `hydrate_legacy_from_new`, `get_mapping` are existing public methods on `LegacySettingsBridge` (verified at `LegacySettingsBridge.php:134`, `:204`, and `LegacySettingsBridgeTest.php:44`).
+
+**No placeholders.**

--- a/docs/superpowers/plans/2026-05-19-schema-coverage-prereq.md
+++ b/docs/superpowers/plans/2026-05-19-schema-coverage-prereq.md
@@ -1,0 +1,557 @@
+# Schema Coverage Prereq Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the schema coverage gap — every `dokan_get_option()` call in `includes/` has a corresponding new-flat schema element with a `legacy_key` declaration, and a PHPUnit coverage gate prevents regressions.
+
+**Architecture:** Add a PHPUnit coverage test (TDD-style red first); attach `legacy_key` to 3 existing schema elements (mechanical); design and add 18 new schema elements via an explicit triage step that the user reviews; verify all-green.
+
+**Tech Stack:** PHP 7.4+, WordPress, PHPUnit 9.6. All work lives under `includes/Admin/Settings/Schema/` and `tests/php/src/Admin/Settings/Schema/`.
+
+---
+
+## File Structure
+
+**New files:**
+
+- `tests/php/src/Admin/Settings/Schema/LegacyReadCoverageTest.php` — single PHPUnit test that scans `includes/**/*.php` for literal `dokan_get_option(<key>, <section>)` calls and asserts every pair is covered by `LegacySettingsBridge::get_mapping()`.
+- `docs/superpowers/specs/2026-05-19-schema-coverage-triage.md` — triage deliverable: per-key design decisions (new-flat id, parent section, variant, default, transformer notes) for the 18 keys that need full design. User-reviewable.
+
+**Modified files:**
+
+- `includes/Admin/Settings/Schema/SettingsSchema.php` — add `legacy_key` to 3 existing field elements; add ~18 new field elements (and possibly one new `section` element if existing sections don't naturally host them).
+
+**Not touched:**
+
+- `includes/Admin/Settings/Schema/Generated/csv_fields.php` — auto-generated, off by default. Out of scope.
+- `includes/Admin/Settings/Migration/LegacySettingsBridge.php` — already supports the `legacy_key` shape.
+- `includes/Admin/Settings/Repository/*.php` — no behavioral change.
+- Any `dokan_get_option()` call site — call sites do not change in this PR.
+
+---
+
+## Conventions
+
+- Namespace for the test: `WeDevs\Dokan\Test\Admin\Settings\Schema`.
+- Test class extends `WeDevs\Dokan\Test\DokanTestCase` and uses `@group admin-settings`.
+- `@since DOKAN_SINCE` on every new schema element field that's a brand-new addition (existing elements being augmented with `legacy_key` don't need a fresh `@since`).
+- Each commit message follows the repo convention (`feat(settings):`, `test(settings):`, `docs(settings):`, etc.).
+- Run a single PHPUnit class: `npm run phpunit -- --filter=LegacyReadCoverageTest`.
+- Run the admin-settings group: `npm run phpunit -- --group=admin-settings`.
+
+---
+
+## Task 1 — Coverage test (TDD red)
+
+**Files:**
+- Create: `tests/php/src/Admin/Settings/Schema/LegacyReadCoverageTest.php`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/php/src/Admin/Settings/Schema/LegacyReadCoverageTest.php`:
+
+```php
+<?php
+
+namespace WeDevs\Dokan\Test\Admin\Settings\Schema;
+
+use WeDevs\Dokan\Admin\Settings\Migration\LegacySettingsBridge;
+use WeDevs\Dokan\Test\DokanTestCase;
+
+/**
+ * Coverage gate: every static `dokan_get_option('<key>', '<section>')` call
+ * site in includes/ must have a corresponding `legacy_key` declaration in
+ * the schema (so the bridge's mapping table covers it).
+ *
+ * Dynamic-arg call sites (e.g. `dokan_get_option( $page, 'dokan_pages' )`)
+ * cannot be statically resolved and are intentionally skipped.
+ *
+ * @group admin-settings
+ */
+class LegacyReadCoverageTest extends DokanTestCase {
+
+    public function test_every_internal_dokan_get_option_call_has_a_legacy_key_mapping(): void {
+        $pairs    = $this->extract_static_legacy_reads();
+        $mapping  = ( new LegacySettingsBridge() )->get_mapping();
+        $mapped   = [];
+        foreach ( $mapping as $entry ) {
+            if ( is_array( $entry ) && isset( $entry['option'], $entry['field'] ) ) {
+                $mapped[ "{$entry['option']}.{$entry['field']}" ] = true;
+            }
+        }
+
+        $unmapped = [];
+        foreach ( $pairs as $pair => $files ) {
+            if ( ! isset( $mapped[ $pair ] ) ) {
+                $unmapped[ $pair ] = $files;
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $unmapped,
+            "Unmapped legacy reads (no legacy_key in schema):\n" .
+            implode(
+                "\n",
+                array_map(
+                    static fn( $pair, $files ) => "  - {$pair}  (" . implode( ', ', $files ) . ')',
+                    array_keys( $unmapped ),
+                    array_values( $unmapped )
+                )
+            )
+        );
+    }
+
+    /**
+     * Scan includes/**\/*.php for literal `dokan_get_option('<key>', '<section>')` calls.
+     *
+     * @return array<string, array<int,string>>  Map of "<section>.<key>" => list of relative file paths.
+     */
+    private function extract_static_legacy_reads(): array {
+        $root  = realpath( __DIR__ . '/../../../../../../includes' );
+        $this->assertIsString( $root, 'includes/ directory not found from test path.' );
+
+        $rii    = new \RecursiveIteratorIterator( new \RecursiveDirectoryIterator( $root ) );
+        $pairs  = [];
+        foreach ( $rii as $file ) {
+            if ( ! $file->isFile() || 'php' !== strtolower( $file->getExtension() ) ) {
+                continue;
+            }
+            $code = file_get_contents( $file->getPathname() );
+            if ( false === $code || false === strpos( $code, 'dokan_get_option' ) ) {
+                continue;
+            }
+            if ( preg_match_all(
+                "/dokan_get_option\\(\\s*'([a-z0-9_]+)'\\s*,\\s*'(dokan_[a-z0-9_]+)'/i",
+                $code,
+                $m,
+                PREG_SET_ORDER
+            ) ) {
+                $rel = ltrim( str_replace( $root, '', $file->getPathname() ), '/' );
+                foreach ( $m as $hit ) {
+                    $pair             = "{$hit[2]}.{$hit[1]}";
+                    $pairs[ $pair ][] = $rel;
+                }
+            }
+        }
+
+        // De-duplicate file lists.
+        foreach ( $pairs as $pair => $files ) {
+            $pairs[ $pair ] = array_values( array_unique( $files ) );
+        }
+        ksort( $pairs );
+        return $pairs;
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails with 21 unmapped pairs**
+
+Run: `npm run phpunit -- --filter=LegacyReadCoverageTest`
+
+Expected: FAIL. The failure message must list 21 unmapped pairs, including (verify presence; order may differ):
+- `dokan_ai.dokan_ai_image_gen_availability`
+- `dokan_appearance.captcha_enable_status`
+- `dokan_appearance.captcha_provider`
+- `dokan_appearance.default_store_banner`
+- `dokan_appearance.default_store_profile`
+- `dokan_appearance.product_sections`
+- `dokan_appearance.recaptcha_enable_status`
+- `dokan_appearance.recaptcha_secret_key`
+- `dokan_appearance.recaptcha_site_key`
+- `dokan_appearance.store_list_sort_by`
+- `dokan_appearance.store_products`
+- `dokan_appearance.vendor_layout_style`
+- `dokan_general.contact_seller`
+- `dokan_general.store_banner_flex_height`
+- `dokan_general.store_banner_flex_width`
+- `dokan_general.store_map`
+- `dokan_general.store_open_close`
+- `dokan_reverse_withdrawal.reverse_withdrawal_enabled`
+- `dokan_selling.additional_fee`
+- `dokan_selling.admin_percentage`
+
+If the count is different, **stop and report** — either the codebase has changed since the spec was written, or the regex is mis-extracting. Adjust the regex or escalate before continuing.
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add tests/php/src/Admin/Settings/Schema/LegacyReadCoverageTest.php
+git commit -m "test(settings): coverage gate for unmapped dokan_get_option reads (red)"
+```
+
+Committing the test in its red state is deliberate — subsequent commits will be observably driven by it.
+
+---
+
+## Task 2 — Attach `legacy_key` to 3 existing schema elements
+
+The following elements already exist in `SettingsSchema.php` but lack `legacy_key`. Attaching the declaration is mechanical.
+
+| Schema element id | Legacy address to declare |
+|---|---|
+| `recaptcha_site_key` | `dokan_appearance.recaptcha_site_key` |
+| `recaptcha_secret_key` | `dokan_appearance.recaptcha_secret_key` |
+| `reverse_withdrawal_enabled` | `dokan_reverse_withdrawal.reverse_withdrawal_enabled` |
+
+**Files:**
+- Modify: `includes/Admin/Settings/Schema/SettingsSchema.php`
+
+- [ ] **Step 1: Locate each existing element**
+
+Run:
+```bash
+grep -n "'id'\s*=>\s*'recaptcha_site_key'\|'id'\s*=>\s*'recaptcha_secret_key'\|'id'\s*=>\s*'reverse_withdrawal_enabled'" includes/Admin/Settings/Schema/SettingsSchema.php
+```
+
+Expected: three line numbers, one per id.
+
+- [ ] **Step 2: Add `legacy_key` to each element**
+
+For each of the three elements, add the `legacy_key` entry alongside the existing `default`, `validations`, etc. Use the array form (matches the style of the existing declarations elsewhere in `SettingsSchema.php`):
+
+For `recaptcha_site_key` and `recaptcha_secret_key` — add INSIDE the element's array (typically right after `default` or `tooltip`):
+
+```php
+'legacy_key' => [
+    'option' => 'dokan_appearance',
+    'field'  => 'recaptcha_site_key',
+],
+```
+
+(swap `'recaptcha_site_key'` → `'recaptcha_secret_key'` for the second element)
+
+For `reverse_withdrawal_enabled` — add INSIDE that element's array:
+
+```php
+'legacy_key' => [
+    'option' => 'dokan_reverse_withdrawal',
+    'field'  => 'reverse_withdrawal_enabled',
+],
+```
+
+- [ ] **Step 3: Run the coverage test — should now report 18 unmapped pairs**
+
+Run: `npm run phpunit -- --filter=LegacyReadCoverageTest`
+
+Expected: FAIL, but with 18 pairs (not 21). The three attached above must NOT appear in the failure list.
+
+- [ ] **Step 4: Run admin-settings group to confirm no regressions**
+
+Run: `npm run phpunit -- --group=admin-settings`
+
+Expected: existing tests pass (other than `LegacyReadCoverageTest` which still reports 18 unmapped). If any other test fails, the `legacy_key` attachment broke a parity assumption — investigate before continuing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add includes/Admin/Settings/Schema/SettingsSchema.php
+git commit -m "feat(settings): attach legacy_key to 3 existing schema elements (recaptcha + reverse withdrawal)"
+```
+
+---
+
+## Task 3 — Triage the 18 remaining keys (deliverable + checkpoint)
+
+The remaining 18 keys have no existing schema element. Each needs:
+1. **New-flat id** — short, descriptive, must not collide with existing schema ids.
+2. **Parent section** — which `section_id` / `subpage_id` the field attaches to (required: `field` elements must have a parent pointer).
+3. **Variant** — `text`, `switch`, `select`, `number`, `croppable_image`, etc. (see `SchemaValidator::DEFAULT_KNOWN_VARIANTS`).
+4. **Default** — must match the legacy default the call sites pass to `dokan_get_option()`.
+5. **Transformer** (rare) — only if the new-side value shape differs from legacy (e.g., boolean vs. `'on'/'off'`).
+
+**Files:**
+- Create: `docs/superpowers/specs/2026-05-19-schema-coverage-triage.md`
+
+- [ ] **Step 1: For each of the 18 keys, gather the inputs**
+
+For each pair below, run:
+
+```bash
+# Find the legacy default(s) the call sites pass — the third arg to dokan_get_option:
+grep -n "dokan_get_option(\s*'<KEY>'\s*,\s*'<SECTION>'" includes -r --include="*.php"
+
+# Check Installer.php / SetupWizard.php / Upgrade/*.php for explicit on-disk defaults:
+grep -n "'<KEY>'" includes/Install includes/Admin/SetupWizard.php includes/Upgrade -r --include="*.php"
+
+# Verify no schema element with the chosen new-flat id already exists:
+grep -n "'id'\s*=>\s*'<PROPOSED_NEW_ID>'" includes/Admin/Settings/Schema/SettingsSchema.php
+```
+
+The 18 keys to triage:
+
+```
+dokan_ai.dokan_ai_image_gen_availability
+dokan_appearance.captcha_enable_status
+dokan_appearance.captcha_provider
+dokan_appearance.default_store_banner
+dokan_appearance.default_store_profile
+dokan_appearance.product_sections
+dokan_appearance.recaptcha_enable_status
+dokan_appearance.store_list_sort_by
+dokan_appearance.store_products
+dokan_appearance.vendor_layout_style
+dokan_general.contact_seller
+dokan_general.store_banner_flex_height
+dokan_general.store_banner_flex_width
+dokan_general.store_map
+dokan_general.store_open_close
+dokan_selling.additional_fee
+dokan_selling.admin_percentage
+```
+
+(Note: `dokan_reverse_withdrawal.reverse_withdrawal_enabled` was handled in Task 2; the count above is 17 listed pairs — actual is 18 total minus 1 already-handled = 17 here. If the count is off, re-verify with: `npm run phpunit -- --filter=LegacyReadCoverageTest` and read the latest unmapped list.)
+
+- [ ] **Step 2: Write the triage document**
+
+Create `docs/superpowers/specs/2026-05-19-schema-coverage-triage.md` with this structure:
+
+```markdown
+# Schema Coverage Triage — 18 new schema elements
+
+Per-key decisions feeding Tasks 4–6 of `2026-05-19-schema-coverage-prereq.md`.
+
+## Conventions
+
+- Format: one heading per legacy pair, followed by a structured decision table.
+- Parent section refers to an existing `section_id` in `SettingsSchema.php` unless explicitly noted as "needs new section".
+- "Variant" is the rendered input control; see SchemaValidator::DEFAULT_KNOWN_VARIANTS for the allow-list.
+- "Default" must exactly match the legacy default the call sites pass to `dokan_get_option()`. If multiple call sites pass different defaults, document them all and explain the chosen one.
+
+## dokan_ai.dokan_ai_image_gen_availability
+
+| Field | Decision |
+|---|---|
+| New-flat id | `dokan_ai_image_gen_availability` |
+| Parent section_id | `<existing section>` |
+| Variant | `<variant>` |
+| Default | `<default>` |
+| Transformer | `<none / spec>` |
+| Notes | <free text> |
+
+[…repeat for all 17 remaining pairs…]
+```
+
+For each entry, fill in real values — no placeholders.
+
+**Guidance for the triage author:**
+- For appearance / general / selling keys that have well-defined neighbors in `SettingsSchema.php`, choose the same parent section.
+- For `dokan_ai_image_gen_availability`, the only call sites are in REST controllers; no existing AI section in the lite schema — proposed section: see what `dokan_ai` other fields look like; if none, the field needs a "Settings / AI" section. **Escalate** to user if a new section is needed.
+- For `captcha_*` / `recaptcha_enable_status`, peers exist in the schema (`recaptcha_site_key`, `recaptcha_secret_key`, the `recaptcha` toggle). Use the same parent.
+- For `additional_fee` and `admin_percentage`, peers exist in the commission section. Reuse them.
+
+- [ ] **Step 3: Self-review the triage document**
+
+Before committing, re-read your triage:
+- Every chosen new-flat id is unique (grep `SettingsSchema.php` for collisions).
+- Every parent section_id you reference exists in `SettingsSchema.php` (grep to verify).
+- Every variant is in `SchemaValidator::DEFAULT_KNOWN_VARIANTS`.
+- Every default matches what the call sites pass.
+
+- [ ] **Step 4: Commit the triage**
+
+```bash
+git add docs/superpowers/specs/2026-05-19-schema-coverage-triage.md
+git commit -m "docs(settings): triage decisions for 18 new schema elements"
+```
+
+- [ ] **Step 5: CHECKPOINT — pause for user review**
+
+This is a hard pause. The triage document drives all subsequent tasks. Do NOT proceed to Task 4 until the user has reviewed and approved the triage doc.
+
+Report back with:
+- Number of entries (must be 17 or 18).
+- Any keys you escalated (needs new section, ambiguous default, etc.).
+- Any keys you couldn't decide on alone.
+
+---
+
+## Task 4 — Add declarations for the `dokan_appearance.*` group
+
+Per the approved triage, add ~10 new field elements covering all `dokan_appearance.*` unmapped pairs (every entry whose pair starts with `dokan_appearance.`).
+
+**Files:**
+- Modify: `includes/Admin/Settings/Schema/SettingsSchema.php`
+
+- [ ] **Step 1: For each appearance entry in the triage, add the field element to `SettingsSchema.php`**
+
+Each element follows this shape:
+
+```php
+[
+    'id'         => '<new_flat_id>',
+    'type'       => 'field',
+    'variant'    => '<variant>',
+    'section_id' => '<parent_section_id_from_triage>',
+    'title'      => esc_html__( '<short title>', 'dokan-lite' ),
+    'default'    => <default>,
+    'legacy_key' => [
+        'option' => 'dokan_appearance',
+        'field'  => '<original_legacy_key>',
+    ],
+],
+```
+
+Add each element in the same array block as its peers (e.g., elements with the same `section_id`) to keep the schema file readable.
+
+If the triage prescribes a transformer, add the `dokan_legacy_settings_key_mapping` filter wiring per the bridge's documented pattern (see `LegacySettingsBridge.php:402` for the filter, and the `transform_legacy_payload_to_new` flow). Transformer plumbing is rare and the triage should have flagged it.
+
+- [ ] **Step 2: Run the coverage test — should now report appearance pairs as resolved**
+
+Run: `npm run phpunit -- --filter=LegacyReadCoverageTest`
+
+Expected: FAIL, but the failure message no longer lists any `dokan_appearance.*` pairs.
+
+- [ ] **Step 3: Run the schema validator + admin-settings group**
+
+Run: `npm run phpunit -- --group=admin-settings`
+
+Expected: PASS on everything except `LegacyReadCoverageTest` (still reports the remaining `dokan_general.*`, `dokan_selling.*`, `dokan_ai.*` pairs).
+
+`SchemaValidatorTest`, `SettingsSchemaTest`, `LegacySettingsBridgeTest`, and all per-tab schema tests must remain green. If any fail, the new declarations violated a schema invariant — re-check parent pointers, variant names, id uniqueness.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add includes/Admin/Settings/Schema/SettingsSchema.php
+git commit -m "feat(settings): declare schema elements for dokan_appearance.* unmapped reads"
+```
+
+---
+
+## Task 5 — Add declarations for the `dokan_general.*` group
+
+5 entries: `contact_seller`, `store_banner_flex_height`, `store_banner_flex_width`, `store_map`, `store_open_close`.
+
+**Files:**
+- Modify: `includes/Admin/Settings/Schema/SettingsSchema.php`
+
+- [ ] **Step 1: For each general entry in the triage, add the field element**
+
+Same shape as Task 4, with `'legacy_key' => [ 'option' => 'dokan_general', 'field' => '<original>' ]`.
+
+- [ ] **Step 2: Run the coverage test — should now report only `dokan_selling.*` + `dokan_ai.*`**
+
+Run: `npm run phpunit -- --filter=LegacyReadCoverageTest`
+
+Expected: FAIL with 3 remaining unmapped pairs: `dokan_selling.additional_fee`, `dokan_selling.admin_percentage`, `dokan_ai.dokan_ai_image_gen_availability`.
+
+- [ ] **Step 3: Run admin-settings group**
+
+Run: `npm run phpunit -- --group=admin-settings`
+
+Expected: PASS (except `LegacyReadCoverageTest`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add includes/Admin/Settings/Schema/SettingsSchema.php
+git commit -m "feat(settings): declare schema elements for dokan_general.* unmapped reads"
+```
+
+---
+
+## Task 6 — Add declarations for `dokan_selling.*` + `dokan_ai.*`
+
+3 entries: `additional_fee`, `admin_percentage`, `dokan_ai_image_gen_availability`.
+
+**Files:**
+- Modify: `includes/Admin/Settings/Schema/SettingsSchema.php`
+
+- [ ] **Step 1: Add the field elements per the triage**
+
+For `additional_fee` and `admin_percentage`: `'legacy_key' => [ 'option' => 'dokan_selling', 'field' => '<original>' ]`.
+
+For `dokan_ai_image_gen_availability`: `'legacy_key' => [ 'option' => 'dokan_ai', 'field' => 'dokan_ai_image_gen_availability' ]`. If the triage flagged that a new section is needed for AI, add it now per the design noted in the triage doc.
+
+- [ ] **Step 2: Run the coverage test — must now pass**
+
+Run: `npm run phpunit -- --filter=LegacyReadCoverageTest`
+
+Expected: PASS — zero unmapped pairs.
+
+If the test still fails, the failure message lists exactly which pair is still missing. Cross-check against the triage; one entry was skipped or has a typo'd `legacy_key` field name.
+
+- [ ] **Step 3: Run admin-settings group**
+
+Run: `npm run phpunit -- --group=admin-settings`
+
+Expected: PASS — all green.
+
+- [ ] **Step 4: Run PHPCS on the schema file**
+
+Run: `composer phpcs -- includes/Admin/Settings/Schema/SettingsSchema.php`
+
+Expected: 0 errors, 0 warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add includes/Admin/Settings/Schema/SettingsSchema.php
+git commit -m "feat(settings): declare schema elements for dokan_selling.* + dokan_ai.* unmapped reads"
+```
+
+---
+
+## Task 7 — Final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Coverage test green**
+
+Run: `npm run phpunit -- --filter=LegacyReadCoverageTest`
+Expected: PASS — 1 test, 1 assertion.
+
+- [ ] **Step 2: Full admin-settings group green**
+
+Run: `npm run phpunit -- --group=admin-settings`
+Expected: PASS — all tests, no failures.
+
+- [ ] **Step 3: Schema file PHPCS clean**
+
+Run: `composer phpcs -- includes/Admin/Settings/Schema/SettingsSchema.php`
+Expected: 0 errors, 0 warnings.
+
+- [ ] **Step 4: Confirm no behavioral change for `dokan_get_option()` callers**
+
+Run the existing parity test:
+```
+npm run phpunit -- --filter=DokanGetOptionReflectsNewSettingsTest
+```
+Expected: PASS. This test exercises the read-time overlay; adding `legacy_key` declarations should not change its assertions.
+
+- [ ] **Step 5: Report and stop**
+
+No commit — verification only.
+
+Report back with:
+- Coverage test result.
+- Admin-settings group result (total tests, assertions, time).
+- PHPCS result.
+- DokanGetOptionReflectsNewSettings result.
+
+---
+
+## Self-Review Notes
+
+**Spec coverage:**
+
+| Spec section | Plan task(s) |
+|---|---|
+| Discovery script / coverage check | Task 1 |
+| Per-key triage | Task 3 |
+| 21 unmapped reads → declared | Tasks 2, 4, 5, 6 |
+| PHPUnit coverage gate | Task 1 (test created) + Task 6 (passes) |
+| Dynamic call sites accepted as out-of-scope | Documented in Task 1's test docblock |
+| New-flat id naming policy | Documented in Task 3's guidance |
+| Behavioral default parity | Task 3 step 1 + Task 4–6 enforce in declarations |
+
+**Spec adjustments discovered during plan-write:**
+
+1. The spec said "per-tab files under `includes/Admin/Settings/Schema/Tab/`" — those don't exist. The hand-authored schema is one file (`SettingsSchema.php`). The auto-generated `Generated/csv_fields.php` is opt-in (gated by `dokan_csv_schema_enabled`, default off) and out of scope. Plan reflects this.
+2. The spec said all 21 keys need new schema elements. Plan-time discovery: 3 of 21 already have schema elements (`recaptcha_site_key`, `recaptcha_secret_key`, `reverse_withdrawal_enabled`); only 18 need new declarations. Task 2 attaches `legacy_key` to the existing 3; Tasks 4–6 handle the 18 via triage.
+3. Triage promoted to a deliverable with user-review checkpoint (Task 3). The spec described it as a step; the plan makes it a discrete artifact (`2026-05-19-schema-coverage-triage.md`) the user can review before any schema writes.
+
+**Type consistency:** No types/methods invented across tasks. The test uses only existing public API (`LegacySettingsBridge::get_mapping()` is verified at `LegacySettingsBridgeTest.php:44`). The schema element shape matches existing declarations in `SettingsSchema.php` (verified by inspection of `recaptcha_site_key` and `custom_store_url` neighbors).
+
+**No placeholders.**

--- a/docs/superpowers/specs/2026-05-18-legacy-settings-repository-design.md
+++ b/docs/superpowers/specs/2026-05-18-legacy-settings-repository-design.md
@@ -1,0 +1,231 @@
+# Legacy Settings Repository — Design Spec
+
+**Date:** 2026-05-18
+**Status:** Approved for planning
+**Scope:** Backend (PHP) only
+
+## Goal
+
+Provide a single read/write seam for the legacy per-section `dokan_*` wp_options (`dokan_general`, `dokan_selling`, `dokan_appearance`, `dokan_pages`, `dokan_privacy`, `dokan_withdraw`, …) so all settings access flows through a repository.
+
+**Primary motivation:** testability and per-request caching. Not a migration step, not an enforcement project, not a deletion of the legacy bridge.
+
+## Non-goals
+
+- Does not modify `SettingsRepository` (owner of `dokan_admin_settings`).
+- Does not delete or restructure `LegacySettingsBridge`.
+- Does not add a PHPCS sniff to forbid raw legacy writes (follow-up after call-site migration).
+- Does not change schema, validation, or REST behavior.
+- Does not collapse legacy per-section storage into the flat option.
+
+## Architecture
+
+```
+                    ┌──────────────────────────────┐
+   callers ───────► │ LegacySettingsRepository     │
+                    │  (per-section reads/writes)  │
+                    └──────┬────────────────┬──────┘
+                           │                │
+            read overlay   │                │ write mirror
+            + l→n map      ▼                ▼
+                  ┌──────────────────┐  ┌────────────────────┐
+                  │ LegacySettings   │  │ SettingsRepository │
+                  │ Bridge           │  │ (dokan_admin_      │
+                  │                  │  │  settings)         │
+                  └──────────────────┘  └────────────────────┘
+                           │
+                  ┌────────▼─────────┐
+                  │ get_option(      │
+                  │  'dokan_<sec>')  │
+                  └──────────────────┘
+```
+
+**Ownership:**
+
+| Concern | Owner |
+|---|---|
+| Per-section legacy storage reads/writes | `LegacySettingsRepository` |
+| Flat `dokan_admin_settings` storage | `SettingsRepository` (unchanged) |
+| Legacy ↔ new key mapping | `LegacySettingsBridge` (unchanged + one new public method) |
+| Schema, validation | `SettingsSchema` / `SchemaValidator` (unchanged) |
+
+## Files
+
+- `includes/Admin/Settings/Repository/LegacySettingsRepositoryInterface.php` (new)
+- `includes/Admin/Settings/Repository/LegacySettingsRepository.php` (new)
+- `includes/Admin/Settings/Migration/LegacySettingsBridge.php` (one new public method: `map_legacy_section_to_new`)
+- `includes/DependencyManagement/ServiceProvider.php` (one new binding)
+- `includes/functions.php` (`dokan_get_option` becomes a thin adapter)
+- A handful of direct `get_option('dokan_*')` / `update_option('dokan_*')` callers in `functions.php`, `Rewrites.php`, `Fees.php`, `wc-functions.php`, `wc-template.php`, `store-functions.php` migrate to the repository.
+
+## Interface
+
+```php
+namespace WeDevs\Dokan\Admin\Settings\Repository;
+
+interface LegacySettingsRepositoryInterface {
+    public function all( string $section ): array;
+    public function get( string $section, string $key, $default_value = null );
+    public function update( string $section, array $slice ): array;
+    public function replace( string $section, array $payload ): array;
+    public function flush_cache( ?string $section = null ): void;
+}
+```
+
+**Notes:**
+- Section-aware throughout. Parameter order is `(section, key, default)` — `dokan_get_option()` adapts from its public `(option, section, default)` order.
+- `update()` returns added/changed entries (matches `SettingsRepository::update()`).
+- `replace()` returns a deletion-aware diff (removed keys appear as `null`).
+- No `set()` convenience — callers use `update($section, [ $key => $value ])`.
+
+## Read path
+
+```
+get($section, $key, $default):
+  return all($section)[$key] ?? $default
+
+all($section):
+  if (!isset($snapshots[$section])):
+    $raw = get_option($section, []);
+    $raw = is_array($raw) ? $raw : [];
+    $snapshots[$section] = $bridge->hydrate_legacy_from_new($section, $raw);
+  return $snapshots[$section];
+```
+
+**Overlay semantics:** identical to today's `dokan_get_option()` — the new flat option wins over the raw section value. The refactor centralizes this; it does not change semantics.
+
+**Cache shape:** `array<string, array<string, mixed>> $snapshots` keyed by section name.
+
+## Write path
+
+```
+update($section, $slice):
+  $current = $this->all($section);                            // overlay-applied
+  $slice   = apply_filters('dokan_legacy_settings_pre_save', $slice, $section, $current);
+  $changed = self::diff($current, $slice);
+  if (empty($changed)) return [];
+
+  // 1. Legacy storage write
+  $raw     = get_option($section, []);
+  $raw     = is_array($raw) ? $raw : [];
+  $merged  = array_merge($raw, $slice);
+  update_option($section, $merged, true);
+  $this->snapshots[$section] = $bridge->hydrate_legacy_from_new($section, $merged);
+
+  // 2. Mirror mapped keys to dokan_admin_settings
+  try {
+      $flat_slice = $bridge->map_legacy_section_to_new($section, $slice);
+      if (!empty($flat_slice)) {
+          $new_repo->update($flat_slice);
+      }
+  } catch (\Throwable $e) {
+      dokan_log('[LegacySettingsRepository] mirror write failed: ' . $e->getMessage());
+  }
+
+  do_action('dokan_legacy_settings_changed', $section, $changed, $current, $merged);
+  return $changed;
+```
+
+`replace()` follows the same shape, writes `$payload` whole, and computes a deletion-aware diff.
+
+**Why both writes:** legacy-only writes are silently shadowed by the overlay; mirror-only writes leave the legacy section option stale for any third-party code still reading it directly. Both keeps the two stores coherent; the new flat option remains source-of-truth for the overlay.
+
+**Failure mode:** if the bridge mapping throws, the legacy write has already landed. The mirror call is caught + logged; the read overlay reconciles on the next access once the new option catches up. No exception propagates to the caller.
+
+## Cache invalidation
+
+Constructor subscribes:
+
+- For each section in `known_sections()`: `update_option_<section>` and `add_option_<section>` → flush that section's snapshot.
+- `update_option_dokan_admin_settings` and `add_option_dokan_admin_settings` → flush **all** section snapshots (the overlay source changed).
+
+`flush_cache(null)` clears every section.
+
+**`known_sections()` source:** derived from `SettingsSchema` group ids. Single source of truth, no hardcoded list.
+
+**Known gap (accepted):** sections added at runtime via the `dokan_settings_sections` filter *after* the repository constructs will not get cache-invalidation listeners. Documented in the class docblock. Callers using late-bound custom sections are responsible for calling `flush_cache($section)` themselves if they bypass the repository for writes.
+
+## Hooks introduced
+
+| Hook | Type | Signature |
+|---|---|---|
+| `dokan_legacy_settings_pre_save` | filter | `( array $slice, string $section, array $current )` |
+| `dokan_legacy_settings_changed` | action | `( string $section, array $changed, array $current, array $merged )` |
+
+## DI wiring
+
+```php
+// ServiceProvider
+$this->getContainer()->add(
+    LegacySettingsRepositoryInterface::class,
+    LegacySettingsRepository::class
+)->addArgument(SettingsRepositoryInterface::class)
+ ->addArgument(LegacySettingsBridge::class);
+```
+
+Exposed via the magic getter as `dokan()->legacy_settings`.
+
+## `dokan_get_option()` adapter
+
+```php
+function dokan_get_option( $option, $section, $default_value = '' ) {
+    [ $option, $section ] = dokan_admin_settings_rearrange_map( $option, $section );
+
+    if ( function_exists( 'dokan_get_container' ) ) {
+        try {
+            return dokan_get_container()
+                ->get( LegacySettingsRepositoryInterface::class )
+                ->get( $section, $option, $default_value );
+        } catch ( \Throwable $e ) {
+            // Container not booted — fall through to raw read.
+        }
+    }
+
+    $options = get_option( $section );
+    $options = is_array( $options ) ? $options : [];
+    return $options[ $option ] ?? $default_value;
+}
+```
+
+The container-missing fallback preserves the current early-boot safety net (no overlay, no cache — same as today's fallback path).
+
+## Call-site migration
+
+- Direct `get_option('dokan_*')` reads in `functions.php` (lines 3227, 3606, etc.) migrate to `dokan()->legacy_settings->all($section)` — they pick up the overlay for free (currently they don't, which is a latent inconsistency this fixes).
+- Direct `update_option('dokan_*', …)` writes migrate to `dokan()->legacy_settings->update($section, $slice)`.
+
+## Testing
+
+Unit tests at `tests/php/Admin/Settings/Repository/LegacySettingsRepositoryTest.php`:
+
+1. Read — raw section, no new-flat value.
+2. Read — overlay wins.
+3. Read cache — repeat `get()` hits `get_option` once.
+4. Write — legacy section option persisted.
+5. Write — mirror fires with bridge-mapped flat slice.
+6. Write — empty diff is a no-op (zero `update_option` calls).
+7. Write — bridge mapping throws → legacy write lands, mirror swallowed + logged, no exception.
+8. `replace()` returns deletion-aware diff.
+9. Cache invalidation — foreign legacy write flushes only that section.
+10. Cache invalidation — `update_option_dokan_admin_settings` flushes all sections.
+11. `flush_cache(null)` clears every section.
+12. Filter `dokan_legacy_settings_pre_save` can mutate the slice.
+13. Action `dokan_legacy_settings_changed` fires with `(section, changed, before, after)`.
+
+One integration smoke test under wp-env: round-trip a write through `dokan()->legacy_settings->update(...)` and assert both `get_option('dokan_general')` and `get_option('dokan_admin_settings')` reflect the change.
+
+## Risks
+
+1. **Early-boot calls** — covered by the container-missing fallback in the adapter.
+2. **Late-bound sections via filter** — accepted gap, documented.
+3. **Write amplification** — every legacy write triggers two `update_option` calls. Settings writes are rare; acceptable.
+4. **WP option hook timing** — listeners only flush the in-request snapshot; next read picks up the fresh value. Safe.
+
+## Rollout
+
+One PR, no feature flag (read overlay already exists; write mirror is additive):
+
+1. Add interface, class, DI binding, unit tests.
+2. Flip `dokan_get_option()` to delegate.
+3. Migrate the handful of direct `get_option('dokan_*')` / `update_option('dokan_*')` callers.
+4. Run PHPUnit + Playwright smoke.

--- a/docs/superpowers/specs/2026-05-19-schema-coverage-prereq-design.md
+++ b/docs/superpowers/specs/2026-05-19-schema-coverage-prereq-design.md
@@ -1,0 +1,157 @@
+# Schema Coverage Prereq — Design Spec
+
+**Date:** 2026-05-19
+**Status:** Approved for planning
+**Scope:** Backend (PHP) — settings schema additions + one PHPUnit coverage gate
+
+## Goal
+
+Make the admin settings schema authoritative for every legacy `(option, key)` pair that `dokan-lite`'s own code reads via `dokan_get_option()`. Concretely: every call site in `includes/` that reads from a legacy section option (`dokan_general`, `dokan_appearance`, `dokan_selling`, …) must have a corresponding new-flat schema element with a `legacy_key` declaration pointing back to that legacy address.
+
+This is the prerequisite phase before the broader "migrate consumers to `dokan()->settings`" PR (PR-2, future). It does not migrate any callers — that PR cannot proceed safely until every legacy read has a new-flat id to migrate *to*.
+
+## Non-goals
+
+- Does not migrate any `dokan_get_option()` call sites to the new API.
+- Does not add `dokan()->settings` container alias (PR-2).
+- Does not mark `dokan_get_option()` as deprecated (PR-2).
+- Does not modify `LegacySettingsRepository` or `LegacySettingsBridge`.
+- Does not touch dokan-pro keys (only `dokan-lite`'s own reads are in scope).
+
+## Current state
+
+A discovery scan of `includes/**/*.php` finds:
+
+- **156** `dokan_get_option()` call sites.
+- **84** unique `(section, key)` pairs read.
+- **216** `legacy_key` declarations in the schema.
+- **21** read pairs have no `legacy_key` declaration anywhere in the schema. These are the gap this PR closes.
+
+### The 21 unmapped reads
+
+| Legacy pair | Call site(s) |
+|---|---|
+| `dokan_ai.dokan_ai_image_gen_availability` | `includes/REST/ProductControllerV3.php`, `includes/REST/VendorDashboardController.php` |
+| `dokan_appearance.captcha_enable_status` | `includes/Captcha/Manager.php` |
+| `dokan_appearance.captcha_provider` | `includes/Captcha/Manager.php` |
+| `dokan_appearance.default_store_banner` | `includes/Utilities/VendorUtil.php` |
+| `dokan_appearance.default_store_profile` | `includes/Utilities/VendorUtil.php` |
+| `dokan_appearance.product_sections` | `includes/ProductSections/Featured.php`, `BestSelling.php`, `AbstractProductSection.php` |
+| `dokan_appearance.recaptcha_enable_status` | `includes/functions.php`, `includes/Captcha/Manager.php` |
+| `dokan_appearance.recaptcha_secret_key` | `includes/functions.php` |
+| `dokan_appearance.recaptcha_site_key` | `includes/functions.php` |
+| `dokan_appearance.store_list_sort_by` | `includes/Vendor/StoreListsFilter.php` |
+| `dokan_appearance.store_products` | `includes/Product/Hooks.php` |
+| `dokan_appearance.vendor_layout_style` | `includes/Shortcodes/FullWidthVendorLayout.php` |
+| `dokan_general.contact_seller` | `includes/template-tags.php` |
+| `dokan_general.store_banner_flex_height` | `includes/Admin/Dashboard/Dashboard.php` |
+| `dokan_general.store_banner_flex_width` | `includes/Admin/Dashboard/Dashboard.php` |
+| `dokan_general.store_map` | `includes/template-tags.php` |
+| `dokan_general.store_open_close` | `includes/template-tags.php` |
+| `dokan_reverse_withdrawal.reverse_withdrawal_enabled` | `includes/ReverseWithdrawal/SettingsHelper.php` |
+| `dokan_selling.additional_fee` | `includes/Commission/Settings/GlobalSetting.php` |
+| `dokan_selling.admin_percentage` | `includes/Commission/Settings/GlobalSetting.php`, `includes/Admin/Settings.php` |
+
+All 21 reads are legitimate `dokan-lite` features — none are pro-only leaks. They lack schema declarations only because the schema was assembled incrementally and these fields were never registered on the new side.
+
+## Approach
+
+### 1. Triage each of the 21 keys
+
+For each unmapped pair:
+
+1. Find its existing legacy default and current value semantics (true/false, enum strings, integer, etc.).
+2. Choose a new-flat id. Naming follows neighboring schema entries:
+   - Lift the legacy key name directly when it's already descriptive and unique (`recaptcha_site_key` → `recaptcha_site_key`).
+   - Prefix or rename when the legacy name is too generic or collides (`additional_fee` → `commission_additional_fee` if `additional_fee` is already taken).
+3. Pick the section/subpage the field belongs to in the new UI. Use the existing schema groups (`marketplace_settings`, `appearance_settings`, etc.) — most of these 21 fields are already conceptually represented in those groups; we're just filling in the declarations.
+4. Add the schema element with `legacy_key`, `default`, `type`, and any validation that mirrors the legacy behavior.
+
+### 2. Add the schema declarations
+
+Schema elements live in `includes/Admin/Settings/Schema/SettingsSchema.php` and per-tab files under `includes/Admin/Settings/Schema/Tab/`. Add each new declaration alongside its conceptual peers.
+
+The `legacy_key` declaration has two equivalent forms (both accepted by the bridge):
+
+```php
+// String form — when path is single-level.
+'legacy_key' => 'dokan_general.custom_store_url',
+
+// Array form — also single-level, more explicit.
+'legacy_key' => [
+    'option' => 'dokan_general',
+    'field'  => 'custom_store_url',
+],
+```
+
+Either form is acceptable. Match the style of the surrounding schema entries in each file.
+
+### 3. Add a PHPUnit coverage gate
+
+New test file: `tests/php/src/Admin/Settings/Schema/LegacyReadCoverageTest.php`.
+
+Behavior:
+
+- Scans `includes/**/*.php` for literal `dokan_get_option('<key>', 'dokan_<section>')` call sites (regex-based — call sites with dynamic arguments are skipped and noted).
+- Loads the bridge via `LegacySettingsBridge::get_mapping()` to get the canonical mapping table.
+- Asserts every scanned `(section, key)` pair is present in the mapping.
+- Test failure message lists any pairs that lack mappings, with their call-site file paths.
+
+Single test method: `test_every_internal_dokan_get_option_call_has_a_legacy_key_mapping()`. Fails fast and loud when a new unmapped read is added.
+
+### 4. Document the allow-list for dynamic call sites
+
+`dokan_get_option()` is sometimes called with dynamic args (e.g., `dokan_get_option( $page, 'dokan_pages' )` where `$page` is a variable). The test's regex skips these — they can't be statically verified. The spec accepts this gap: the coverage gate guards the *static* surface, not the dynamic one. Dynamic call sites are flagged via a separate documented helper if/when they become a concern.
+
+## Files
+
+**Modified:**
+
+- `includes/Admin/Settings/Schema/SettingsSchema.php` — add some of the 21 new schema elements alongside their conceptual peers (most of `dokan_general.*`, `dokan_appearance.*`, `dokan_selling.*` fields).
+- `includes/Admin/Settings/Schema/Tab/AppearanceSchema.php` — likely target for `captcha_*`, `recaptcha_*`, `default_store_banner`, `default_store_profile`, `product_sections`, `store_list_sort_by`, `store_products`, `vendor_layout_style`, `store_banner_flex_*`.
+- `includes/Admin/Settings/Schema/Tab/ReverseWithdrawalSchema.php` (if it exists; otherwise wherever reverse-withdrawal settings live) — `reverse_withdrawal_enabled`.
+- Possibly: a tab file for AI (`AiAssistSchema.php` already exists per directory listing) — `dokan_ai_image_gen_availability`.
+- Possibly: commission schema file — `additional_fee`, `admin_percentage`.
+
+Exact file routing is determined during implementation by following neighboring declarations.
+
+**New:**
+
+- `tests/php/src/Admin/Settings/Schema/LegacyReadCoverageTest.php` — single coverage test.
+
+**Not touched:**
+
+- `includes/Admin/Settings/Migration/LegacySettingsBridge.php` — already supports both `legacy_key` forms.
+- `includes/Admin/Settings/Repository/SettingsRepository.php` — no behavioral changes.
+- `includes/Admin/Settings/Repository/LegacySettingsRepository.php` — no behavioral changes.
+- Any `dokan_get_option()` call site — call sites do not change in this PR.
+
+## Verification
+
+After the PR:
+
+1. `npm run phpunit -- --group=admin-settings` — passes, including the new coverage test.
+2. `npm run phpunit -- --filter=LegacyReadCoverageTest` — single-test run, asserts 0 unmapped pairs.
+3. Existing tests (`LegacySettingsBridgeTest`, `LegacySettingsRepositoryTest`, `DokanGetOptionReflectsNewSettingsTest`) — all pass without modification.
+4. `composer phpcs -- includes/Admin/Settings/Schema` — clean.
+
+## Risks
+
+1. **New-flat id collisions.** If a chosen new-flat id matches an existing schema id, the field collides. Mitigation: the implementation plan includes a collision check (grep the existing schema for the proposed id before adding it). The existing `SchemaValidator` also detects duplicates at boot.
+2. **Behavioral drift in defaults.** If the new schema entry's default differs from the legacy on-disk default, callers that previously got the legacy default may see the new one once they migrate (PR-2). Mitigation: each new declaration mirrors the existing legacy default exactly.
+3. **Dynamic `dokan_get_option()` calls slip past the gate.** Documented in the spec — this PR doesn't try to solve the dynamic-arg case. PR-2 may need to address specific dynamic call sites individually.
+4. **Schema element type mismatches.** A legacy value stored as `'on'`/`'off'` (string) must not be declared as `boolean` in the new schema without also declaring a transformer. Mitigation: each new declaration's `type` matches the legacy value shape; transformers are added only where the on-disk value needs translation.
+
+## Rollout
+
+Single PR. No feature flag. Adding schema declarations is additive — existing code paths continue to work; the bridge picks up the new mappings automatically.
+
+1. Add the 21 schema declarations (triage + add, file by file).
+2. Add the PHPUnit coverage test.
+3. Run the test — it must pass with 0 unmapped pairs.
+4. Run the admin-settings group — must still pass.
+5. Ship.
+
+## What this unlocks (next PR — out of scope here)
+
+PR-2 will be brainstormed separately. With this prereq in place, every internal `dokan_get_option('<key>', 'dokan_<section>', $default)` call has a known new-flat id (`$bridge->get_mapping()[<new_id>] === ['option' => '<section>', 'field' => '<key>']`), making the bulk migration to `dokan()->settings->get('<new_id>', $default)` mechanical.

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -423,14 +423,7 @@ class Settings {
         $pages_array = $this->get_post_type( 'page' );
 
         $commission_types              = dokan_commission_types();
-        $withdraw_order_status_options = apply_filters(
-            'dokan_settings_withdraw_order_status_options',
-            [
-                'wc-completed'  => __( 'Completed', 'dokan-lite' ),
-                'wc-processing' => __( 'Processing', 'dokan-lite' ),
-                'wc-on-hold'    => __( 'On-hold', 'dokan-lite' ),
-            ]
-        );
+        $withdraw_order_status_options = \WeDevs\Dokan\Utilities\AdminSettings::withdraw_order_status_options();
 
         $general_site_options = apply_filters(
             'dokan_settings_general_site_options', [

--- a/includes/Admin/Settings/Migration/LegacySettingsBridge.php
+++ b/includes/Admin/Settings/Migration/LegacySettingsBridge.php
@@ -25,7 +25,13 @@ class LegacySettingsBridge {
     /**
      * Cached normalized mapping, lazily built per-request.
      *
-     * @var array<string,LegacyAddress>|null
+     * Each entry is either:
+     *   - A single {@see LegacyAddress} for 1:1 mappings, or
+     *   - `array<string $slot, LegacyAddress>` for 1:N mappings, where each
+     *     slot name is a logical handle the transformer uses to assemble the
+     *     unified new value from / split it into N legacy addresses.
+     *
+     * @var array<string, LegacyAddress|array<string, LegacyAddress>>|null
      */
     private ?array $map = null;
 
@@ -39,7 +45,12 @@ class LegacySettingsBridge {
     /**
      * Cached reverse index keyed by legacy option name.
      *
-     * @var array<string,array<string,LegacyAddress>>|null
+     * For each option, the inner array maps new_key → entry, where the entry
+     * is either a single {@see LegacyAddress} (1:1 mapping) or
+     * `array<string $slot, LegacyAddress>` containing only the slots whose
+     * addresses live under that option (1:N mappings can span options).
+     *
+     * @var array<string, array<string, LegacyAddress|array<string, LegacyAddress>>>|null
      */
     private ?array $by_option = null;
 
@@ -105,16 +116,30 @@ class LegacySettingsBridge {
     /**
      * Return the normalized mapping of new flat ids to legacy addresses.
      *
-     * @return array<string,array{option:string,field:string}>
+     * Single-mapped entries surface as `['option' => ..., 'field' => ...]`.
+     * Multi-mapped entries surface as `[$slot => ['option' => ..., 'field' => ...], ...]`.
+     *
+     * @return array<string, array{option:string,field:string}|array<string,array{option:string,field:string}>>
      */
     public function get_mapping(): array {
         $this->build_map();
         $out = [];
-        foreach ( $this->map as $new_key => $address ) {
-            $out[ $new_key ] = [
-                'option' => $address->option(),
-                'field'  => implode( '.', $address->path() ),
-            ];
+        foreach ( $this->map as $new_key => $entry ) {
+            if ( $entry instanceof LegacyAddress ) {
+                $out[ $new_key ] = [
+                    'option' => $entry->option(),
+                    'field'  => implode( '.', $entry->path() ),
+                ];
+                continue;
+            }
+            $multi = [];
+            foreach ( $entry as $slot => $address ) {
+                $multi[ $slot ] = [
+                    'option' => $address->option(),
+                    'field'  => implode( '.', $address->path() ),
+                ];
+            }
+            $out[ $new_key ] = $multi;
         }
         return $out;
     }
@@ -133,17 +158,43 @@ class LegacySettingsBridge {
      */
     public function transform_legacy_payload_to_new( string $option_name, array $legacy_payload ): array {
         $this->build_map();
-        $pairs = $this->by_option[ $option_name ] ?? [];
-        $slice = [];
-        foreach ( $pairs as $new_key => $address ) {
-            // For nested paths the AJAX payload still arrives as a top-level
-            // structure under the section option, so we read the path from
-            // that payload directly.
-            $value = $address->read_from( $legacy_payload );
-            if ( null === $value && ! $this->path_exists( $legacy_payload, $address->path() ) ) {
+        $pairs            = $this->by_option[ $option_name ] ?? [];
+        $slice            = [];
+        $other_opt_cache  = [];
+        foreach ( $pairs as $new_key => $entry ) {
+            if ( $entry instanceof LegacyAddress ) {
+                // For nested paths the AJAX payload still arrives as a top-level
+                // structure under the section option, so we read the path from
+                // that payload directly.
+                $value = $entry->read_from( $legacy_payload );
+                if ( null === $value && ! $this->path_exists( $legacy_payload, $entry->path() ) ) {
+                    continue;
+                }
+                $slice[ $new_key ] = $this->resolve_transformer( $new_key )->to_new( $value );
                 continue;
             }
-            $slice[ $new_key ] = $this->resolve_transformer( $new_key )->to_new( $value );
+
+            // Multi-mapped: assemble all slot values into one array, then
+            // hand off to the transformer. Slots in other legacy options are
+            // fetched via get_option(), cached per request.
+            $all_slots   = $this->map[ $new_key ];
+            $values      = [];
+            $any_present = false;
+            foreach ( $all_slots as $slot => $address ) {
+                $source = $address->option() === $option_name
+                    ? $legacy_payload
+                    : ( $other_opt_cache[ $address->option() ] ??= $this->read_option( $address->option() ) );
+                if ( $this->path_exists( $source, $address->path() ) ) {
+                    $values[ $slot ] = $address->read_from( $source );
+                    $any_present     = true;
+                } else {
+                    $values[ $slot ] = null;
+                }
+            }
+            if ( ! $any_present ) {
+                continue;
+            }
+            $slice[ $new_key ] = $this->resolve_transformer( $new_key )->to_new( $values );
         }
         return $slice;
     }
@@ -162,27 +213,37 @@ class LegacySettingsBridge {
     public function hydrate_new_from_legacy( array $new_option ): array {
         $this->build_map();
 
-        $missing_by_option = [];
-        foreach ( $this->map as $new_key => $address ) {
+        $legacy_cache = [];
+
+        foreach ( $this->map as $new_key => $entry ) {
             if ( array_key_exists( $new_key, $new_option ) ) {
                 continue;
             }
-            $missing_by_option[ $address->option() ][ $new_key ] = $address;
-        }
-
-        foreach ( $missing_by_option as $option_name => $pairs ) {
-            $legacy = get_option( $option_name, [] );
-            if ( ! is_array( $legacy ) ) {
-                $legacy = [];
-            }
-            foreach ( $pairs as $new_key => $address ) {
-                if ( $this->path_exists( $legacy, $address->path() ) ) {
-                    $value                  = $address->read_from( $legacy );
-                    $new_option[ $new_key ] = $this->resolve_transformer( $new_key )->to_new( $value );
+            if ( $entry instanceof LegacyAddress ) {
+                $legacy = $legacy_cache[ $entry->option() ] ??= $this->read_option( $entry->option() );
+                if ( $this->path_exists( $legacy, $entry->path() ) ) {
+                    $new_option[ $new_key ] = $this->resolve_transformer( $new_key )->to_new( $entry->read_from( $legacy ) );
                 } else {
                     $new_option[ $new_key ] = $this->get_schema_default( $new_key );
                 }
+                continue;
             }
+
+            // Multi-mapped: read every slot, then transform.
+            $values      = [];
+            $any_present = false;
+            foreach ( $entry as $slot => $address ) {
+                $legacy = $legacy_cache[ $address->option() ] ??= $this->read_option( $address->option() );
+                if ( $this->path_exists( $legacy, $address->path() ) ) {
+                    $values[ $slot ] = $address->read_from( $legacy );
+                    $any_present     = true;
+                } else {
+                    $values[ $slot ] = null;
+                }
+            }
+            $new_option[ $new_key ] = $any_present
+                ? $this->resolve_transformer( $new_key )->to_new( $values )
+                : $this->get_schema_default( $new_key );
         }
 
         return $new_option;
@@ -208,12 +269,27 @@ class LegacySettingsBridge {
             $new_option = [];
         }
         $pairs = $this->by_option[ $option_name ] ?? [];
-        foreach ( $pairs as $new_key => $address ) {
+        foreach ( $pairs as $new_key => $entry ) {
             if ( ! array_key_exists( $new_key, $new_option ) ) {
                 continue;
             }
-            $legacy_value = $this->resolve_transformer( $new_key )->to_legacy( $new_option[ $new_key ] );
-            $address->write_to( $legacy_option, $legacy_value );
+            if ( $entry instanceof LegacyAddress ) {
+                $legacy_value = $this->resolve_transformer( $new_key )->to_legacy( $new_option[ $new_key ] );
+                $entry->write_to( $legacy_option, $legacy_value );
+                continue;
+            }
+            // Multi-mapped: transform once, then write only the slots whose
+            // addresses live under this option ($entry is pre-filtered).
+            $multi_result = $this->resolve_transformer( $new_key )->to_legacy( $new_option[ $new_key ] );
+            if ( ! is_array( $multi_result ) ) {
+                continue;
+            }
+            foreach ( $entry as $slot => $address ) {
+                if ( ! array_key_exists( $slot, $multi_result ) ) {
+                    continue;
+                }
+                $address->write_to( $legacy_option, $multi_result[ $slot ] );
+            }
         }
         return $legacy_option;
     }
@@ -234,21 +310,33 @@ class LegacySettingsBridge {
         $this->build_map();
         $changes_by_option = [];
         foreach ( $new_slice as $new_key => $value ) {
-            $address = $this->map[ $new_key ] ?? null;
-            if ( ! $address instanceof LegacyAddress ) {
+            $entry = $this->map[ $new_key ] ?? null;
+            if ( $entry instanceof LegacyAddress ) {
+                $legacy_value                              = $this->resolve_transformer( $new_key )->to_legacy( $value );
+                $changes_by_option[ $entry->option() ][]   = [ $entry, $legacy_value ];
                 continue;
             }
-            $legacy_value                                = $this->resolve_transformer( $new_key )->to_legacy( $value );
-            $changes_by_option[ $address->option() ][]   = [ $address, $legacy_value ];
+            if ( ! is_array( $entry ) ) {
+                continue;
+            }
+            // Multi-mapped: run the transformer once and fan slot values out to
+            // their respective options.
+            $multi_result = $this->resolve_transformer( $new_key )->to_legacy( $value );
+            if ( ! is_array( $multi_result ) ) {
+                continue;
+            }
+            foreach ( $entry as $slot => $address ) {
+                if ( ! array_key_exists( $slot, $multi_result ) ) {
+                    continue;
+                }
+                $changes_by_option[ $address->option() ][] = [ $address, $multi_result[ $slot ] ];
+            }
         }
         $written = [];
         foreach ( $changes_by_option as $option_name => $entries ) {
-            $legacy = get_option( $option_name, [] );
-            if ( ! is_array( $legacy ) ) {
-                $legacy = [];
-            }
-            foreach ( $entries as $entry ) {
-                [ $address, $legacy_value ] = $entry;
+            $legacy = $this->read_option( $option_name );
+            foreach ( $entries as $pair ) {
+                [ $address, $legacy_value ] = $pair;
                 $address->write_to( $legacy, $legacy_value );
             }
             update_option( $option_name, $legacy );
@@ -473,26 +561,70 @@ class LegacySettingsBridge {
     /**
      * Normalize raw addresses into value objects, dropping malformed entries.
      *
-     * @param array<string,string|array{option:string,field:string}> $map
+     * Two `legacy_key` shapes are accepted:
+     *   - Single: dotted string ("option.field") or struct
+     *     `['option' => ..., 'field' => ...]`.
+     *   - Multi:  associative array of slot name => single-form address. The
+     *     transformer's `to_new` receives `array<slot, mixed>`; `to_legacy`
+     *     must return the same shape.
      *
-     * @return array{0: array<string,LegacyAddress>, 1: array<string,array<string,LegacyAddress>>}
+     * @param array<string, mixed> $map
+     *
+     * @return array{0: array<string, LegacyAddress|array<string, LegacyAddress>>, 1: array<string, array<string, LegacyAddress|array<string, LegacyAddress>>>}
      */
     private function normalize( array $map ): array {
         $normalized = [];
         $by_option  = [];
 
-        foreach ( $map as $new_key => $address ) {
-            $object = LegacyAddress::parse( $address );
-            if ( null === $object ) {
-                if ( function_exists( 'dokan_log' ) ) {
-                    dokan_log( sprintf( '[LegacySettingsBridge] dropping malformed legacy_key for "%s"', $new_key ) );
-                }
+        foreach ( $map as $new_key => $raw ) {
+            // Try single shape first.
+            $single = LegacyAddress::parse( $raw );
+            if ( null !== $single ) {
+                $normalized[ $new_key ]                      = $single;
+                $by_option[ $single->option() ][ $new_key ]  = $single;
                 continue;
             }
-            $normalized[ $new_key ]                      = $object;
-            $by_option[ $object->option() ][ $new_key ]  = $object;
+
+            // Multi shape: assoc array of slot => address-input.
+            if ( is_array( $raw ) ) {
+                $multi = [];
+                foreach ( $raw as $slot => $address_input ) {
+                    if ( ! is_string( $slot ) || '' === $slot ) {
+                        continue;
+                    }
+                    $address = LegacyAddress::parse( $address_input );
+                    if ( null === $address ) {
+                        continue;
+                    }
+                    $multi[ $slot ] = $address;
+                }
+                if ( ! empty( $multi ) ) {
+                    $normalized[ $new_key ] = $multi;
+                    foreach ( $multi as $slot => $address ) {
+                        $by_option[ $address->option() ][ $new_key ][ $slot ] = $address;
+                    }
+                    continue;
+                }
+            }
+
+            if ( function_exists( 'dokan_log' ) ) {
+                dokan_log( sprintf( '[LegacySettingsBridge] dropping malformed legacy_key for "%s"', $new_key ) );
+            }
         }
 
         return [ $normalized, $by_option ];
+    }
+
+    /**
+     * Read a wp_option and coerce non-array values to an empty array so callers
+     * can safely path-walk the result.
+     *
+     * @param string $option_name
+     *
+     * @return array<string, mixed>
+     */
+    private function read_option( string $option_name ): array {
+        $value = get_option( $option_name, [] );
+        return is_array( $value ) ? $value : [];
     }
 }

--- a/includes/Admin/Settings/Migration/Transformer/CallableTransformer.php
+++ b/includes/Admin/Settings/Migration/Transformer/CallableTransformer.php
@@ -15,9 +15,11 @@ use InvalidArgumentException;
  *         'to_legacy' => [ MyHelper::class, 'to_string' ],
  *     ],
  *
- * Only string callables and `[Class, method]` array callables are accepted —
- * closures and bound-object callables are rejected because the schema array
- * travels through `apply_filters` and must remain serializable / filter-safe.
+ * Accepts string callables, `[Class, method]` array callables, closures, and
+ * invokable objects. Closures and invokable objects are convenient for inline
+ * transforms but cannot be serialized — if the schema is ever cached to a
+ * transient or other persistent store, use a string callable, a
+ * `[Class, method]` pair, or a dedicated transformer class instead.
  *
  * @since DOKAN_SINCE
  */
@@ -76,10 +78,12 @@ final class CallableTransformer implements TransformerInterface {
             is_array( $candidate )
             && 2 === count( $candidate )
             && isset( $candidate[0], $candidate[1] )
-            && is_string( $candidate[0] )
             && is_string( $candidate[1] )
             && is_callable( $candidate )
         ) {
+            return $candidate;
+        }
+        if ( ( $candidate instanceof \Closure ) || ( is_object( $candidate ) && is_callable( $candidate ) ) ) {
             return $candidate;
         }
         throw new InvalidArgumentException(
@@ -87,7 +91,7 @@ final class CallableTransformer implements TransformerInterface {
             // identifier passed from this class itself, not user input.
             esc_html(
                 sprintf(
-                    'CallableTransformer "%s" must be a string callable or [Class, method] array; closures and object callables are not supported.',
+                    'CallableTransformer "%s" must be a string callable, [Class, method] array, closure, or invokable object.',
                     $label
                 )
             )

--- a/includes/Admin/Settings/Migration/Transformer/HideVendorInfoTransformer.php
+++ b/includes/Admin/Settings/Migration/Transformer/HideVendorInfoTransformer.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace WeDevs\Dokan\Admin\Settings\Migration\Transformer;
+
+/**
+ * Maps the legacy `hide_vendor_info` multicheck shape to/from the new
+ * `vendor_info_visibility` field.
+ *
+ * Two things flip between the shapes:
+ *
+ * 1. Semantics. Legacy stores "what to hide" — a non-empty value at `email`
+ *    means hide the email. New stores "what to show" — `store_email: true`
+ *    means show it. Empty legacy / missing key = show.
+ * 2. Keys. Legacy: `email` / `phone` / `address`. New: `store_email` /
+ *    `store_phone` / `store_address`.
+ *
+ * Legacy WordPress multicheck values are the option key as a string when
+ * checked, empty string when unchecked. We normalize anything truthy on the
+ * legacy side to "hidden" so partial / pre-filtered payloads still round-trip.
+ *
+ * @since DOKAN_SINCE
+ */
+final class HideVendorInfoTransformer implements TransformerInterface {
+
+    /**
+     * Mapping of new schema keys → legacy multicheck keys.
+     *
+     * @var array<string, string>
+     */
+    private const KEY_MAP = [
+        'store_email'   => 'email',
+        'store_phone'   => 'phone',
+        'store_address' => 'address',
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function to_new( $legacy_value ) {
+        $legacy = is_array( $legacy_value ) ? $legacy_value : [];
+        $new    = [];
+
+        foreach ( self::KEY_MAP as $new_key => $legacy_key ) {
+            $hidden            = ! empty( $legacy[ $legacy_key ] );
+            $new[ $new_key ]   = ! $hidden;
+        }
+
+        return $new;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function to_legacy( $new_value ) {
+        $new    = is_array( $new_value ) ? $new_value : [];
+        $legacy = [];
+
+        foreach ( self::KEY_MAP as $new_key => $legacy_key ) {
+            $visible                = ! empty( $new[ $new_key ] );
+            $legacy[ $legacy_key ]  = $visible ? '' : $legacy_key;
+        }
+
+        return $legacy;
+    }
+}

--- a/includes/Admin/Settings/Migration/Transformer/InvertOnOffTransformer.php
+++ b/includes/Admin/Settings/Migration/Transformer/InvertOnOffTransformer.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace WeDevs\Dokan\Admin\Settings\Migration\Transformer;
+
+/**
+ * Inverts `on`/`off` between legacy and new shapes.
+ *
+ * Used for legacy fields whose semantics are negated in the new schema —
+ * e.g. legacy `disable_welcome_wizard` ↔ new `welcome_wizard`, where a
+ * legacy value of `off` ("not disabled") corresponds to a new value of
+ * `on` ("enabled"). Any value other than `on`/`off` is passed through
+ * unchanged so unexpected stored values are not silently mutated.
+ *
+ * @since DOKAN_SINCE
+ */
+final class InvertOnOffTransformer implements TransformerInterface {
+
+    /**
+     * {@inheritDoc}
+     */
+    public function to_new( $legacy_value ) {
+        return $this->flip( $legacy_value );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function to_legacy( $new_value ) {
+        return $this->flip( $new_value );
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return mixed
+     */
+    private function flip( $value ) {
+        if ( 'on' === $value ) {
+            return 'off';
+        }
+        if ( 'off' === $value ) {
+            return 'on';
+        }
+        return $value;
+    }
+}

--- a/includes/Admin/Settings/Migration/Transformer/MulticheckArrayBooleanTransformer.php
+++ b/includes/Admin/Settings/Migration/Transformer/MulticheckArrayBooleanTransformer.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace WeDevs\Dokan\Admin\Settings\Migration\Transformer;
+
+use Closure;
+
+/**
+ * Builds a callable transformer pair for a `multicheck` variant whose option
+ * slots each bridge to an independent legacy `'on'`/`'off'` switch.
+ *
+ *   legacy: per-slot key holds 'on' (checked) or 'off' (unchecked)
+ *   new:    [ 'slot_a', 'slot_c', ... ]   // string[] of enabled slot keys
+ *
+ * Use this when each `multicheck` option owns its own legacy boolean address
+ * (e.g. `dokan_appearance.store_map`) rather than living under a shared
+ * multicheck parent. Companion to {@see MulticheckArrayTransformer}, which
+ * serves the WordPress multicheck parent-array convention (key-as-value).
+ *
+ * Schema authors pass the slot list so `to_legacy` can clear unselected
+ * slots — exactly the same factory signature as the sibling transformer:
+ *
+ *     'legacy_transformer' => MulticheckArrayBooleanTransformer::for_slots( [ 'store_listing' ] ),
+ *
+ * Closures are filter-safe in the current pipeline (no schema persistence);
+ * swap to a dedicated class if the schema ever gets cached to a transient.
+ *
+ * @since DOKAN_SINCE
+ */
+final class MulticheckArrayBooleanTransformer {
+
+    /**
+     * Build the callable pair for the given slot universe.
+     *
+     * @param array<int,string> $slot_keys Every slot the bridge knows about.
+     *                                     `to_legacy` walks this list to
+     *                                     emit `'on'` for enabled slots and
+     *                                     `'off'` for the rest.
+     *
+     * @return array{to_new: Closure, to_legacy: Closure}
+     */
+    public static function for_slots( array $slot_keys ): array {
+        $slot_keys = array_values( array_map( 'strval', $slot_keys ) );
+
+        return [
+            'to_new'    => static function ( $legacy_slots ) {
+                $slots   = is_array( $legacy_slots ) ? $legacy_slots : [];
+                $enabled = [];
+                foreach ( $slots as $key => $value ) {
+                    if ( 'on' === $value ) {
+                        $enabled[] = (string) $key;
+                    }
+                }
+                return $enabled;
+            },
+            'to_legacy' => static function ( $new_value ) use ( $slot_keys ) {
+                $enabled = is_array( $new_value ) ? array_map( 'strval', $new_value ) : [];
+                $legacy  = [];
+                foreach ( $slot_keys as $key ) {
+                    $legacy[ $key ] = in_array( $key, $enabled, true ) ? 'on' : 'off';
+                }
+                return $legacy;
+            },
+        ];
+    }
+}

--- a/includes/Admin/Settings/Migration/Transformer/MulticheckArrayTransformer.php
+++ b/includes/Admin/Settings/Migration/Transformer/MulticheckArrayTransformer.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace WeDevs\Dokan\Admin\Settings\Migration\Transformer;
+
+use Closure;
+
+/**
+ * Builds a callable transformer pair for a `multicheck` variant that bridges to
+ * a WordPress multicheck legacy option.
+ *
+ *   legacy: [ 'wc-completed' => 'wc-completed', 'wc-processing' => '', ... ]
+ *   new:    [ 'wc-completed', ... ]   // string[] of enabled keys (multicheck shape)
+ *
+ * Plugin-ui's `multicheck` field stores enabled keys as an array, not as a
+ * `Record<key, bool>`. So `to_legacy` cannot infer the disabled set from the
+ * new value alone — it needs the full slot universe up front so it can emit
+ * empty strings for unselected slots and clear them on the legacy side.
+ *
+ * Schema authors pass the slot list from the same source that drives the
+ * field's `options` and `legacy_key`:
+ *
+ *     'legacy_transformer' => MulticheckArrayTransformer::for_slots( array_keys( $statuses ) ),
+ *
+ * The returned pair is a `[ 'to_new' => Closure, 'to_legacy' => Closure ]` array
+ * that the bridge wraps in a {@see CallableTransformer}. Closures are
+ * filter-safe in the current pipeline (no schema persistence); if the schema
+ * ever gets cached to a transient, swap to a dedicated class.
+ *
+ * Companion to {@see MulticheckSlotTransformer}, which serves the
+ * `Record<key, bool>` shape used by `info_preview` / `multi_switch`-style fields.
+ *
+ * @since DOKAN_SINCE
+ */
+final class MulticheckArrayTransformer {
+
+    /**
+     * Build the callable pair for the given slot universe.
+     *
+     * @param array<int,string> $slot_keys Every legacy slot the field is
+     *                                     bridged to. Order doesn't matter;
+     *                                     used only as a complete set so
+     *                                     `to_legacy` can clear unselected
+     *                                     slots.
+     *
+     * @return array{to_new: Closure, to_legacy: Closure}
+     */
+    public static function for_slots( array $slot_keys ): array {
+        $slot_keys = array_values( array_map( 'strval', $slot_keys ) );
+
+        return [
+            'to_new'    => static function ( $legacy_slots ) {
+                $slots   = is_array( $legacy_slots ) ? $legacy_slots : [];
+                $enabled = [];
+                foreach ( $slots as $key => $value ) {
+                    if ( ! empty( $value ) ) {
+                        $enabled[] = (string) $key;
+                    }
+                }
+                return $enabled;
+            },
+            'to_legacy' => static function ( $new_value ) use ( $slot_keys ) {
+                $enabled = is_array( $new_value ) ? array_map( 'strval', $new_value ) : [];
+                $legacy  = [];
+                foreach ( $slot_keys as $key ) {
+                    $legacy[ $key ] = in_array( $key, $enabled, true ) ? $key : '';
+                }
+                return $legacy;
+            },
+        ];
+    }
+}

--- a/includes/Admin/Settings/Migration/Transformer/SingleProductAppearanceTransformer.php
+++ b/includes/Admin/Settings/Migration/Transformer/SingleProductAppearanceTransformer.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace WeDevs\Dokan\Admin\Settings\Migration\Transformer;
+
+/**
+ * Bridges the new `single_product_page_appearance` info_preview field to three
+ * legacy switches.
+ *
+ * Slot layout (driven by the schema's multi `legacy_key`):
+ *
+ *   slot              | legacy address                              | legacy value | semantic
+ *   ------------------|---------------------------------------------|--------------|---------
+ *   vendor_info       | dokan_general.show_vendor_info              | "on" / ""    | direct
+ *   more_products_tab | dokan_general.enabled_more_products_tab     | "on" / ""    | direct
+ *   shipping_tab      | dokan_selling.disable_shipping_tab          | "on" / ""    | inverted
+ *
+ * `shipping_tab` is **inverted**: legacy `disable_shipping_tab = "on"` means
+ * the tab is hidden, so the new schema value (which means "show") is the
+ * negation. The first two slots are direct ("on" ⇔ true).
+ *
+ * @since DOKAN_SINCE
+ */
+final class SingleProductAppearanceTransformer implements TransformerInterface {
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param array<string,mixed>|null $legacy_value
+     */
+    public function to_new( $legacy_value ) {
+        $slots = is_array( $legacy_value ) ? $legacy_value : [];
+        return [
+            'vendor_info'       => 'on' === ( $slots['vendor_info'] ?? '' ),
+            'more_products_tab' => 'on' === ( $slots['more_products_tab'] ?? '' ),
+            'shipping_tab'      => 'on' !== ( $slots['shipping_tab'] ?? '' ),
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return array<string,string>
+     */
+    public function to_legacy( $new_value ) {
+        $new = is_array( $new_value ) ? $new_value : [];
+        return [
+            'vendor_info'       => ! empty( $new['vendor_info'] ) ? 'on' : 'off',
+            'more_products_tab' => ! empty( $new['more_products_tab'] ) ? 'on' : 'off',
+            'shipping_tab'      => empty( $new['shipping_tab'] ) ? 'on' : 'off',
+        ];
+    }
+}

--- a/includes/Admin/Settings/Migration/Transformer/WithdrawChargeTransformer.php
+++ b/includes/Admin/Settings/Migration/Transformer/WithdrawChargeTransformer.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace WeDevs\Dokan\Admin\Settings\Migration\Transformer;
+
+/**
+ * Bridges one withdraw-method charge entry between the legacy and new shapes.
+ *
+ * Shape map:
+ *   legacy: [ 'fixed' => 7.89, 'percentage' => 10.11 ]
+ *   new:    [ 'admin_percentage' => '10.11', 'additional_fee' => '7.89' ]
+ *
+ * The legacy `dokan_withdraw.withdraw_charges` option is a parent array keyed
+ * by method (`paypal`, `bank`, `dokan_stripe_express`, `skrill`,
+ * `dokan_custom`, …). Each new field declares its own dotted `legacy_key`
+ * pointing to one sub-path:
+ *
+ *   'legacy_key' => 'dokan_withdraw.withdraw_charges.paypal',
+ *
+ * The bridge resolves the path with {@see LegacyAddress::read_from} /
+ * `write_to`, so a single transformer instance round-trips every method.
+ *
+ * Values are passed through unchanged on the values themselves — only the
+ * key names are flipped (percentage ⇔ admin_percentage, fixed ⇔
+ * additional_fee). The combine_input field stores strings (from the text
+ * inputs), so this transformer doesn't coerce types and leaves rounding /
+ * formatting to the consumer.
+ *
+ * @since DOKAN_SINCE
+ */
+final class WithdrawChargeTransformer implements TransformerInterface {
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param array<string,mixed>|null $legacy_value
+     */
+    public function to_new( $legacy_value ) {
+        $legacy = is_array( $legacy_value ) ? $legacy_value : [];
+        return [
+            'admin_percentage' => $legacy['percentage'] ?? '',
+            'additional_fee'   => $legacy['fixed'] ?? '',
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return array<string,mixed>
+     */
+    public function to_legacy( $new_value ) {
+        $new = is_array( $new_value ) ? $new_value : [];
+        return [
+            'percentage' => $new['admin_percentage'] ?? '',
+            'fixed'      => $new['additional_fee'] ?? '',
+        ];
+    }
+}

--- a/includes/Admin/Settings/Migration/Transformer/WithdrawMethodToggleTransformer.php
+++ b/includes/Admin/Settings/Migration/Transformer/WithdrawMethodToggleTransformer.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace WeDevs\Dokan\Admin\Settings\Migration\Transformer;
+
+use Closure;
+
+/**
+ * Builds a callable transformer pair for one slot of a WordPress multicheck
+ * legacy option (e.g. `dokan_withdraw.withdraw_methods`,
+ * `dokan_withdraw.withdraw_order_status`).
+ *
+ *   legacy: [ '<slot_key>' => '<slot_key>', ... ]   // enabled = key as value
+ *   new:    one boolean switch per slot, value "on" | "off"
+ *
+ * Each new switch field is one boolean toggle, but the legacy parent array
+ * uses the WordPress multicheck convention where an enabled method stores
+ * its own key as the value (`'paypal' => 'paypal'`) so downstream code can
+ * read the enabled set with `array_filter` / `array_intersect`. That makes
+ * the value method-aware, which prevents a single zero-arg transformer
+ * class from serving every method.
+ *
+ * Wiring is intentionally one-line in the schema:
+ *
+ *     'legacy_key'         => 'dokan_withdraw.withdraw_methods.paypal',
+ *     'legacy_transformer' => WithdrawMethodToggleTransformer::for_method( 'paypal' ),
+ *
+ * Returns a `[ 'to_new' => Closure, 'to_legacy' => Closure ]` pair that the
+ * bridge wraps in a {@see CallableTransformer}. Closures are filter-safe in
+ * the current pipeline (no schema persistence); switch to a dedicated class
+ * per method if the schema ever gets cached to a transient.
+ *
+ * @since DOKAN_SINCE
+ */
+final class WithdrawMethodToggleTransformer {
+
+    /**
+     * Build the callable pair for one method key.
+     *
+     * @param string $method_key Legacy method id (e.g. "paypal", "bank",
+     *                           "dokan_stripe_express").
+     *
+     * @return array{to_new: Closure, to_legacy: Closure}
+     */
+    public static function for_method( string $method_key ): array {
+        return [
+            'to_new'    => static function ( $legacy_value ) {
+                return ! empty( $legacy_value ) ? 'on' : 'off';
+            },
+            'to_legacy' => static function ( $new_value ) use ( $method_key ) {
+                return 'on' === $new_value ? $method_key : '';
+            },
+        ];
+    }
+}

--- a/includes/Admin/Settings/Repository/LegacySettingsRepository.php
+++ b/includes/Admin/Settings/Repository/LegacySettingsRepository.php
@@ -30,6 +30,18 @@ final class LegacySettingsRepository implements LegacySettingsRepositoryInterfac
     ) {
         $this->new_repo = $new_repo ?? new SettingsRepository();
         $this->bridge   = $bridge ?? new LegacySettingsBridge();
+
+        foreach ( $this->known_sections() as $section ) {
+            add_action( "update_option_{$section}", [ $this, 'on_section_changed' ] );
+            add_action( "add_option_{$section}",    [ $this, 'on_section_changed' ] );
+        }
+
+        // The new flat option participates in every overlay — its writes invalidate
+        // every snapshot. Use named callbacks so the same listener isn't bound twice
+        // if the repository is instantiated more than once in a request.
+        $new_option = SettingsRepository::OPTION_KEY;
+        add_action( "update_option_{$new_option}", [ $this, 'flush_all_snapshots' ] );
+        add_action( "add_option_{$new_option}",    [ $this, 'flush_all_snapshots' ] );
     }
 
     public function all( string $section ): array {
@@ -61,5 +73,48 @@ final class LegacySettingsRepository implements LegacySettingsRepositoryInterfac
             return;
         }
         unset( $this->snapshots[ $section ] );
+    }
+
+    /**
+     * WP hook listener — receives `($option, …)` from add_option / `($old, $new, $option)` from update_option.
+     * We only need the option name, which we derive from the current filter name.
+     *
+     * @return void
+     */
+    public function on_section_changed(): void {
+        $option = current_action();
+        foreach ( [ 'update_option_', 'add_option_' ] as $prefix ) {
+            if ( 0 === strpos( $option, $prefix ) ) {
+                $section = substr( $option, strlen( $prefix ) );
+                $this->flush_cache( $section );
+                return;
+            }
+        }
+    }
+
+    /**
+     * Listener for the new flat option — every section snapshot must be flushed
+     * because the overlay source changed.
+     *
+     * @return void
+     */
+    public function flush_all_snapshots(): void {
+        $this->flush_cache( null );
+    }
+
+    /**
+     * Unique legacy wp_option names that the bridge currently knows about.
+     *
+     * @return array<int,string>
+     */
+    private function known_sections(): array {
+        $map      = $this->bridge->get_mapping();
+        $sections = [];
+        foreach ( $map as $entry ) {
+            if ( is_array( $entry ) && isset( $entry['option'] ) && is_string( $entry['option'] ) ) {
+                $sections[ $entry['option'] ] = true;
+            }
+        }
+        return array_keys( $sections );
     }
 }

--- a/includes/Admin/Settings/Repository/LegacySettingsRepository.php
+++ b/includes/Admin/Settings/Repository/LegacySettingsRepository.php
@@ -121,7 +121,38 @@ final class LegacySettingsRepository implements LegacySettingsRepositoryInterfac
     }
 
     public function replace( string $section, array $payload ): array {
-        return [];
+        $current = $this->all( $section );
+
+        /** This filter is documented in includes/Admin/Settings/Repository/LegacySettingsRepository.php */
+        $payload = (array) apply_filters( 'dokan_legacy_settings_pre_save', $payload, $section, $current );
+
+        $diff = self::diff( $current, $payload );
+        foreach ( $current as $k => $_ ) {
+            if ( ! array_key_exists( $k, $payload ) ) {
+                $diff[ $k ] = null;
+            }
+        }
+
+        update_option( $section, $payload, true );
+        $this->snapshots[ $section ] = $this->bridge->hydrate_legacy_from_new( $section, $payload );
+
+        try {
+            $flat_slice = $this->bridge->transform_legacy_payload_to_new( $section, $payload );
+            if ( ! empty( $flat_slice ) ) {
+                $this->new_repo->update( $flat_slice );
+            }
+        } catch ( \Throwable $e ) {
+            if ( function_exists( 'dokan_log' ) ) {
+                dokan_log( '[LegacySettingsRepository] mirror replace failed: ' . $e->getMessage() );
+            }
+        }
+
+        if ( ! empty( $diff ) ) {
+            /** This action is documented in includes/Admin/Settings/Repository/LegacySettingsRepository.php */
+            do_action( 'dokan_legacy_settings_changed', $section, $diff, $current, $payload );
+        }
+
+        return $diff;
     }
 
     public function flush_cache( ?string $section = null ): void {

--- a/includes/Admin/Settings/Repository/LegacySettingsRepository.php
+++ b/includes/Admin/Settings/Repository/LegacySettingsRepository.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace WeDevs\Dokan\Admin\Settings\Repository;
+
+use WeDevs\Dokan\Admin\Settings\Migration\LegacySettingsBridge;
+
+/**
+ * Default legacy settings repository.
+ *
+ * Reads/writes legacy per-section `dokan_*` wp_options with overlay + mirror.
+ *
+ * @since DOKAN_SINCE
+ */
+final class LegacySettingsRepository implements LegacySettingsRepositoryInterface {
+
+    private SettingsRepositoryInterface $new_repo;
+
+    private LegacySettingsBridge $bridge;
+
+    /**
+     * Per-section in-request snapshot cache.
+     *
+     * @var array<string, array<string, mixed>>
+     */
+    private array $snapshots = [];
+
+    public function __construct(
+        ?SettingsRepositoryInterface $new_repo = null,
+        ?LegacySettingsBridge $bridge = null
+    ) {
+        $this->new_repo = $new_repo ?? new SettingsRepository();
+        $this->bridge   = $bridge ?? new LegacySettingsBridge();
+    }
+
+    public function all( string $section ): array {
+        return [];
+    }
+
+    public function get( string $section, string $key, $default_value = null ) {
+        return $default_value;
+    }
+
+    public function update( string $section, array $slice ): array {
+        return [];
+    }
+
+    public function replace( string $section, array $payload ): array {
+        return [];
+    }
+
+    public function flush_cache( ?string $section = null ): void {
+        if ( null === $section ) {
+            $this->snapshots = [];
+            return;
+        }
+        unset( $this->snapshots[ $section ] );
+    }
+}

--- a/includes/Admin/Settings/Repository/LegacySettingsRepository.php
+++ b/includes/Admin/Settings/Repository/LegacySettingsRepository.php
@@ -33,11 +33,18 @@ final class LegacySettingsRepository implements LegacySettingsRepositoryInterfac
     }
 
     public function all( string $section ): array {
-        return [];
+        if ( ! array_key_exists( $section, $this->snapshots ) ) {
+            $raw = get_option( $section, [] );
+            $raw = is_array( $raw ) ? $raw : [];
+
+            $this->snapshots[ $section ] = $this->bridge->hydrate_legacy_from_new( $section, $raw );
+        }
+        return $this->snapshots[ $section ];
     }
 
     public function get( string $section, string $key, $default_value = null ) {
-        return $default_value;
+        $all = $this->all( $section );
+        return array_key_exists( $key, $all ) ? $all[ $key ] : $default_value;
     }
 
     public function update( string $section, array $slice ): array {

--- a/includes/Admin/Settings/Repository/LegacySettingsRepository.php
+++ b/includes/Admin/Settings/Repository/LegacySettingsRepository.php
@@ -60,7 +60,64 @@ final class LegacySettingsRepository implements LegacySettingsRepositoryInterfac
     }
 
     public function update( string $section, array $slice ): array {
-        return [];
+        $current = $this->all( $section );
+
+        /**
+         * Filter the slice about to be merged into a legacy section option.
+         *
+         * Subscribers may add, remove, or normalize keys. Returning an empty
+         * array effectively blocks the write (the diff becomes empty and
+         * neither the legacy option nor the new-flat mirror is touched).
+         *
+         * @since DOKAN_SINCE
+         *
+         * @param array<string,mixed> $slice   Incoming change set.
+         * @param string              $section Legacy wp_option name.
+         * @param array<string,mixed> $current Overlay-applied view before the write.
+         */
+        $slice = (array) apply_filters( 'dokan_legacy_settings_pre_save', $slice, $section, $current );
+
+        $changed = self::diff( $current, $slice );
+        if ( empty( $changed ) ) {
+            return [];
+        }
+
+        $raw    = get_option( $section, [] );
+        $raw    = is_array( $raw ) ? $raw : [];
+        $merged = array_merge( $raw, $slice );
+
+        update_option( $section, $merged, true );
+        // Refresh our snapshot now — the WP hook already flushed it, but we want
+        // the next read in *this* request to skip a get_option round-trip.
+        $this->snapshots[ $section ] = $this->bridge->hydrate_legacy_from_new( $section, $merged );
+
+        // Mirror mapped keys into the new flat option. Best-effort: a thrown
+        // exception from the bridge or new repo is caught and logged so the
+        // legacy write that already landed is not silently rolled back.
+        try {
+            $flat_slice = $this->bridge->transform_legacy_payload_to_new( $section, $slice );
+            if ( ! empty( $flat_slice ) ) {
+                $this->new_repo->update( $flat_slice );
+            }
+        } catch ( \Throwable $e ) {
+            if ( function_exists( 'dokan_log' ) ) {
+                dokan_log( '[LegacySettingsRepository] mirror write failed: ' . $e->getMessage() );
+            }
+        }
+
+        /**
+         * Fired after a successful write to a legacy section option.
+         *
+         * @since DOKAN_SINCE
+         *
+         * @param string              $section Legacy wp_option name.
+         * @param array<string,mixed> $changed Added/changed entries.
+         * @param array<string,mixed> $current Overlay-applied view before the write.
+         * @param array<string,mixed> $merged  Raw section payload after the write.
+         */
+        do_action( 'dokan_legacy_settings_changed', $section, $changed, $current, $merged );
+
+        return $changed;
     }
 
     public function replace( string $section, array $payload ): array {
@@ -116,5 +173,23 @@ final class LegacySettingsRepository implements LegacySettingsRepositoryInterfac
             }
         }
         return array_keys( $sections );
+    }
+
+    /**
+     * Strict-equality diff: returns added or modified entries only.
+     *
+     * @param array<string,mixed> $old
+     * @param array<string,mixed> $new_payload
+     *
+     * @return array<string,mixed>
+     */
+    private static function diff( array $old, array $new_payload ): array {
+        $out = [];
+        foreach ( $new_payload as $k => $v ) {
+            if ( ! array_key_exists( $k, $old ) || $old[ $k ] !== $v ) {
+                $out[ $k ] = $v;
+            }
+        }
+        return $out;
     }
 }

--- a/includes/Admin/Settings/Repository/LegacySettingsRepository.php
+++ b/includes/Admin/Settings/Repository/LegacySettingsRepository.php
@@ -33,7 +33,7 @@ final class LegacySettingsRepository implements LegacySettingsRepositoryInterfac
 
         foreach ( $this->known_sections() as $section ) {
             add_action( "update_option_{$section}", [ $this, 'on_section_changed' ] );
-            add_action( "add_option_{$section}",    [ $this, 'on_section_changed' ] );
+            add_action( "add_option_{$section}", [ $this, 'on_section_changed' ] );
         }
 
         // The new flat option participates in every overlay — its writes invalidate
@@ -41,7 +41,7 @@ final class LegacySettingsRepository implements LegacySettingsRepositoryInterfac
         // if the repository is instantiated more than once in a request.
         $new_option = SettingsRepository::OPTION_KEY;
         add_action( "update_option_{$new_option}", [ $this, 'flush_all_snapshots' ] );
-        add_action( "add_option_{$new_option}",    [ $this, 'flush_all_snapshots' ] );
+        add_action( "add_option_{$new_option}", [ $this, 'flush_all_snapshots' ] );
     }
 
     public function all( string $section ): array {

--- a/includes/Admin/Settings/Repository/LegacySettingsRepositoryInterface.php
+++ b/includes/Admin/Settings/Repository/LegacySettingsRepositoryInterface.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace WeDevs\Dokan\Admin\Settings\Repository;
+
+/**
+ * Legacy Settings Repository contract.
+ *
+ * Single sanctioned read/write surface for the legacy per-section `dokan_*`
+ * wp_options (`dokan_general`, `dokan_selling`, `dokan_appearance`,
+ * `dokan_pages`, `dokan_privacy`, `dokan_withdraw`, …).
+ *
+ * Reads apply the new-flat overlay via {@see \WeDevs\Dokan\Admin\Settings\Migration\LegacySettingsBridge}.
+ * Writes persist to the legacy section option AND mirror mapped keys to the
+ * new flat option via {@see SettingsRepositoryInterface}.
+ *
+ * @since DOKAN_SINCE
+ */
+interface LegacySettingsRepositoryInterface {
+
+    /**
+     * Full overlay-applied view of one legacy section.
+     *
+     * @param string $section Legacy wp_option name (e.g. `dokan_general`).
+     *
+     * @return array<string,mixed>
+     */
+    public function all( string $section ): array;
+
+    /**
+     * Single-key overlay-applied read.
+     *
+     * @param string $section       Legacy wp_option name.
+     * @param string $key           Field id inside that section.
+     * @param mixed  $default_value Returned when the key is absent.
+     *
+     * @return mixed
+     */
+    public function get( string $section, string $key, $default_value = null );
+
+    /**
+     * Batch upsert: merges `$slice` into the legacy section option and
+     * mirrors mapped keys to `dokan_admin_settings`.
+     *
+     * Fires:
+     *  - `dokan_legacy_settings_pre_save` filter — subscribers may mutate `$slice`.
+     *  - `dokan_legacy_settings_changed` action — fires on non-empty diff.
+     *
+     * @param string              $section Legacy wp_option name.
+     * @param array<string,mixed> $slice
+     *
+     * @return array<string,mixed> Added/changed entries actually written.
+     */
+    public function update( string $section, array $slice ): array;
+
+    /**
+     * Full replacement of one section's payload. Returns a deletion-aware
+     * diff (removed keys appear as `null`). Mirrors mapped keys to the new
+     * flat option.
+     *
+     * @param string              $section Legacy wp_option name.
+     * @param array<string,mixed> $payload
+     *
+     * @return array<string,mixed>
+     */
+    public function replace( string $section, array $payload ): array;
+
+    /**
+     * Drop the in-request snapshot. Pass null to flush every section.
+     *
+     * @param string|null $section
+     *
+     * @return void
+     */
+    public function flush_cache( ?string $section = null ): void;
+}

--- a/includes/Admin/Settings/Schema/SettingsSchema.php
+++ b/includes/Admin/Settings/Schema/SettingsSchema.php
@@ -2,6 +2,7 @@
 
 namespace WeDevs\Dokan\Admin\Settings\Schema;
 
+use WeDevs\Dokan\Admin\Settings\Migration\Transformer\InvertOnOffTransformer;
 use WeDevs\Dokan\Utilities\AdminSettings;
 
 /**
@@ -170,139 +171,219 @@ class SettingsSchema {
                     return ! in_array( $value, dokan_get_reserved_url_slugs(), true );
                 },
             ],
+            [
+                'id'            => 'catalog_mode_add_to_cart_button_visibility',
+                'type'          => 'field',
+                'variant'       => 'switch',
+                'section_id'    => 'marketplace_settings',
+                'title'         => esc_html__( 'Add to Cart Button Visibility', 'dokan-lite' ),
+                'description'   => esc_html__( 'Show or hide the Add to Cart button on product pages in catalog mode.', 'dokan-lite' ),
+                'default'       => 'on',
+                'enable_state'  => [
+					'label' => esc_html__( 'Enabled', 'dokan-lite' ),
+					'value' => 'on',
+				],
+                'disable_state' => [
+					'label' => esc_html__( 'Disabled', 'dokan-lite' ),
+					'value' => 'off',
+				],
+                'legacy_key'    => [
+                    'option' => 'dokan_selling',
+                    'field'  => 'catalog_mode_hide_add_to_cart_button',
+				],
+                'legacy_transformer' => InvertOnOffTransformer::class,
+            ],
+			[
+				'id'            => 'catalog_mode_hide_product_price',
+				'type'          => 'field',
+				'variant'       => 'switch',
+				'section_id'    => 'marketplace_settings',
+                'title'   => __( 'Product Price Visibility', 'dokan-lite' ),
+                'description'    => __( 'Check to hide product price.', 'dokan-lite' ),
+                'default' => 'on',
+				'enable_state'  => [
+					'label' => esc_html__( 'Enabled', 'dokan-lite' ),
+					'value' => 'on',
+				],
+				'disable_state' => [
+					'label' => esc_html__( 'Disabled', 'dokan-lite' ),
+					'value' => 'off',
+				],
+				'legacy_key'    => [
+					'option' => 'dokan_selling',
+					'field'  => 'catalog_mode_hide_product_price',
+				],
+                'dependencies' => [
+					[
+						'key' => 'catalog_mode_add_to_cart_button_visibility',
+						'value' => 'off',
+						'to_self' => true,
+						'attribute' => 'display',
+						'effect' => 'show',
+						'comparison' => '===',
+					],
+					[
+						'key' => 'catalog_mode_add_to_cart_button_visibility',
+						'value' => 'off',
+						'to_self' => true,
+						'attribute' => 'display',
+						'effect' => 'hide',
+						'comparison' => '!==',
+					],
+				],
+                'legacy_transformer' => InvertOnOffTransformer::class,
+			],
+			// === SubPage: Page Setup ===
+			[
+				'id'          => 'dokan_pages',
+				'type'        => 'subpage',
+				'page_id'     => 'general',
+				'title'       => esc_html__( 'Page Setup', 'dokan-lite' ),
+				'description' => esc_html__( 'Link your WordPress pages to essential Dokan marketplace functions and features.', 'dokan-lite' ),
+				'priority'    => 200,
+				'doc_link'    => 'https://wedevs.com/docs/dokan/settings/page-settings-2/',
+			],
+			[
+				'id'         => 'dashboard_section',
+				'type'       => 'section',
+				'subpage_id' => 'dokan_pages',
+			],
+			[
+				'id'          => 'vendor_dashboard_page',
+				'legacy_key' => [
+					'option' => 'dokan_pages',
+					'field'  => 'dashboard',
+				],
+				'type'        => 'field',
+				'variant'     => 'select',
+				'section_id'  => 'dashboard_section',
+				'title'       => esc_html__( 'Dashboard', 'dokan-lite' ),
+				'description' => esc_html__( 'Select a page to show vendor dashboard.', 'dokan-lite' ),
+				'placeholder' => esc_html__( 'Select page', 'dokan-lite' ),
+				'options'     => $pages_array,
+			],
+			[
+				'id'         => 'my_orders_section',
+				'type'       => 'section',
+				'subpage_id' => 'dokan_pages',
+			],
+			[
+				'id'          => 'my_orders_page',
+				'legacy_key' => [
+					'option' => 'dokan_pages',
+					'field'  => 'my_orders',
+				],
+				'type'        => 'field',
+				'variant'     => 'select',
+				'section_id'  => 'my_orders_section',
+				'title'       => esc_html__( 'My Orders', 'dokan-lite' ),
+				'description' => esc_html__( 'Select a page to show my orders', 'dokan-lite' ),
+				'placeholder' => esc_html__( 'Select page', 'dokan-lite' ),
+				'options'     => $pages_array,
+			],
+			[
+				'id'         => 'store_listing_section',
+				'type'       => 'section',
+				'subpage_id' => 'dokan_pages',
+			],
+			[
+				'id'          => 'store_listing_page',
+				'legacy_key' => [
+					'option' => 'dokan_pages',
+					'field'  => 'store_listing',
+				],
+				'type'        => 'field',
+				'variant'     => 'select',
+				'section_id'  => 'store_listing_section',
+				'title'       => esc_html__( 'Store Listing', 'dokan-lite' ),
+				'description' => esc_html__( 'Select a page to show all stores', 'dokan-lite' ),
+				'placeholder' => esc_html__( 'Select page', 'dokan-lite' ),
+				'options'     => $pages_array,
+			],
+			[
+				'id'         => 'reg_tc_page_section',
+				'type'       => 'section',
+				'subpage_id' => 'dokan_pages',
+			],
+			[
+				'id'          => 'reg_tc_page',
+				'legacy_key' => [
+					'option' => 'dokan_pages',
+					'field'  => 'reg_tc_page',
+				],
+				'type'        => 'field',
+				'variant'     => 'select',
+				'section_id'  => 'reg_tc_page_section',
+				'title'       => esc_html__( 'Terms and Conditions Page', 'dokan-lite' ),
+				'description' => esc_html__( 'Select where you want to add Dokan pages.', 'dokan-lite' ),
+				'placeholder' => esc_html__( 'Select page', 'dokan-lite' ),
+				'tooltip'     => esc_html__( 'Select a page to display the Terms and Conditions of your store for Vendors.', 'dokan-lite' ),
+				'options'     => $pages_array,
+			],
+            [
+				'id'         => 'vendor_onboarding_page_section',
+				'type'       => 'section',
+				'subpage_id' => 'dokan_pages',
+			],
+			[
+				'id'          => 'vendor_onboarding_page',
+				'legacy_key' => [
+					'option' => 'dokan_pages',
+					'field'  => 'vendor_onboarding',
+				],
+				'type'        => 'field',
+				'variant'     => 'select',
+				'section_id'  => 'vendor_onboarding_page_section',
+				'title'       => esc_html__( 'Vendor Onboarding Page', 'dokan-lite' ),
+				'description' => esc_html__( 'Select a page for vendor onboarding and login', 'dokan-lite' ),
+				'placeholder' => esc_html__( 'Select page', 'dokan-lite' ),
+				'options'     => $pages_array,
+			],
 
-            // === SubPage: Page Setup ===
-            [
-                'id'          => 'dokan_pages',
-                'type'        => 'subpage',
-                'page_id'     => 'general',
-                'title'       => esc_html__( 'Page Setup', 'dokan-lite' ),
-                'description' => esc_html__( 'Link your WordPress pages to essential Dokan marketplace functions and features.', 'dokan-lite' ),
-                'priority'    => 200,
-                'doc_link'    => 'https://wedevs.com/docs/dokan/settings/page-settings-2/',
-            ],
-            [
-                'id'         => 'dashboard_section',
-                'type'       => 'section',
-                'subpage_id' => 'dokan_pages',
-            ],
-            [
-                'id'          => 'dashboard',
-                'legacy_key' => [
-                    'option' => 'dokan_pages',
-                    'field'  => 'dashboard',
-                ],
-                'type'        => 'field',
-                'variant'     => 'select',
-                'section_id'  => 'dashboard_section',
-                'title'       => esc_html__( 'Dashboard', 'dokan-lite' ),
-                'description' => esc_html__( 'Select a page to show vendor dashboard.', 'dokan-lite' ),
-                'placeholder' => esc_html__( 'Select page', 'dokan-lite' ),
-                'options'     => $pages_array,
-            ],
-            [
-                'id'         => 'my_orders_section',
-                'type'       => 'section',
-                'subpage_id' => 'dokan_pages',
-            ],
-            [
-                'id'          => 'my_orders',
-                'legacy_key' => [
-                    'option' => 'dokan_pages',
-                    'field'  => 'my_orders',
-                ],
-                'type'        => 'field',
-                'variant'     => 'select',
-                'section_id'  => 'my_orders_section',
-                'title'       => esc_html__( 'My Orders', 'dokan-lite' ),
-                'description' => esc_html__( 'Select a page to show my orders', 'dokan-lite' ),
-                'placeholder' => esc_html__( 'Select page', 'dokan-lite' ),
-                'options'     => $pages_array,
-            ],
-            [
-                'id'         => 'store_listing_section',
-                'type'       => 'section',
-                'subpage_id' => 'dokan_pages',
-            ],
-            [
-                'id'          => 'store_listing',
-                'legacy_key' => [
-                    'option' => 'dokan_pages',
-                    'field'  => 'store_listing',
-                ],
-                'type'        => 'field',
-                'variant'     => 'select',
-                'section_id'  => 'store_listing_section',
-                'title'       => esc_html__( 'Store Listing', 'dokan-lite' ),
-                'description' => esc_html__( 'Select a page to show all stores', 'dokan-lite' ),
-                'placeholder' => esc_html__( 'Select page', 'dokan-lite' ),
-                'options'     => $pages_array,
-            ],
-            [
-                'id'         => 'reg_tc_page_section',
-                'type'       => 'section',
-                'subpage_id' => 'dokan_pages',
-            ],
-            [
-                'id'          => 'reg_tc_page',
-                'legacy_key' => [
-                    'option' => 'dokan_pages',
-                    'field'  => 'reg_tc_page',
-                ],
-                'type'        => 'field',
-                'variant'     => 'select',
-                'section_id'  => 'reg_tc_page_section',
-                'title'       => esc_html__( 'Terms and Conditions Page', 'dokan-lite' ),
-                'description' => esc_html__( 'Select where you want to add Dokan pages.', 'dokan-lite' ),
-                'placeholder' => esc_html__( 'Select page', 'dokan-lite' ),
-                'tooltip'     => esc_html__( 'Select a page to display the Terms and Conditions of your store for Vendors.', 'dokan-lite' ),
-                'options'     => $pages_array,
-            ],
-
-            // === SubPage: Location ===
-            [
-                'id'          => 'location',
-                'type'        => 'subpage',
-                'page_id'     => 'general',
-                'title'       => esc_html__( 'Location', 'dokan-lite' ),
-                'description' => esc_html__( 'Configure how map locations are displayed throughout your marketplace.', 'dokan-lite' ),
-                'priority'    => 300,
-                'doc_link'    => 'https://wedevs.com/docs/dokan/settings/page-settings-2/',
-            ],
-            [
-                'id'         => 'map_api_configuration',
-                'type'       => 'section',
-                'subpage_id' => 'location',
-            ],
-            [
-                'id'          => 'map_api_source',
-                'legacy_key' => [
-                    'option' => 'dokan_appearance',
-                    'field'  => 'map_api_source',
-                ],
-                'type'        => 'field',
-                'variant'     => 'radio_capsule',
-                'section_id'  => 'map_api_configuration',
-                'title'       => esc_html__( 'Map API Source', 'dokan-lite' ),
-                'description' => esc_html__( 'Which map API source you want to use in your site?', 'dokan-lite' ),
-                'default'     => 'google_maps',
-                'options'     => [
-                    [
+			// === SubPage: Location ===
+			[
+				'id'          => 'location',
+				'type'        => 'subpage',
+				'page_id'     => 'general',
+				'title'       => esc_html__( 'Location', 'dokan-lite' ),
+				'description' => esc_html__( 'Configure how map locations are displayed throughout your marketplace.', 'dokan-lite' ),
+				'priority'    => 300,
+				'doc_link'    => 'https://wedevs.com/docs/dokan/settings/page-settings-2/',
+			],
+			[
+				'id'         => 'map_api_configuration',
+				'type'       => 'section',
+				'subpage_id' => 'location',
+			],
+			[
+				'id'          => 'map_api_source',
+				'legacy_key' => [
+					'option' => 'dokan_appearance',
+					'field'  => 'map_api_source',
+				],
+				'type'        => 'field',
+				'variant'     => 'radio_capsule',
+				'section_id'  => 'map_api_configuration',
+				'title'       => esc_html__( 'Map API Source', 'dokan-lite' ),
+				'description' => esc_html__( 'Which map API source you want to use in your site?', 'dokan-lite' ),
+				'default'     => 'google_maps',
+				'options'     => [
+					[
 						'title' => esc_html__( 'Google Maps', 'dokan-lite' ),
 						'value' => 'google_maps',
 					],
-                    [
+					[
 						'title' => esc_html__( 'Mapbox', 'dokan-lite' ),
 						'value' => 'mapbox',
 					],
-                ],
-            ],
-            [
-                'id'           => 'google_map_api_key_group',
-                'type'         => 'fieldgroup',
-                'section_id'   => 'map_api_configuration',
-                'dependencies' => [
-                    [
+				],
+			],
+			[
+				'id'           => 'google_map_api_key_group',
+				'type'         => 'fieldgroup',
+				'section_id'   => 'map_api_configuration',
+				'dependencies' => [
+					[
 						'key' => 'map_api_source',
 						'value' => 'google_maps',
 						'to_self' => true,
@@ -310,7 +391,7 @@ class SettingsSchema {
 						'effect' => 'show',
 						'comparison' => '==',
 					],
-                    [
+					[
 						'key' => 'map_api_source',
 						'value' => 'mapbox',
 						'to_self' => true,
@@ -318,34 +399,38 @@ class SettingsSchema {
 						'effect' => 'hide',
 						'comparison' => '==',
 					],
-                ],
-            ],
-            [
-                'id'          => 'google_map_base',
-                'type'        => 'field',
-                'variant'     => 'base_field_label',
-                'field_group_id' => 'google_map_api_key_group',
-                'title'       => esc_html__( 'Google Map API Key', 'dokan-lite' ),
-                'description' => sprintf(
-                    /* translators: %s: Google Maps API documentation URL */
-                    __( '<a href="%s" target="_blank" rel="noopener noreferrer">API Key</a> is needed to display map on store page.', 'dokan-lite' ),
-                    'https://developers.google.com/maps/documentation/javascript/'
-                ),
-                'tooltip'     => __( 'Insert Google API Key (with hyperlink) to display store map.', 'dokan-lite' ),
-            ],
-            [
-                'id'             => 'google_map_api_key',
-                'type'           => 'field',
-                'variant'        => 'show_hide',
-                'field_group_id' => 'google_map_api_key_group',
-                'placeholder'    => esc_html__( 'Enter your Google Maps API key', 'dokan-lite' ),
-            ],
-            [
-                'id'           => 'mapbox_api_key_group',
-                'type'         => 'fieldgroup',
-                'section_id'   => 'map_api_configuration',
-                'dependencies' => [
-                    [
+				],
+			],
+			[
+				'id'          => 'google_map_base',
+				'type'        => 'field',
+				'variant'     => 'base_field_label',
+				'field_group_id' => 'google_map_api_key_group',
+				'title'       => esc_html__( 'Google Map API Key', 'dokan-lite' ),
+				'description' => sprintf(
+					/* translators: %s: Google Maps API documentation URL */
+					__( '<a href="%s" target="_blank" rel="noopener noreferrer">API Key</a> is needed to display map on store page.', 'dokan-lite' ),
+					'https://developers.google.com/maps/documentation/javascript/'
+				),
+				'tooltip'     => __( 'Insert Google API Key (with hyperlink) to display store map.', 'dokan-lite' ),
+			],
+			[
+				'id'             => 'google_map_api_key',
+				'type'           => 'field',
+				'variant'        => 'show_hide',
+				'field_group_id' => 'google_map_api_key_group',
+				'placeholder'    => esc_html__( 'Enter your Google Maps API key', 'dokan-lite' ),
+				'legacy_key'     => [
+					'option' => 'dokan_appearance',
+					'field'  => 'gmap_api_key',
+				],
+			],
+			[
+				'id'           => 'mapbox_api_key_group',
+				'type'         => 'fieldgroup',
+				'section_id'   => 'map_api_configuration',
+				'dependencies' => [
+					[
 						'key' => 'map_api_source',
 						'value' => 'mapbox',
 						'to_self' => true,
@@ -353,7 +438,7 @@ class SettingsSchema {
 						'effect' => 'show',
 						'comparison' => '==',
 					],
-                    [
+					[
 						'key' => 'map_api_source',
 						'value' => 'google_maps',
 						'to_self' => true,
@@ -361,24 +446,56 @@ class SettingsSchema {
 						'effect' => 'hide',
 						'comparison' => '==',
 					],
-                ],
-            ],
-            [
-                'id'             => 'mapbox_map_base',
-                'type'           => 'field',
-                'variant'        => 'base_field_label',
-                'field_group_id' => 'mapbox_api_key_group',
-                'title'          => esc_html__( 'Mapbox API Key', 'dokan-lite' ),
-                'description'    => esc_html__( 'Enter your Mapbox API key to enable map functionality.', 'dokan-lite' ),
-            ],
-            [
-                'id'             => 'mapbox_api_key',
-                'type'           => 'field',
-                'variant'        => 'show_hide',
-                'field_group_id' => 'mapbox_api_key_group',
-                'placeholder'    => esc_html__( 'Enter your Mapbox API key', 'dokan-lite' ),
-            ],
-        ];
+				],
+			],
+			[
+				'id'             => 'mapbox_map_base',
+				'type'           => 'field',
+				'variant'        => 'base_field_label',
+				'field_group_id' => 'mapbox_api_key_group',
+				'title'          => esc_html__( 'Mapbox API Key', 'dokan-lite' ),
+				'description'    => esc_html__( 'Enter your Mapbox API key to enable map functionality.', 'dokan-lite' ),
+			],
+			[
+				'id'             => 'mapbox_api_key',
+				'type'           => 'field',
+				'variant'        => 'show_hide',
+				'field_group_id' => 'mapbox_api_key_group',
+				'placeholder'    => esc_html__( 'Enter your Mapbox API key', 'dokan-lite' ),
+				'legacy_key'     => [
+					'option' => 'dokan_appearance',
+					'field'  => 'mapbox_access_token',
+				],
+			],
+
+			// Map Placement
+			[
+				'id'         => 'map_placement',
+				'type'       => 'section',
+				'subpage_id' => 'location',
+				'priority'    => 120,
+			],
+			[
+				'id'                 => 'map_placement_locations',
+				'type'               => 'field',
+				'variant'            => 'multicheck',
+				'section_id'         => 'map_placement',
+				'title'              => esc_html__( 'Map Placement Locations', 'dokan-lite' ),
+				'description'        => esc_html__( 'Choose where the store location map appears', 'dokan-lite' ),
+				'tooltip'            => esc_html__( 'Select the pages where you want to display the store location map.', 'dokan-lite' ),
+				'default'            => [ 'store_listing' ],
+				'options'            => [
+					[
+						'title' => esc_html__( 'Store Listing', 'dokan-lite' ),
+						'value' => 'store_listing',
+					],
+				],
+				'legacy_key'         => [
+					'store_listing' => 'dokan_appearance.store_map',
+				],
+				'legacy_transformer' => \WeDevs\Dokan\Admin\Settings\Migration\Transformer\MulticheckArrayBooleanTransformer::for_slots( [ 'store_listing' ] ),
+			],
+		];
     }
 
     /**
@@ -420,7 +537,7 @@ class SettingsSchema {
                 'subpage_id' => 'fees',
             ],
             [
-                'id'          => 'shipping_fee',
+                'id'          => 'shipping_fee_recipient',
                 'type'        => 'field',
                 'variant'     => 'radio_capsule',
                 'section_id'  => 'fees',
@@ -439,9 +556,13 @@ class SettingsSchema {
 						'icon' => 'User',
 					],
                 ],
+                'legacy_key' => [
+                    'option' => 'dokan_selling',
+                    'field'  => 'shipping_fee_recipient',
+                ],
             ],
             [
-                'id'          => 'product_tax_fee',
+                'id'          => 'product_tax_fee_recipient',
                 'type'        => 'field',
                 'variant'     => 'radio_capsule',
                 'section_id'  => 'fees',
@@ -460,9 +581,13 @@ class SettingsSchema {
 						'icon' => 'User',
 					],
                 ],
+                'legacy_key' => [
+                    'option' => 'dokan_selling',
+                    'field'  => 'tax_fee_recipient',
+                ],
             ],
             [
-                'id'          => 'shipping_tax_fee',
+                'id'          => 'shipping_tax_fee_recipient',
                 'type'        => 'field',
                 'variant'     => 'radio_capsule',
                 'section_id'  => 'fees',
@@ -480,6 +605,10 @@ class SettingsSchema {
 						'value' => 'admin',
 						'icon' => 'User',
 					],
+                ],
+                'legacy_key' => [
+                    'option' => 'dokan_selling',
+                    'field'  => 'shipping_tax_fee_recipient',
                 ],
             ],
 
@@ -685,6 +814,8 @@ class SettingsSchema {
 					'label' => esc_html__( 'Disabled', 'dokan-lite' ),
 					'value' => 'off',
 				],
+                'legacy_key'         => 'dokan_withdraw.withdraw_methods.paypal',
+                'legacy_transformer' => \WeDevs\Dokan\Admin\Settings\Migration\Transformer\WithdrawMethodToggleTransformer::for_method( 'paypal' ),
             ],
             [
                 'id'               => 'paypal_withdraw_charges',
@@ -716,6 +847,8 @@ class SettingsSchema {
                 'validations'      => [
                     [ 'not_empty' => esc_html__( 'Both percentage and fixed fee is required.', 'dokan-lite' ) ],
                 ],
+                'legacy_key'         => 'dokan_withdraw.withdraw_charges.paypal',
+                'legacy_transformer' => \WeDevs\Dokan\Admin\Settings\Migration\Transformer\WithdrawChargeTransformer::class,
             ],
             // Bank Transfer
             [
@@ -740,6 +873,8 @@ class SettingsSchema {
 					'label' => esc_html__( 'Disabled', 'dokan-lite' ),
 					'value' => 'off',
 				],
+                'legacy_key'         => 'dokan_withdraw.withdraw_methods.bank',
+                'legacy_transformer' => \WeDevs\Dokan\Admin\Settings\Migration\Transformer\WithdrawMethodToggleTransformer::for_method( 'bank' ),
             ],
             [
                 'id'               => 'bank_transfer_withdraw_charges',
@@ -771,6 +906,8 @@ class SettingsSchema {
                 'validations'      => [
                     [ 'not_empty' => esc_html__( 'Both percentage and fixed fee is required.', 'dokan-lite' ) ],
                 ],
+                'legacy_key'         => 'dokan_withdraw.withdraw_charges.bank',
+                'legacy_transformer' => \WeDevs\Dokan\Admin\Settings\Migration\Transformer\WithdrawChargeTransformer::class,
             ],
             // Note: Pro adds more withdraw methods (Skrill, Razorpay, Stripe, Paystack, Custom) via dokan_get_admin_settings_schema filter
 
@@ -789,7 +926,19 @@ class SettingsSchema {
                 'description' => esc_html__( 'Minimum balance required to make a withdraw request. Leave blank to set no minimum limits.', 'dokan-lite' ),
                 'prefix'      => function_exists( 'get_woocommerce_currency_symbol' ) ? get_woocommerce_currency_symbol() : '$',
                 'default'     => 50,
+                'legacy_key' => [
+                    'option' => 'dokan_withdraw',
+                    'field'  => 'withdraw_limit',
+                ],
             ],
+
+            // Order Status for Withdraw
+            [
+                'id'         => 'withdraw_order_status_section',
+                'type'       => 'section',
+                'subpage_id' => 'withdraw_charge',
+            ],
+            self::withdraw_order_status_field(),
 
             // COD Payments
             [
@@ -798,7 +947,7 @@ class SettingsSchema {
                 'subpage_id' => 'withdraw_charge',
             ],
             [
-                'id'          => 'cod_payments',
+                'id'          => 'include_cod_payments_in_balance',
                 'type'        => 'field',
                 'variant'     => 'radio_capsule',
                 'section_id'  => 'cod_payments_section',
@@ -808,13 +957,18 @@ class SettingsSchema {
                 'options'     => [
                     [
 						'title' => esc_html__( 'Include', 'dokan-lite' ),
-						'value' => 'include',
+						'value' => 'on',
 					],
                     [
 						'title' => esc_html__( 'Exclude', 'dokan-lite' ),
-						'value' => 'exclude',
+						'value' => 'off',
 					],
                 ],
+                'legacy_key' => [
+                    'option' => 'dokan_withdraw',
+                    'field'  => 'exclude_cod_payment',
+                ],
+                'legacy_transformer' => \WeDevs\Dokan\Admin\Settings\Migration\Transformer\InvertOnOffTransformer::class,
             ],
 
             // === SubPage: Reverse Withdrawal ===
@@ -838,7 +992,7 @@ class SettingsSchema {
                 'variant'       => 'switch',
                 'section_id'    => 'reverse_withdrawal_section',
                 'title'         => esc_html__( 'Activate Reverse Withdrawal (Cash On Delivery)', 'dokan-lite' ),
-                'description'   => esc_html__( 'Enable this option to activate automatic balance deducting from vendors.', 'dokan-lite' ),
+                'description'   => esc_html__( 'Enable this option to activate automatic balance collection from vendors.', 'dokan-lite' ),
                 'default'       => 'off',
                 'enable_state'  => [
 					'label' => esc_html__( 'Enabled', 'dokan-lite' ),
@@ -848,9 +1002,13 @@ class SettingsSchema {
 					'label' => esc_html__( 'Disabled', 'dokan-lite' ),
 					'value' => 'off',
 				],
+                'legacy_key' => [
+					'option' => 'dokan_reverse_withdrawal',
+					'field' => 'enabled',
+				],
             ],
             [
-                'id'          => 'billing_type',
+                'id'          => 'reverse_withdrawal_billing_type',
                 'legacy_key' => [
                     'option' => 'dokan_reverse_withdrawal',
                     'field'  => 'billing_type',
@@ -875,7 +1033,7 @@ class SettingsSchema {
                 ],
             ],
             [
-                'id'           => 'reverse_balance_threshold',
+                'id'           => 'reverse_withdrawal_balance_threshold',
                 'legacy_key' => [
                     'option' => 'dokan_reverse_withdrawal',
                     'field'  => 'reverse_balance_threshold',
@@ -896,7 +1054,7 @@ class SettingsSchema {
                 'step'         => 0.5,
                 'dependencies' => [
                     [
-						'key' => 'billing_type',
+						'key' => 'reverse_withdrawal_billing_type',
 						'value' => 'by_amount',
 						'to_self' => true,
 						'attribute' => 'display',
@@ -904,7 +1062,7 @@ class SettingsSchema {
 						'comparison' => '===',
 					],
                     [
-						'key' => 'billing_type',
+						'key' => 'reverse_withdrawal_billing_type',
 						'value' => 'by_month',
 						'to_self' => true,
 						'attribute' => 'display',
@@ -914,7 +1072,7 @@ class SettingsSchema {
                 ],
             ],
             [
-                'id'           => 'monthly_billing_day',
+                'id'           => 'reverse_withdrawal_monthly_billing_day',
                 'legacy_key' => [
                     'option' => 'dokan_reverse_withdrawal',
                     'field'  => 'monthly_billing_day',
@@ -925,13 +1083,30 @@ class SettingsSchema {
                 'title'        => esc_html__( 'Monthly Billing Date', 'dokan-lite' ),
                 'description'  => esc_html__( 'Enter the day of month when you want to send reverse withdrawal balance invoices to vendors.', 'dokan-lite' ),
                 'addon_icon'   => true,
-                'prefix'       => 'Calendar',
                 'default'      => 1,
                 'min_value'    => 1,
                 'max_value'    => 28,
+                'validations'  => [
+                    [
+                        'rules'   => 'not_empty|min_value|max_value',
+                        'message' => '',
+                        'params'  => [
+							'min' => 1,
+							'max' => 28,
+						],
+                    ],
+                    [
+                        'rules'   => 'sum_max',
+                        'message' => esc_html__( 'Monthly billing date (when billing type is monthly) plus grace period must not exceed 28.', 'dokan-lite' ),
+                        'params'  => [
+							'field' => 'reverse_withdrawal_due_period',
+							'max' => 28,
+						],
+                    ],
+                ],
                 'dependencies' => [
                     [
-						'key' => 'billing_type',
+						'key' => 'reverse_withdrawal_billing_type',
 						'value' => 'by_month',
 						'to_self' => true,
 						'attribute' => 'display',
@@ -939,7 +1114,7 @@ class SettingsSchema {
 						'comparison' => '===',
 					],
                     [
-						'key' => 'billing_type',
+						'key' => 'reverse_withdrawal_billing_type',
 						'value' => 'by_amount',
 						'to_self' => true,
 						'attribute' => 'display',
@@ -949,7 +1124,7 @@ class SettingsSchema {
                 ],
             ],
             [
-                'id'          => 'due_period',
+                'id'          => 'reverse_withdrawal_due_period',
                 'legacy_key' => [
                     'option' => 'dokan_reverse_withdrawal',
                     'field'  => 'due_period',
@@ -960,26 +1135,39 @@ class SettingsSchema {
                 'title'       => esc_html__( 'Grace Period', 'dokan-lite' ),
                 'description' => esc_html__( 'Number of days to wait before enforcing collection actions. Set to 0 for immediate action.', 'dokan-lite' ),
                 'addon_icon'  => true,
-                'prefix'      => 'Calendar',
                 'postfix'     => esc_html__( 'Days', 'dokan-lite' ),
                 'default'     => 7,
                 'min_value'   => 0,
                 'max_value'   => 28,
                 'step'        => 1,
+                'validations' => [
+                    [
+                        'rules'   => 'not_empty|min_value|max_value',
+                        'message' => '',
+                        'params'  => [
+							'min' => 0,
+							'max' => 28,
+						],
+                    ],
+                    [
+                        'rules'   => 'sum_max',
+                        'message' => esc_html__( 'Monthly billing date (when billing type is monthly) plus grace period must not exceed 28.', 'dokan-lite' ),
+                        'params'  => [
+							'field' => 'reverse_withdrawal_monthly_billing_day',
+							'max' => 28,
+						],
+                    ],
+                ],
             ],
             [
-                'id'          => 'failed_actions',
-                'legacy_key' => [
-                    'option' => 'dokan_reverse_withdrawal',
-                    'field'  => 'failed_actions',
-                ],
-                'type'        => 'field',
-                'variant'     => 'multicheck',
-                'section_id'  => 'reverse_withdrawal_section',
-                'title'       => esc_html__( 'Penalty Actions After Grace Period', 'dokan-lite' ),
-                'description' => esc_html__( 'Choose actions to take when the grace period expires and payment remains outstanding.', 'dokan-lite' ),
-                'default'     => [ 'enable_catalog_mode' ],
-                'options'     => [
+                'id'                 => 'reverse_withdrawal_failed_penalty_actions',
+                'type'               => 'field',
+                'variant'            => 'multicheck',
+                'section_id'         => 'reverse_withdrawal_section',
+                'title'              => esc_html__( 'Penalty Actions After Grace Period', 'dokan-lite' ),
+                'description'        => esc_html__( 'Choose actions to take when the grace period expires and payment remains outstanding.', 'dokan-lite' ),
+                'default'            => [ 'enable_catalog_mode' ],
+                'options'            => [
                     [
 						'title' => esc_html__( 'Disable Add to Cart Button', 'dokan-lite' ),
 						'value' => 'enable_catalog_mode',
@@ -993,6 +1181,18 @@ class SettingsSchema {
 						'value' => 'status_inactive',
 					],
                 ],
+                // Legacy `dokan_reverse_withdrawal.failed_actions` is a WP
+                // multicheck parent array (key-as-value). Bridge each option
+                // to its own sub-path so unselected slots are cleared without
+                // wiping sibling keys.
+                'legacy_key'         => [
+                    'enable_catalog_mode' => 'dokan_reverse_withdrawal.failed_actions.enable_catalog_mode',
+                    'hide_withdraw_menu'  => 'dokan_reverse_withdrawal.failed_actions.hide_withdraw_menu',
+                    'status_inactive'     => 'dokan_reverse_withdrawal.failed_actions.status_inactive',
+                ],
+                'legacy_transformer' => \WeDevs\Dokan\Admin\Settings\Migration\Transformer\MulticheckArrayTransformer::for_slots(
+                    [ 'enable_catalog_mode', 'hide_withdraw_menu', 'status_inactive' ]
+                ),
             ],
             [
                 'id'            => 'display_notice',
@@ -1015,6 +1215,46 @@ class SettingsSchema {
 					'value' => 'off',
 				],
             ],
+        ];
+    }
+
+    /**
+     * Build the `withdraw_order_status` multi-switch field.
+     *
+     * Options are derived from the legacy `dokan_settings_withdraw_order_status_options`
+     * filter so Pro modules / extensions that already extend that filter continue to
+     * add statuses on both the legacy and new UIs with one declaration. The new
+     * field stores a `Record<string,bool>` keyed by status (e.g. `wc-completed`),
+     * each slot bridged through {@see MulticheckSlotTransformer} to the legacy
+     * `dokan_withdraw.withdraw_order_status` parent array.
+     *
+     * @return array
+     */
+    private static function withdraw_order_status_field(): array {
+        $statuses = AdminSettings::withdraw_order_status_options();
+
+        $options    = [];
+        $legacy_key = [];
+        foreach ( $statuses as $value => $label ) {
+            $options[]            = [
+                'value' => (string) $value,
+                'label' => (string) $label,
+            ];
+            $legacy_key[ $value ] = 'dokan_withdraw.withdraw_order_status.' . $value;
+        }
+        $slot_keys = array_keys( $legacy_key );
+
+        return [
+            'id'                 => 'withdraw_order_status',
+            'type'               => 'field',
+            'variant'            => 'multicheck',
+            'section_id'         => 'withdraw_order_status_section',
+            'title'              => esc_html__( 'Order Status for Withdraw', 'dokan-lite' ),
+            'description'        => esc_html__( 'Order status for which vendor can make a withdraw request.', 'dokan-lite' ),
+            'options'            => $options,
+            'default'            => [ 'wc-processing' ],
+            'legacy_key'         => $legacy_key,
+            'legacy_transformer' => \WeDevs\Dokan\Admin\Settings\Migration\Transformer\MulticheckArrayTransformer::for_slots( $slot_keys ),
         ];
     }
 
@@ -1077,6 +1317,58 @@ class SettingsSchema {
 					'label' => esc_html__( 'Disabled', 'dokan-lite' ),
 					'value' => 'off',
 				],
+                'legacy_key' => [
+                    'option' => 'dokan_general',
+                    'field' => 'enabled_address_on_reg',
+                ],
+            ],
+            [
+                'id'            => 'vendor_setup_wizard_logo',
+                'type'          => 'field',
+                'variant'       => 'wp_media_upload',
+                'subpage_id'    => 'vendor_onboarding',
+                'title'         => esc_html__( 'Vendor Setup Wizard Logo', 'dokan-lite' ),
+                'description'   => esc_html__( 'Upload a logo for the vendor setup wizard.', 'dokan-lite' ),
+                'allowed_types' => [ 'image/jpeg', 'image/png', 'image/gif', 'image/svg+xml' ],
+                'max_file_size' => 2097152,
+                'legacy_key'    => [
+                    'option' => 'dokan_general',
+                    'field'  => 'setup_wizard_logo_url',
+                ],
+            ],
+            [
+                'id'          => 'vendor_setup_wizard_message',
+                'type'        => 'field',
+                'variant'     => 'rich_text',
+                'subpage_id'  => 'vendor_onboarding',
+                'title'       => esc_html__( 'Vendor Setup Wizard Message', 'dokan-lite' ),
+                'description' => esc_html__( 'Welcome message shown to vendors during setup.', 'dokan-lite' ),
+                'legacy_key'    => [
+                    'option' => 'dokan_general',
+                    'field'  => 'setup_wizard_message',
+                ],
+            ],
+            [
+                'id'            => 'welcome_wizard',
+                'type'          => 'field',
+                'variant'       => 'switch',
+                'subpage_id'    => 'vendor_onboarding',
+                'title'         => esc_html__( 'Welcome Wizard', 'dokan-lite' ),
+                'description'   => esc_html__( 'Show the vendor setup wizard after first login.', 'dokan-lite' ),
+                'default'       => 'on',
+                'enable_state'  => [
+					'label' => esc_html__( 'Enabled', 'dokan-lite' ),
+					'value' => 'on',
+				],
+                'disable_state' => [
+					'label' => esc_html__( 'Disabled', 'dokan-lite' ),
+					'value' => 'off',
+				],
+                'legacy_key'    => [
+					'option' => 'dokan_general',
+					'field'  => 'disable_welcome_wizard',
+				],
+                'legacy_transformer' => \WeDevs\Dokan\Admin\Settings\Migration\Transformer\InvertOnOffTransformer::class,
             ],
 
             // === SubPage: Vendor Capabilities ===
@@ -1094,7 +1386,7 @@ class SettingsSchema {
                 'subpage_id' => 'vendor_capabilities',
             ],
             [
-                'id'            => 'one_page_creation',
+                'id'            => 'one_page_product_creation',
                 'type'          => 'field',
                 'variant'       => 'switch',
                 'section_id'    => 'vendor_capabilities',
@@ -1110,6 +1402,10 @@ class SettingsSchema {
 					'label' => esc_html__( 'Disabled', 'dokan-lite' ),
 					'value' => 'off',
 				],
+                'legacy_key'    => [
+                    'option' => 'dokan_selling',
+                    'field'  => 'one_step_product_create',
+                ],
             ],
             [
                 'id'            => 'product_popup',
@@ -1130,7 +1426,7 @@ class SettingsSchema {
 				],
                 'dependencies'  => [
                     [
-						'key' => 'one_page_creation',
+						'key' => 'one_page_product_creation',
 						'value' => 'on',
 						'to_self' => true,
 						'attribute' => 'display',
@@ -1138,7 +1434,7 @@ class SettingsSchema {
 						'comparison' => '!==',
 					],
                     [
-						'key' => 'one_page_creation',
+						'key' => 'one_page_product_creation',
 						'value' => 'on',
 						'to_self' => true,
 						'attribute' => 'display',
@@ -1146,6 +1442,11 @@ class SettingsSchema {
 						'comparison' => '===',
 					],
                 ],
+                'legacy_key'    => [
+                    'option' => 'dokan_selling',
+                    'field'  => 'disable_product_popup',
+                ],
+                'legacy_transformer' => \WeDevs\Dokan\Admin\Settings\Migration\Transformer\InvertOnOffTransformer::class,
             ],
             [
                 'id'            => 'order_status_change',
@@ -1170,7 +1471,7 @@ class SettingsSchema {
 				],
             ],
             [
-                'id'            => 'select_any_category',
+                'id'            => 'vendor_select_any_product_category',
                 'type'          => 'field',
                 'variant'       => 'switch',
                 'section_id'    => 'vendor_capabilities',
@@ -1185,6 +1486,10 @@ class SettingsSchema {
 					'label' => esc_html__( 'Disabled', 'dokan-lite' ),
 					'value' => 'off',
 				],
+                'legacy_key'    => [
+                    'option' => 'dokan_selling',
+                    'field'  => 'dokan_any_category_selection',
+                ],
             ],
         ];
     }
@@ -1208,7 +1513,7 @@ class SettingsSchema {
                 'id'          => 'store',
                 'type'        => 'subpage',
                 'page_id'     => 'appearance',
-                'title'       => esc_html__( 'Store Page', 'dokan-lite' ),
+                'title'       => esc_html__( 'Store', 'dokan-lite' ),
                 'priority'    => 100,
             ],
 
@@ -1230,6 +1535,10 @@ class SettingsSchema {
                 'default'     => 12,
                 'min_value'   => 1,
                 'step'        => 1,
+                'legacy_key' => [
+                    'option' => 'dokan_general',
+                    'field' => 'store_products_per_page',
+                ],
             ],
 
             // Google reCAPTCHA
@@ -1372,6 +1681,10 @@ class SettingsSchema {
 					'label' => esc_html__( 'Disable', 'dokan-lite' ),
 					'value' => 'off',
 				],
+                'legacy_key' => [
+					'option' => 'dokan_appearance',
+					'field' => 'contact_seller',
+				],
             ],
 
             // Banner Dimension
@@ -1431,6 +1744,11 @@ class SettingsSchema {
 						'image' => DOKAN_PLUGIN_ASSEST . '/images/admin-settings-icons/store/store-page-template-four.svg',
 					],
                 ],
+                'radio_variant' => 'template',
+                'legacy_key' => [
+                    'option' => 'dokan_appearance',
+                    'field'  => 'store_header_template',
+                ],
             ],
 
             // Store Time Widget
@@ -1454,6 +1772,10 @@ class SettingsSchema {
                 'disable_state' => [
 					'label' => esc_html__( 'Disable', 'dokan-lite' ),
 					'value' => 'off',
+				],
+				'legacy_key' => [
+					'option' => 'dokan_appearance',
+					'field' => 'store_open_close',
 				],
             ],
 
@@ -1479,6 +1801,10 @@ class SettingsSchema {
 					'label' => esc_html__( 'Disable', 'dokan-lite' ),
 					'value' => 'off',
 				],
+                'legacy_key' => [
+					'option' => 'dokan_appearance',
+					'field' => 'enable_theme_store_sidebar',
+				],
             ],
 
             // Vendor Info Visibility
@@ -1490,10 +1816,34 @@ class SettingsSchema {
             [
                 'id'          => 'vendor_info_visibility',
                 'type'        => 'field',
-                'variant'     => 'vendor_info_preview',
+                'variant'     => 'info_preview',
                 'section_id'  => 'vendor_info_visibility_section',
                 'title'       => esc_html__( 'Vendor Info Visibility', 'dokan-lite' ),
                 'description' => esc_html__( 'Choose what vendor details to show customers in single store page.', 'dokan-lite' ),
+                'options'     => [
+                    [
+                        'value' => 'store_email',
+                        'label' => esc_html__( 'Email Address', 'dokan-lite' ),
+                    ],
+                    [
+                        'value' => 'store_phone',
+                        'label' => esc_html__( 'Phone Number', 'dokan-lite' ),
+                    ],
+                    [
+                        'value' => 'store_address',
+                        'label' => esc_html__( 'Store Address', 'dokan-lite' ),
+                    ],
+                ],
+                'default'     => [
+                    'store_email'   => true,
+                    'store_phone'   => true,
+                    'store_address' => true,
+                ],
+                'legacy_key' => [
+                    'option' => 'dokan_appearance',
+                    'field'  => 'hide_vendor_info',
+                ],
+                'legacy_transformer' => \WeDevs\Dokan\Admin\Settings\Migration\Transformer\HideVendorInfoTransformer::class,
             ],
 
             // Dokan Font
@@ -1518,6 +1868,11 @@ class SettingsSchema {
 					'label' => esc_html__( 'Disable', 'dokan-lite' ),
 					'value' => 'off',
 				],
+                'legacy_key' => [
+                    'option' => 'dokan_appearance',
+                    'field'  => 'disable_dokan_fontawesome',
+                ],
+                'legacy_transformer' => \WeDevs\Dokan\Admin\Settings\Migration\Transformer\InvertOnOffTransformer::class,
             ],
 
             // Single Product Preview
@@ -1527,12 +1882,38 @@ class SettingsSchema {
                 'subpage_id' => 'store',
             ],
             [
-                'id'          => 'single_product_preview',
+                'id'          => 'single_product_page_appearance',
                 'type'        => 'field',
-                'variant'     => 'single_product_preview',
+                'variant'     => 'info_preview',
                 'section_id'  => 'single_product_preview_section',
                 'title'       => esc_html__( 'Single Product Page Appearance', 'dokan-lite' ),
                 'description' => esc_html__( 'Choose which sections to show when customers view individual products.', 'dokan-lite' ),
+                'options'     => [
+                    [
+                        'value' => 'vendor_info',
+                        'label' => esc_html__( 'Vendor Info', 'dokan-lite' ),
+                    ],
+                    [
+                        'value' => 'more_products_tab',
+                        'label' => esc_html__( 'More products tab', 'dokan-lite' ),
+                    ],
+                ],
+                'default'     => [
+                    'vendor_info'       => true,
+                    'more_products_tab' => true,
+                    'shipping_tab'      => true,
+                ],
+                'legacy_key'  => [
+                    'vendor_info'       => [
+						'option' => 'dokan_general',
+						'field' => 'show_vendor_info',
+					],
+                    'more_products_tab' => [
+						'option' => 'dokan_general',
+						'field' => 'enabled_more_products_tab',
+					],
+                ],
+                'legacy_transformer' => \WeDevs\Dokan\Admin\Settings\Migration\Transformer\SingleProductAppearanceTransformer::class,
             ],
         ];
     }
@@ -1606,6 +1987,7 @@ class SettingsSchema {
                 'variant'       => 'switch',
                 'section_id'    => 'privacy_settings',
                 'title'         => esc_html__( 'Privacy Policy', 'dokan-lite' ),
+                'description'   => esc_html__( 'Show privacy policy link on vendor store contact forms.', 'dokan-lite' ),
                 'default'       => 'on',
                 'enable_state'  => [
 					'label' => esc_html__( 'Enabled', 'dokan-lite' ),
@@ -1615,6 +1997,10 @@ class SettingsSchema {
 					'label' => esc_html__( 'Disabled', 'dokan-lite' ),
 					'value' => 'off',
 				],
+                'legacy_key' => [
+					'option' => 'dokan_privacy',
+					'field' => 'enable_privacy',
+				],
             ],
             [
                 'id'         => 'privacy_policy_page',
@@ -1622,7 +2008,12 @@ class SettingsSchema {
                 'variant'    => 'select',
                 'section_id' => 'privacy_settings',
                 'title'      => esc_html__( 'Privacy Policy Page', 'dokan-lite' ),
+                'description' => esc_html__( 'Choose which page displays your privacy policy.', 'dokan-lite' ),
                 'options'    => self::get_page_options(),
+                'legacy_key' => [
+					'option' => 'dokan_privacy',
+					'field' => 'privacy_page',
+				],
             ],
             [
                 'id'         => 'privacy_policy_content',
@@ -1635,6 +2026,11 @@ class SettingsSchema {
                 'variant'    => 'rich_text',
                 'section_id' => 'privacy_policy_content',
                 'title'      => esc_html__( 'Privacy Policy Content', 'dokan-lite' ),
+                'description' => esc_html__( 'Create or edit your privacy policy text that will be displayed to users.', 'dokan-lite' ),
+                'legacy_key' => [
+					'option' => 'dokan_privacy',
+					'field' => 'privacy_policy',
+				],
             ],
             [
                 'id'         => 'admin_access_section',
@@ -1668,31 +2064,30 @@ class SettingsSchema {
                 'subpage_id' => 'privacy',
             ],
             [
-                'id'              => 'data_clear_on_uninstall',
-                'legacy_key' => [
+                'id'             => 'data_clear_on_uninstall',
+                'legacy_key'     => [
                     'option' => 'dokan_general',
                     'field'  => 'data_clear_on_uninstall',
                 ],
-                'type'            => 'field',
-                'variant'         => 'switch',
-                'section_id'      => 'data_clear_section',
-                'title'           => esc_html__( 'Clear Data on Uninstall', 'dokan-lite' ),
-                'description'     => esc_html__( 'Remove all Dokan data when the plugin is uninstalled.', 'dokan-lite' ),
-                'default'         => 'off',
-                'switcher_type'   => 'error',
-                'should_confirm'  => true,
-                'enable_state'    => [
-					'label' => esc_html__( 'Clear Data', 'dokan-lite' ),
-					'value' => 'on',
-				],
-                'disable_state'   => [
-					'label' => esc_html__( 'Disabled', 'dokan-lite' ),
-					'value' => 'off',
-				],
-                'confirm_modal'   => [
+                'type'           => 'field',
+                'variant'        => 'danger_switch',
+                'section_id'     => 'data_clear_section',
+                'title'          => esc_html__( 'Data Clear Consent', 'dokan-lite' ),
+                'description'    => esc_html__( 'Permanently delete all data and database tables related to Dokan and Dokan Pro plugins. This action cannot be undone.', 'dokan-lite' ),
+                'icon'           => 'TriangleAlert',
+                'default'        => 'off',
+                'enable_state'   => [
+                    'label' => esc_html__( 'Clear Data', 'dokan-lite' ),
+                    'value' => 'on',
+                ],
+                'disable_state'  => [
+                    'label' => esc_html__( 'Disabled', 'dokan-lite' ),
+                    'value' => 'off',
+                ],
+                'confirm_modal'  => [
                     'title'             => esc_html__( 'Are you sure to delete all data?', 'dokan-lite' ),
                     'confirmationTitle' => esc_html__( 'Are you sure to delete all data?', 'dokan-lite' ),
-                    'description'       => esc_html__( 'All data and tables related to Dokan and Dokan Pro will be deleted permanently. This action cannot be undone.', 'dokan-lite' ),
+                    'description'       => esc_html__( 'All data and tables related to Dokan and Dokan Pro will be deleted permanently. You will not be able to recover your lost data unless you keep a backup. Do you want to continue?', 'dokan-lite' ),
                     'confirmText'       => esc_html__( 'Yes, Delete', 'dokan-lite' ),
                     'cancelText'        => esc_html__( 'Cancel', 'dokan-lite' ),
                     'checkboxLabel'     => esc_html__( 'Yes, I understand.', 'dokan-lite' ),
@@ -1704,13 +2099,50 @@ class SettingsSchema {
     /**
      * AI Assist page schema.
      *
-     * Note: Provider-specific fields (API key, model select per provider) are
-     * generated dynamically based on registered AI providers via the Intelligence module.
-     * The static fields (toggle + engine select) are defined here.
+     * Page/subpage/section structure is static; engine options and per-provider
+     * fieldgroups (api_info / api_notice / api_key / model) are generated
+     * dynamically from {@see \WeDevs\Dokan\Intelligence\Manager}'s registered
+     * providers, so adding a new AI provider (Lite or Pro) flows through with
+     * no schema edits. Each generated api_key/model field declares its own
+     * `legacy_key` against the `dokan_ai` option using the established
+     * `dokan_ai_<provider_id>_api_key` / `dokan_ai_<provider_id>_model`
+     * convention (`dokan_ai_image_<provider_id>_*` for the image side), so the
+     * legacy admin form and the new UI stay in sync via the bridge.
+     *
+     * The image section is appended only when at least one image-capable
+     * provider is registered — Lite ships none, Pro registers Leonardo AI
+     * (and any others) via the Intelligence Manager, so Lite-only installs
+     * see just the text section.
      *
      * @return array
      */
     private static function ai_assist_page(): array {
+        $on_generate = [
+            [ 'key' => 'product_info_generate', 'value' => 'on', 'to_self' => true, 'attribute' => 'display', 'effect' => 'show', 'comparison' => '===' ],
+            [ 'key' => 'product_info_generate', 'value' => 'on', 'to_self' => true, 'attribute' => 'display', 'effect' => 'hide', 'comparison' => '!==' ],
+        ];
+        $on_enhance = [
+            [ 'key' => 'product_image_enhancement', 'value' => 'on', 'to_self' => true, 'attribute' => 'display', 'effect' => 'show', 'comparison' => '===' ],
+            [ 'key' => 'product_image_enhancement', 'value' => 'on', 'to_self' => true, 'attribute' => 'display', 'effect' => 'hide', 'comparison' => '!==' ],
+        ];
+        $when_engine = static function ( string $engine_key, string $value ): array {
+            return [
+                [ 'key' => $engine_key, 'value' => $value, 'to_self' => true, 'attribute' => 'display', 'effect' => 'show', 'comparison' => '===' ],
+                [ 'key' => $engine_key, 'value' => $value, 'to_self' => true, 'attribute' => 'display', 'effect' => 'hide', 'comparison' => '!==' ],
+            ];
+        };
+
+        $text_providers  = self::resolve_ai_providers( 'text' );
+        $image_providers = self::resolve_ai_providers( 'image' );
+
+        $provider_options = static function ( array $providers ): array {
+            $out = [];
+            foreach ( $providers as $id => $provider ) {
+                $out[] = [ 'title' => $provider->get_title(), 'value' => (string) $id ];
+            }
+            return $out;
+        };
+
         $elements = [
             [
                 'id'          => 'ai_assist',
@@ -1729,6 +2161,8 @@ class SettingsSchema {
                 'priority'    => 100,
                 'doc_link'    => 'https://dokan.co/docs/wordpress/settings/dokan-ai-assistant/',
             ],
+
+            // ===== Product Info (text) =====
             [
                 'id'         => 'product_image_section',
                 'type'       => 'section',
@@ -1741,15 +2175,9 @@ class SettingsSchema {
                 'section_id'    => 'product_image_section',
                 'title'         => esc_html__( 'Product Info Generate', 'dokan-lite' ),
                 'description'   => esc_html__( 'Let vendors generate product info by AI.', 'dokan-lite' ),
-                'default'       => 'off',
-                'enable_state'  => [
-					'label' => esc_html__( 'Enabled', 'dokan-lite' ),
-					'value' => 'on',
-				],
-                'disable_state' => [
-					'label' => esc_html__( 'Disabled', 'dokan-lite' ),
-					'value' => 'off',
-				],
+                'default'       => 'on',
+                'enable_state'  => [ 'label' => esc_html__( 'Enabled', 'dokan-lite' ), 'value' => 'on' ],
+                'disable_state' => [ 'label' => esc_html__( 'Disabled', 'dokan-lite' ), 'value' => 'off' ],
             ],
             [
                 'id'           => 'product_info_engine',
@@ -1759,222 +2187,219 @@ class SettingsSchema {
                 'title'        => esc_html__( 'Engine', 'dokan-lite' ),
                 'description'  => esc_html__( 'Select which AI provider to use for generating content.', 'dokan-lite' ),
                 'default'      => 'openai',
-                'options'      => [], // Populated dynamically from registered AI providers
-                'dependencies' => [
-                    [
-						'key' => 'product_info_generate',
-						'value' => 'on',
-						'to_self' => true,
-						'attribute' => 'display',
-						'effect' => 'show',
-						'comparison' => '===',
-					],
-                    [
-						'key' => 'product_info_generate',
-						'value' => 'off',
-						'to_self' => true,
-						'attribute' => 'display',
-						'effect' => 'hide',
-						'comparison' => '!==',
-					],
-                ],
+                'options'      => $provider_options( $text_providers ),
+                'legacy_key'   => 'dokan_ai.dokan_ai_engine',
+                'dependencies' => $on_generate,
             ],
-            // Note: Per-provider FieldGroups ({provider}_api_info_group) with api_info, api_notice,
-            // api_key, and model fields are generated dynamically by the Intelligence module
-            // and appended via the dokan_get_admin_settings_schema filter.
         ];
 
-        // Generate provider-specific fields dynamically
-        if ( class_exists( '\WeDevs\Dokan\Intelligence\Manager' ) ) {
-            try {
-                $text_providers = dokan()->get_container()->get( \WeDevs\Dokan\Intelligence\Manager::class )->get_text_supported_providers();
+        // Per-text-provider fieldgroups — dynamic from Manager registry.
+        foreach ( $text_providers as $provider_id => $provider ) {
+            $pid = (string) $provider_id;
+            $elements = array_merge(
+                $elements,
+                self::ai_provider_group(
+                    [
+                        'provider_id'     => $pid,
+                        'provider'        => $provider,
+                        'section_id'      => 'product_image_section',
+                        'engine_field_id' => 'product_info_engine',
+                        'toggle_deps'     => $on_generate,
+                        'engine_deps'     => $when_engine( 'product_info_engine', $pid ),
+                        'api_key_legacy'  => 'dokan_ai.dokan_ai_' . $pid . '_api_key',
+                        'model_legacy'    => 'dokan_ai.dokan_ai_' . $pid . '_model',
+                        'model_kind'      => 'text',
+                        'id_prefix'       => 'text',
+                    ]
+                )
+            );
+        }
 
-                // Add provider options to engine select
-                $options = [];
-                foreach ( $text_providers as $provider_id => $provider ) {
-                    $options[] = [
-						'title' => $provider->get_title(),
-						'value' => $provider_id,
-					];
-                }
-                // Update the engine select options
-                foreach ( $elements as &$el ) {
-                    if ( isset( $el['id'] ) && $el['id'] === 'product_info_engine' ) {
-                        $el['options'] = $options;
-                        break;
-                    }
-                }
-                unset( $el );
+        // ===== Product Image Enhancement (Pro: only renders when image providers exist) =====
+        if ( ! empty( $image_providers ) ) {
+            $elements[] = [
+                'id'         => 'product_description_section',
+                'type'       => 'section',
+                'subpage_id' => 'product_generation',
+            ];
+            $elements[] = [
+                'id'            => 'product_image_enhancement',
+                'type'          => 'field',
+                'variant'       => 'switch',
+                'section_id'    => 'product_description_section',
+                'title'         => esc_html__( 'Product Image Enhancement', 'dokan-lite' ),
+                'description'   => esc_html__( 'Allow vendors to enhance and generate professional product images using AI.', 'dokan-lite' ),
+                'default'       => 'off',
+                'enable_state'  => [ 'label' => esc_html__( 'Enabled', 'dokan-lite' ), 'value' => 'on' ],
+                'disable_state' => [ 'label' => esc_html__( 'Disabled', 'dokan-lite' ), 'value' => 'off' ],
+                'legacy_key'    => 'dokan_ai.dokan_ai_image_gen_availability',
+            ];
+            $elements[] = [
+                'id'           => 'product_image_engine',
+                'type'         => 'field',
+                'variant'      => 'select',
+                'section_id'   => 'product_description_section',
+                'title'        => esc_html__( 'Engine', 'dokan-lite' ),
+                'description'  => esc_html__( 'Select your AI provider for image processing and generation.', 'dokan-lite' ),
+                'default'      => 'openai',
+                'options'      => $provider_options( $image_providers ),
+                'legacy_key'   => 'dokan_ai.dokan_ai_image_engine',
+                'dependencies' => $on_enhance,
+            ];
 
-                // Add per-provider field groups
-                foreach ( $text_providers as $provider_id => $provider ) {
-                    $dep_generate = 'product_info_generate';
-                    $dep_engine   = 'product_info_engine';
-
-                    $elements[] = [
-                        'id'           => $provider_id . '_api_info_group',
-                        'type'         => 'fieldgroup',
-                        'section_id'   => 'product_image_section',
-                        'dependencies' => [
-                            [
-								'key' => $dep_engine,
-								'value' => $provider_id,
-								'to_self' => true,
-								'attribute' => 'display',
-								'effect' => 'show',
-								'comparison' => '===',
-							],
-                            [
-								'key' => $dep_engine,
-								'value' => $provider_id,
-								'to_self' => true,
-								'attribute' => 'display',
-								'effect' => 'hide',
-								'comparison' => '!==',
-							],
-                        ],
-                    ];
-                    $elements[] = [
-                        'id'             => $provider_id . '_api_info',
-                        'type'           => 'field',
-                        'variant'        => 'base_field_label',
-                        'field_group_id' => $provider_id . '_api_info_group',
-                        'title'          => sprintf(
-                            /* translators: %s: Provider title */
-                            esc_html__( '%s API', 'dokan-lite' ),
-                            $provider->get_title()
-                        ),
-                        'image_url'      => $provider->get_image_url(),
-                        'dependencies'   => [
-                            [
-								'key' => $dep_generate,
-								'value' => 'on',
-								'to_self' => true,
-								'attribute' => 'display',
-								'effect' => 'show',
-								'comparison' => '===',
-							],
-                            [
-								'key' => $dep_generate,
-								'value' => 'on',
-								'to_self' => true,
-								'attribute' => 'display',
-								'effect' => 'hide',
-								'comparison' => '!==',
-							],
-                        ],
-                    ];
-                    $elements[] = [
-                        'id'             => $provider_id . '_api_notice',
-                        'type'           => 'field',
-                        'variant'        => 'info',
-                        'field_group_id' => $provider_id . '_api_info_group',
-                        'title'          => sprintf(
-                            /* translators: %s: Provider title */
-                            esc_html__( 'You can get your API Keys in your %s Account.', 'dokan-lite' ),
-                            $provider->get_title()
-                        ),
-                        'link_text'      => sprintf(
-                            /* translators: %s: Provider title */
-                            esc_html__( '%s Account', 'dokan-lite' ),
-                            $provider->get_title()
-                        ),
-                        'link_url'       => $provider->get_api_key_url(),
-                        'dependencies'   => [
-                            [
-								'key' => $dep_generate,
-								'value' => 'on',
-								'to_self' => true,
-								'attribute' => 'display',
-								'effect' => 'show',
-								'comparison' => '===',
-							],
-                            [
-								'key' => $dep_generate,
-								'value' => 'on',
-								'to_self' => true,
-								'attribute' => 'display',
-								'effect' => 'hide',
-								'comparison' => '!==',
-							],
-                        ],
-                    ];
-                    $elements[] = [
-                        'id'             => $provider_id . '_api_key',
-                        'type'           => 'field',
-                        'variant'        => 'show_hide',
-                        'field_group_id' => $provider_id . '_api_info_group',
-                        'title'          => esc_html__( 'API Key', 'dokan-lite' ),
-                        'placeholder'    => sprintf(
-                            /* translators: %s: Provider title */
-                            esc_html__( 'Enter your %s API key', 'dokan-lite' ),
-                            $provider->get_title()
-                        ),
-                        'dependencies'   => [
-                            [
-								'key' => $dep_generate,
-								'value' => 'on',
-								'to_self' => true,
-								'attribute' => 'display',
-								'effect' => 'show',
-								'comparison' => '===',
-							],
-                            [
-								'key' => $dep_generate,
-								'value' => 'on',
-								'to_self' => true,
-								'attribute' => 'display',
-								'effect' => 'hide',
-								'comparison' => '!==',
-							],
-                        ],
-                    ];
-
-                    // Model select with dynamic options
-                    $model_options = [];
-                    $models = $provider->get_models_by_type( \WeDevs\Dokan\Intelligence\Services\Model::SUPPORTS_TEXT );
-                    foreach ( $models as $model_id => $model ) {
-                        $model_options[] = [
-							'title' => $model->get_title(),
-							'value' => $model_id,
-						];
-                    }
-
-                    $elements[] = [
-                        'id'             => $provider_id . '_model',
-                        'type'           => 'field',
-                        'variant'        => 'select',
-                        'field_group_id' => $provider_id . '_api_info_group',
-                        'title'          => esc_html__( 'Model', 'dokan-lite' ),
-                        'description'    => esc_html__( 'More advanced models provide higher quality output but may cost more per generation.', 'dokan-lite' ),
-                        'default'        => $provider->get_default_model_id(),
-                        'options'        => $model_options,
-                        'dependencies'   => [
-                            [
-								'key' => $dep_generate,
-								'value' => 'on',
-								'to_self' => true,
-								'attribute' => 'display',
-								'effect' => 'show',
-								'comparison' => '===',
-							],
-                            [
-								'key' => $dep_generate,
-								'value' => 'on',
-								'to_self' => true,
-								'attribute' => 'display',
-								'effect' => 'hide',
-								'comparison' => '!==',
-							],
-                        ],
-                    ];
-                }
-            } catch ( \Exception $e ) {
-                // Intelligence module not available, skip dynamic fields
+            foreach ( $image_providers as $provider_id => $provider ) {
+                $pid = (string) $provider_id;
+                $elements = array_merge(
+                    $elements,
+                    self::ai_provider_group(
+                        [
+                            'provider_id'     => $pid,
+                            'provider'        => $provider,
+                            'section_id'      => 'product_description_section',
+                            'engine_field_id' => 'product_image_engine',
+                            'toggle_deps'     => $on_enhance,
+                            'engine_deps'     => $when_engine( 'product_image_engine', $pid ),
+                            'api_key_legacy'  => 'dokan_ai.dokan_ai_image_' . $pid . '_api_key',
+                            'model_legacy'    => 'dokan_ai.dokan_ai_image_' . $pid . '_model',
+                            'model_kind'      => 'image',
+                            'id_prefix'       => 'image',
+                        ]
+                    )
+                );
             }
         }
 
         return $elements;
+    }
+
+    /**
+     * Resolve registered AI providers for the given kind ('text' | 'image').
+     *
+     * Returns an empty array when the Intelligence module is not loaded or
+     * the container can't resolve Manager — keeps schema generation
+     * best-effort so a partial bootstrap never breaks the settings UI.
+     *
+     * @param string $kind
+     *
+     * @return array
+     */
+    private static function resolve_ai_providers( string $kind ): array {
+        if ( ! class_exists( '\WeDevs\Dokan\Intelligence\Manager' ) ) {
+            return [];
+        }
+        try {
+            $manager = dokan()->get_container()->get( \WeDevs\Dokan\Intelligence\Manager::class );
+            return 'image' === $kind
+                ? $manager->get_image_supported_providers()
+                : $manager->get_text_supported_providers();
+        } catch ( \Throwable $e ) {
+            unset( $e );
+            return [];
+        }
+    }
+
+    /**
+     * Build the 5-element per-provider fieldgroup (group + api_info +
+     * api_notice + api_key + model). Shared between the text and image
+     * sections so the dynamic shape stays in lock-step on both sides.
+     *
+     * @param array $cfg
+     *
+     * @return array
+     */
+    private static function ai_provider_group( array $cfg ): array {
+        $pid          = $cfg['provider_id'];
+        $provider     = $cfg['provider'];
+        $toggle_deps  = $cfg['toggle_deps'];
+        $engine_deps  = $cfg['engine_deps'];
+        // Section-scoped prefix prevents id collisions when the same
+        // provider id (e.g. "gemini") appears in both text and image
+        // provider registries.
+        $prefix       = isset( $cfg['id_prefix'] ) && '' !== $cfg['id_prefix']
+            ? rtrim( (string) $cfg['id_prefix'], '_' ) . '_'
+            : '';
+        $group_id     = $prefix . $pid . '_api_info_group';
+
+        // Build model options + default model id defensively — providers may
+        // not implement get_models_by_type / get_default_model_id.
+        $model_options = [];
+        if ( method_exists( $provider, 'get_models_by_type' ) ) {
+            $model_const = 'image' === ( $cfg['model_kind'] ?? '' )
+                ? '\WeDevs\Dokan\Intelligence\Services\Model::SUPPORTS_IMAGE'
+                : '\WeDevs\Dokan\Intelligence\Services\Model::SUPPORTS_TEXT';
+            try {
+                $models = $provider->get_models_by_type( constant( $model_const ) );
+                foreach ( $models as $model_id => $model ) {
+                    $model_options[] = [ 'title' => $model->get_title(), 'value' => (string) $model_id ];
+                }
+            } catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+                unset( $e );
+            }
+        }
+        $default_model = method_exists( $provider, 'get_default_model_id' ) ? (string) $provider->get_default_model_id() : '';
+
+        $api_key_url = method_exists( $provider, 'get_api_key_url' ) ? (string) $provider->get_api_key_url() : '';
+        $image_url   = method_exists( $provider, 'get_image_url' ) ? (string) $provider->get_image_url() : '';
+
+        return [
+            [
+                'id'           => $group_id,
+                'type'         => 'fieldgroup',
+                'section_id'   => $cfg['section_id'],
+                'dependencies' => $engine_deps,
+            ],
+            [
+                'id'             => $prefix . $pid . '_api_info',
+                'type'           => 'field',
+                'variant'        => 'base_field_label',
+                'field_group_id' => $group_id,
+                /* translators: %s: Provider title */
+                'title'          => sprintf( esc_html__( '%s API', 'dokan-lite' ), $provider->get_title() ),
+                'icon'           => 'CircleCheck',
+                /* translators: %s: Provider title */
+                'description'    => sprintf( esc_html__( 'Connect to your %s account with your website.', 'dokan-lite' ), $provider->get_title() ),
+                'image_url'      => $image_url,
+                'dependencies'   => $toggle_deps,
+            ],
+            [
+                'id'             => $prefix . $pid . '_api_notice',
+                'type'           => 'field',
+                'variant'        => 'info',
+                'field_group_id' => $group_id,
+                /* translators: %s: Provider title */
+                'title'          => sprintf( esc_html__( 'You can get your API Keys in your %s Account.', 'dokan-lite' ), $provider->get_title() ),
+                /* translators: %s: Provider title */
+                'link_text'      => sprintf( esc_html__( '%s Account', 'dokan-lite' ), $provider->get_title() ),
+                'link_url'       => $api_key_url,
+                'show_icon'      => true,
+                'dependencies'   => $toggle_deps,
+            ],
+            [
+                'id'             => $prefix . $pid . '_api_key',
+                'type'           => 'field',
+                'variant'        => 'show_hide',
+                'field_group_id' => $group_id,
+                'title'          => esc_html__( 'API Key', 'dokan-lite' ),
+                /* translators: %s: Provider title */
+                'tooltip'        => sprintf( esc_html__( 'Enter your %s API key.', 'dokan-lite' ), $provider->get_title() ),
+                /* translators: %s: Provider title */
+                'placeholder'    => sprintf( esc_html__( 'Enter your %s API key', 'dokan-lite' ), $provider->get_title() ),
+                'legacy_key'     => $cfg['api_key_legacy'],
+                'dependencies'   => $toggle_deps,
+            ],
+            [
+                'id'           => $prefix . $pid . '_model',
+                'type'         => 'field',
+                'variant'      => 'select',
+                'section_id'   => $cfg['section_id'],
+                'title'        => esc_html__( 'Model', 'dokan-lite' ),
+                'description'  => esc_html__( 'More advanced models provide higher quality output but may cost more per generation.', 'dokan-lite' ),
+                'default'      => $default_model,
+                'options'      => $model_options,
+                'legacy_key'   => $cfg['model_legacy'],
+                'dependencies' => array_merge( $toggle_deps, $engine_deps ),
+            ],
+        ];
     }
 
     /**

--- a/includes/DependencyManagement/Providers/AdminSettingsServiceProvider.php
+++ b/includes/DependencyManagement/Providers/AdminSettingsServiceProvider.php
@@ -4,6 +4,7 @@ namespace WeDevs\Dokan\DependencyManagement\Providers;
 
 use WeDevs\Dokan\Admin\Settings\Migration\BridgeBootstrap;
 use WeDevs\Dokan\Admin\Settings\Migration\LegacySettingsBridge;
+use WeDevs\Dokan\Admin\Settings\Repository\LegacySettingsRepository;
 use WeDevs\Dokan\Admin\Settings\Repository\SettingsRepository;
 use WeDevs\Dokan\Admin\Settings\Schema\SchemaValidator;
 use WeDevs\Dokan\Admin\Settings\Schema\SettingsRegistry;
@@ -23,6 +24,7 @@ class AdminSettingsServiceProvider extends BaseServiceProvider {
         SchemaValidator::class,
         SettingsRepository::class,
         LegacySettingsBridge::class,
+        LegacySettingsRepository::class,
         BridgeBootstrap::class,
     ];
 

--- a/includes/Utilities/AdminSettings.php
+++ b/includes/Utilities/AdminSettings.php
@@ -44,4 +44,29 @@ class AdminSettings {
             ]
         );
     }
+
+    /**
+     * Order statuses that can release a withdraw request.
+     *
+     * Single source of truth for the `dokan_settings_withdraw_order_status_options`
+     * filter — consumed by the legacy admin settings registration
+     * ({@see \WeDevs\Dokan\Admin\Settings}) and by the new flat schema
+     * ({@see \WeDevs\Dokan\Admin\Settings\Schema\SettingsSchema}) so additions
+     * made by Pro / extensions show up on both UIs and in the bridge mapping
+     * with one declaration.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @return array<string,string> Map of `wc-<status>` slug => translated label.
+     */
+    public static function withdraw_order_status_options(): array {
+        return apply_filters(
+            'dokan_settings_withdraw_order_status_options',
+            [
+                'wc-completed'  => __( 'Completed', 'dokan-lite' ),
+                'wc-processing' => __( 'Processing', 'dokan-lite' ),
+                'wc-on-hold'    => __( 'On-hold', 'dokan-lite' ),
+            ]
+        );
+    }
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -3224,7 +3224,9 @@ function dokan_get_permalink( $page_id ) {
         return false;
     }
 
-    $pages = get_option( 'dokan_pages' );
+    $pages = dokan_get_container()
+        ->get( \WeDevs\Dokan\Admin\Settings\Repository\LegacySettingsRepository::class )
+        ->all( 'dokan_pages' );
 
     return isset( $pages[ $page_id ] ) ? get_permalink( $pages[ $page_id ] ) : false;
 }
@@ -3603,7 +3605,9 @@ function dokan_met_minimum_php_version_for_wc( $required_version = '7.0' ) {
  * @return bool
  */
 function dokan_has_map_api_key() {
-    $dokan_appearance = get_option( 'dokan_appearance', [] );
+    $dokan_appearance = dokan_get_container()
+        ->get( \WeDevs\Dokan\Admin\Settings\Repository\LegacySettingsRepository::class )
+        ->all( 'dokan_appearance' );
 
     if ( ! empty( $dokan_appearance['map_api_source'] ) && 'google_maps' === $dokan_appearance['map_api_source'] && ! empty( $dokan_appearance['gmap_api_key'] ) ) {
         return true;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1066,18 +1066,18 @@ add_filter( 'manage_edit-product_columns', 'dokan_admin_product_columns' );
 function dokan_get_option( $option, $section, $default_value = '' ) {
     [ $option, $section ] = dokan_admin_settings_rearrange_map( $option, $section );
 
-    $options = get_option( $section );
-    $options = is_array( $options ) ? $options : [];
-
-    // Reflect new-UI saves in legacy reads (new option is source of truth).
     if ( function_exists( 'dokan_get_container' ) ) {
         try {
-            $bridge  = dokan_get_container()->get( \WeDevs\Dokan\Admin\Settings\Migration\LegacySettingsBridge::class );
-            $options = $bridge->hydrate_legacy_from_new( $section, $options );
+            return dokan_get_container()
+                ->get( \WeDevs\Dokan\Admin\Settings\Repository\LegacySettingsRepository::class )
+                ->get( $section, $option, $default_value );
         } catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-            // Container not booted — fall back to raw legacy read.
+            // Container not booted — fall back to raw legacy read (no overlay).
         }
     }
+
+    $options = get_option( $section );
+    $options = is_array( $options ) ? $options : [];
 
     if ( isset( $options[ $option ] ) ) {
         return $options[ $option ];

--- a/src/admin/dashboard/pages/settings/fields/DokanSingleProductPreview.tsx
+++ b/src/admin/dashboard/pages/settings/fields/DokanSingleProductPreview.tsx
@@ -1,208 +1,103 @@
-import { __ } from '@wordpress/i18n';
-import {
-    LabeledCheckbox,
-    useSettings,
-    type SettingsElement,
-} from '@wedevs/plugin-ui';
-
-type ProductPreviewValue = {
-    vendor_info?: boolean;
-    more_products_tab?: boolean;
-    shipping_tab?: boolean;
-};
-
-const DEFAULT_VALUE: ProductPreviewValue = {
-    vendor_info: true,
-    more_products_tab: true,
-    shipping_tab: true,
-};
-
 type PreviewProps = {
     showVendorInfo: boolean;
     showMoreProductsTab: boolean;
     showShippingTab: boolean;
 };
 
-const ProductPreviewImage = ( {
+export default function DokanSingleProductPreview( {
     showVendorInfo,
     showMoreProductsTab,
     showShippingTab,
-}: PreviewProps ) => (
-    <div className="bg-[#efeaff] rounded-[5.229px] p-3 w-[155.814px] min-h-[163.134px] flex flex-col relative overflow-hidden">
-        <div className="flex flex-col gap-4 justify-center h-full w-[125px]">
-            <div className="flex gap-2 items-center">
-                <div className="w-[43px] h-[43px] bg-[#ab92f6] rounded p-2 flex items-center justify-center border border-[#e9e9e9]">
-                    <svg
-                        className="w-7 h-7 text-white"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 25 25"
-                        strokeWidth="2.5"
-                    >
-                        <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            d="M22.9625 15.975L19.3686 12.3811C18.9318 11.9444 18.3395 11.6991 17.7219 11.6991C17.1043 11.6991 16.5119 11.9444 16.0752 12.3811L5.49375 22.9625M4.32917 2H20.6333C21.9197 2 22.9625 3.0428 22.9625 4.32917V20.6333C22.9625 21.9197 21.9197 22.9625 20.6333 22.9625H4.32917C3.0428 22.9625 2 21.9197 2 20.6333V4.32917C2 3.0428 3.0428 2 4.32917 2ZM11.3167 8.9875C11.3167 10.2739 10.2739 11.3167 8.9875 11.3167C7.70114 11.3167 6.65833 10.2739 6.65833 8.9875C6.65833 7.70114 7.70114 6.65833 8.9875 6.65833C10.2739 6.65833 11.3167 7.70114 11.3167 8.9875Z"
-                        />
-                    </svg>
-                </div>
-                <div className="space-y-1.5 w-full">
-                    <div className="h-[2.8px] bg-[#bfacf9] rounded-full w-[71.715px]"></div>
-                    <div className="h-[2.8px] bg-[#bfacf9] rounded-full w-[51.225px]"></div>
-                    <div className="h-[11.19px] bg-[#bfacf9] rounded-full w-[20.805px]"></div>
-                </div>
-            </div>
-
-            { showVendorInfo && (
-                <div className="flex justify-end">
-                    <div className="bg-[#efeaff] border border-[#bfacf9] rounded-[3.673px] p-1.5 flex items-center gap-2 w-[72px] h-[21px]">
+}: PreviewProps ) {
+    return (
+        <div className="bg-[#efeaff] rounded-[5.229px] p-3 w-[155.814px] min-h-[163.134px] flex flex-col relative overflow-hidden">
+            <div className="flex flex-col gap-4 justify-center h-full w-[125px]">
+                <div className="flex gap-2 items-center">
+                    <div className="w-[43px] h-[43px] bg-[#ab92f6] rounded p-2 flex items-center justify-center border border-[#e9e9e9]">
                         <svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            width="11"
-                            height="10"
-                            viewBox="0 0 11 10"
+                            className="w-7 h-7 text-white"
                             fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 25 25"
+                            strokeWidth="2.5"
                         >
                             <path
-                                d="M10.9556 3.54042L10.3082 0.861271C10.2726 0.711909 10.1424 0.607422 9.99416 0.607422H1.57718C1.42891 0.607422 1.29877 0.711909 1.26316 0.861271L0.615699 3.54042C0.609225 3.56654 0.605988 3.594 0.605988 3.62146C0.605988 4.18274 0.863029 4.67771 1.25345 4.9818V9.64954C1.25345 9.8344 1.39848 9.98443 1.57718 9.98443H4.81448C4.99318 9.98443 5.13821 9.8344 5.13821 9.64954V7.30529H6.43313V9.64954C6.43313 9.8344 6.57816 9.98443 6.75686 9.98443H9.99416C10.1729 9.98443 10.3179 9.8344 10.3179 9.64954V4.9818C10.7083 4.67771 10.9654 4.18274 10.9654 3.62146C10.9654 3.594 10.9621 3.56654 10.9556 3.54042ZM9.67043 9.31465H7.08059V6.97039C7.08059 6.78553 6.93556 6.6355 6.75686 6.6355H4.81448C4.63578 6.6355 4.49075 6.78553 4.49075 6.97039V9.31465H1.90091V5.26914C1.98055 5.2832 2.06083 5.29593 2.14371 5.29593C2.63707 5.29593 3.07605 5.04208 3.35769 4.64824C3.63934 5.04208 4.07832 5.29593 4.57168 5.29593C5.06505 5.29593 5.50402 5.04208 5.78567 4.64824C6.06731 5.04208 6.50629 5.29593 6.99966 5.29593C7.49302 5.29593 7.932 5.04208 8.21364 4.64824C8.49529 5.04208 8.93427 5.29593 9.42763 5.29593C9.51051 5.29593 9.59079 5.2832 9.67043 5.26914V9.31465ZM9.42763 4.62614C8.93686 4.62614 8.53738 4.17537 8.53738 3.62146C8.53738 3.4366 8.39234 3.28657 8.21364 3.28657C8.03495 3.28657 7.88991 3.4366 7.88991 3.62146C7.88991 4.17537 7.49043 4.62614 6.99966 4.62614C6.50888 4.62614 6.1094 4.17537 6.1094 3.62146C6.1094 3.4366 5.96437 3.28657 5.78567 3.28657C5.60697 3.28657 5.46194 3.4366 5.46194 3.62146C5.46194 4.17537 5.06246 4.62614 4.57168 4.62614C4.08091 4.62614 3.68142 4.17537 3.68142 3.62146C3.68142 3.4366 3.53639 3.28657 3.35769 3.28657C3.17899 3.28657 3.03396 3.4366 3.03396 3.62146C3.03396 4.17537 2.63448 4.62614 2.14371 4.62614C1.66458 4.62614 1.27222 4.19614 1.2541 3.66031L1.83033 1.27721H9.74165L10.3179 3.66031C10.2991 4.19614 9.90675 4.62614 9.42763 4.62614Z"
-                                fill="#AB92F6"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                d="M22.9625 15.975L19.3686 12.3811C18.9318 11.9444 18.3395 11.6991 17.7219 11.6991C17.1043 11.6991 16.5119 11.9444 16.0752 12.3811L5.49375 22.9625M4.32917 2H20.6333C21.9197 2 22.9625 3.0428 22.9625 4.32917V20.6333C22.9625 21.9197 21.9197 22.9625 20.6333 22.9625H4.32917C3.0428 22.9625 2 21.9197 2 20.6333V4.32917C2 3.0428 3.0428 2 4.32917 2ZM11.3167 8.9875C11.3167 10.2739 10.2739 11.3167 8.9875 11.3167C7.70114 11.3167 6.65833 10.2739 6.65833 8.9875C6.65833 7.70114 7.70114 6.65833 8.9875 6.65833C10.2739 6.65833 11.3167 7.70114 11.3167 8.9875Z"
                             />
                         </svg>
-                        <div className="h-[1.47px] bg-[#bfacf9] rounded-full w-[38px]"></div>
                     </div>
-                </div>
-            ) }
-
-            <div className="flex flex-col items-center">
-                <div className="flex gap-1.5 mb-3">
-                    <div className="bg-[#e1d7ff] w-5 h-4 rounded-full opacity-1"></div>
-                    <div className="bg-[#e1d7ff] w-5 h-4 rounded-full opacity-1"></div>
-                    { showShippingTab && (
-                        <div className="bg-[#e1d7ff] rounded-full px-1.5 py-0.5">
-                            <svg
-                                className="w-3.5 h-3.5 text-[#7047eb]"
-                                fill="none"
-                                stroke="currentColor"
-                                viewBox="0 0 14 11"
-                                strokeWidth="1"
-                            >
-                                <path
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    d="M8 9.16667V2.16667C8 1.85725 7.87708 1.5605 7.65829 1.34171C7.4395 1.12292 7.14275 1 6.83333 1H2.16667C1.85725 1 1.5605 1.12292 1.34171 1.34171C1.12292 1.5605 1 1.85725 1 2.16667V8.58333C1 8.73804 1.06146 8.88642 1.17085 8.99581C1.28025 9.10521 1.42862 9.16667 1.58333 9.16667H2.75M2.75 9.16667C2.75 9.811 3.27233 10.3333 3.91667 10.3333C4.561 10.3333 5.08333 9.811 5.08333 9.16667M2.75 9.16667C2.75 8.52233 3.27233 8 3.91667 8C4.561 8 5.08333 8.52233 5.08333 9.16667M8.58333 9.16667H5.08333M8.58333 9.16667C8.58333 9.811 9.10567 10.3333 9.75 10.3333C10.3943 10.3333 10.9167 9.811 10.9167 9.16667M8.58333 9.16667C8.58333 8.52233 9.10567 8 9.75 8C10.3943 8 10.9167 8.52233 10.9167 9.16667M10.9167 9.16667H12.0833C12.238 9.16667 12.3864 9.10521 12.4958 8.99581C12.6052 8.88642 12.6667 8.73804 12.6667 8.58333V6.45417C12.6664 6.32179 12.6212 6.19342 12.5383 6.09017L10.5083 3.55267C10.4538 3.48435 10.3846 3.42916 10.3058 3.3912C10.227 3.35323 10.1408 3.33346 10.0533 3.33333H8"
-                                />
-                            </svg>
-                        </div>
-                    ) }
-                    { showMoreProductsTab && (
-                        <div className="bg-[#e1d7ff] rounded-full px-1.5 py-0.5">
-                            <svg
-                                className="w-3.5 h-3.5 text-[#7047eb]"
-                                fill="none"
-                                stroke="currentColor"
-                                viewBox="0 0 12 14"
-                                strokeWidth="1"
-                            >
-                                <path
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    d="M1.175 3.91547L6.25 6.83214M6.25 6.83214L11.325 3.91547M6.25 6.83214V12.6655M11.5 4.4988C11.4998 4.29421 11.4458 4.09328 11.3434 3.91615C11.241 3.73902 11.0938 3.59193 10.9167 3.48964L6.83333 1.1563C6.65598 1.05391 6.45479 1 6.25 1C6.04521 1 5.84402 1.05391 5.66667 1.1563L1.58333 3.48964C1.40615 3.59193 1.25899 3.73902 1.1566 3.91615C1.05422 4.09328 1.00021 4.29421 1 4.4988V9.16547C1.00021 9.37006 1.05422 9.571 1.1566 9.74813C1.25899 9.92525 1.40615 10.0723 1.58333 10.1746L5.66667 12.508C5.84402 12.6104 6.04521 12.6643 6.25 12.6643C6.45479 12.6643 6.65598 12.6104 6.83333 12.508L10.9167 10.1746C11.0938 10.0723 11.241 9.92525 11.3434 9.74813C11.4458 9.571 11.4998 9.37006 11.5 9.16547V4.4988Z"
-                                />
-                            </svg>
-                        </div>
-                    ) }
-                </div>
-                <div className="space-y-1.5">
-                    <div className="h-[2.47px] bg-[#bfacf9] rounded-full w-[124px]"></div>
-                    <div className="h-[3px] bg-[#bfacf9] rounded-full w-[90px]"></div>
-                </div>
-            </div>
-        </div>
-    </div>
-);
-
-type Props = {
-    element: SettingsElement;
-};
-
-export default function DokanSingleProductPreview( { element }: Props ) {
-    const { updateValue } = useSettings();
-
-    const value: ProductPreviewValue =
-        ( element.value as ProductPreviewValue ) ||
-        ( element.default as ProductPreviewValue ) ||
-        DEFAULT_VALUE;
-
-    const handleToggle = (
-        key: keyof ProductPreviewValue,
-        checked: boolean
-    ): void => {
-        // No guard needed: `id` is always present on field elements.
-        updateValue( element.id, {
-            ...value,
-            [ key ]: checked,
-        } );
-    };
-
-    const showVendorInfo = Boolean( value.vendor_info );
-    const showMoreProductsTab = Boolean( value.more_products_tab );
-    const showShippingTab = Boolean( value.shipping_tab );
-
-    return (
-        <div className="bg-white p-5">
-            <div className="flex items-start justify-between">
-                <div className="flex-1 max-w-lg">
-                    { ( element.label || element.title ) && (
-                        <div className="text-sm font-semibold text-foreground">
-                            { element.label || element.title }
-                        </div>
-                    ) }
-                    { element.description && (
-                        <div className="text-xs text-muted-foreground leading-relaxed mt-1">
-                            { element.description }
-                        </div>
-                    ) }
-
-                    <div className="mt-4 flex flex-col gap-3">
-                        <LabeledCheckbox
-                            label={ __( 'Vendor Info', 'dokan-lite' ) }
-                            checked={ showVendorInfo }
-                            onCheckedChange={ ( checked ) =>
-                                handleToggle(
-                                    'vendor_info',
-                                    Boolean( checked )
-                                )
-                            }
-                        />
-                        <LabeledCheckbox
-                            label={ __( 'More products tab', 'dokan-lite' ) }
-                            checked={ showMoreProductsTab }
-                            onCheckedChange={ ( checked ) =>
-                                handleToggle(
-                                    'more_products_tab',
-                                    Boolean( checked )
-                                )
-                            }
-                        />
-                        <LabeledCheckbox
-                            label={ __( 'Shipping tab', 'dokan-lite' ) }
-                            checked={ showShippingTab }
-                            onCheckedChange={ ( checked ) =>
-                                handleToggle(
-                                    'shipping_tab',
-                                    Boolean( checked )
-                                )
-                            }
-                        />
+                    <div className="space-y-1.5 w-full">
+                        <div className="h-[2.8px] bg-[#bfacf9] rounded-full w-[71.715px]"></div>
+                        <div className="h-[2.8px] bg-[#bfacf9] rounded-full w-[51.225px]"></div>
+                        <div className="h-[11.19px] bg-[#bfacf9] rounded-full w-[20.805px]"></div>
                     </div>
                 </div>
 
-                <div className="ml-8">
-                    <ProductPreviewImage
-                        showVendorInfo={ showVendorInfo }
-                        showMoreProductsTab={ showMoreProductsTab }
-                        showShippingTab={ showShippingTab }
-                    />
+                { showVendorInfo && (
+                    <div className="flex justify-end">
+                        <div className="bg-[#efeaff] border border-[#bfacf9] rounded-[3.673px] p-1.5 flex items-center gap-2 w-[72px] h-[21px]">
+                            <svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                width="11"
+                                height="10"
+                                viewBox="0 0 11 10"
+                                fill="none"
+                            >
+                                <path
+                                    d="M10.9556 3.54042L10.3082 0.861271C10.2726 0.711909 10.1424 0.607422 9.99416 0.607422H1.57718C1.42891 0.607422 1.29877 0.711909 1.26316 0.861271L0.615699 3.54042C0.609225 3.56654 0.605988 3.594 0.605988 3.62146C0.605988 4.18274 0.863029 4.67771 1.25345 4.9818V9.64954C1.25345 9.8344 1.39848 9.98443 1.57718 9.98443H4.81448C4.99318 9.98443 5.13821 9.8344 5.13821 9.64954V7.30529H6.43313V9.64954C6.43313 9.8344 6.57816 9.98443 6.75686 9.98443H9.99416C10.1729 9.98443 10.3179 9.8344 10.3179 9.64954V4.9818C10.7083 4.67771 10.9654 4.18274 10.9654 3.62146C10.9654 3.594 10.9621 3.56654 10.9556 3.54042ZM9.67043 9.31465H7.08059V6.97039C7.08059 6.78553 6.93556 6.6355 6.75686 6.6355H4.81448C4.63578 6.6355 4.49075 6.78553 4.49075 6.97039V9.31465H1.90091V5.26914C1.98055 5.2832 2.06083 5.29593 2.14371 5.29593C2.63707 5.29593 3.07605 5.04208 3.35769 4.64824C3.63934 5.04208 4.07832 5.29593 4.57168 5.29593C5.06505 5.29593 5.50402 5.04208 5.78567 4.64824C6.06731 5.04208 6.50629 5.29593 6.99966 5.29593C7.49302 5.29593 7.932 5.04208 8.21364 4.64824C8.49529 5.04208 8.93427 5.29593 9.42763 5.29593C9.51051 5.29593 9.59079 5.2832 9.67043 5.26914V9.31465ZM9.42763 4.62614C8.93686 4.62614 8.53738 4.17537 8.53738 3.62146C8.53738 3.4366 8.39234 3.28657 8.21364 3.28657C8.03495 3.28657 7.88991 3.4366 7.88991 3.62146C7.88991 4.17537 7.49043 4.62614 6.99966 4.62614C6.50888 4.62614 6.1094 4.17537 6.1094 3.62146C6.1094 3.4366 5.96437 3.28657 5.78567 3.28657C5.60697 3.28657 5.46194 3.4366 5.46194 3.62146C5.46194 4.17537 5.06246 4.62614 4.57168 4.62614C4.08091 4.62614 3.68142 4.17537 3.68142 3.62146C3.68142 3.4366 3.53639 3.28657 3.35769 3.28657C3.17899 3.28657 3.03396 3.4366 3.03396 3.62146C3.03396 4.17537 2.63448 4.62614 2.14371 4.62614C1.66458 4.62614 1.27222 4.19614 1.2541 3.66031L1.83033 1.27721H9.74165L10.3179 3.66031C10.2991 4.19614 9.90675 4.62614 9.42763 4.62614Z"
+                                    fill="#AB92F6"
+                                />
+                            </svg>
+                            <div className="h-[1.47px] bg-[#bfacf9] rounded-full w-[38px]"></div>
+                        </div>
+                    </div>
+                ) }
+
+                <div className="flex flex-col items-center">
+                    <div className="flex gap-1.5 mb-3">
+                        <div className="bg-[#e1d7ff] w-5 h-4 rounded-full opacity-1"></div>
+                        <div className="bg-[#e1d7ff] w-5 h-4 rounded-full opacity-1"></div>
+                        { showShippingTab && (
+                            <div className="bg-[#e1d7ff] rounded-full px-1.5 py-0.5">
+                                <svg
+                                    className="w-3.5 h-3.5 text-[#7047eb]"
+                                    fill="none"
+                                    stroke="currentColor"
+                                    viewBox="0 0 14 11"
+                                    strokeWidth="1"
+                                >
+                                    <path
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        d="M8 9.16667V2.16667C8 1.85725 7.87708 1.5605 7.65829 1.34171C7.4395 1.12292 7.14275 1 6.83333 1H2.16667C1.85725 1 1.5605 1.12292 1.34171 1.34171C1.12292 1.5605 1 1.85725 1 2.16667V8.58333C1 8.73804 1.06146 8.88642 1.17085 8.99581C1.28025 9.10521 1.42862 9.16667 1.58333 9.16667H2.75M2.75 9.16667C2.75 9.811 3.27233 10.3333 3.91667 10.3333C4.561 10.3333 5.08333 9.811 5.08333 9.16667M2.75 9.16667C2.75 8.52233 3.27233 8 3.91667 8C4.561 8 5.08333 8.52233 5.08333 9.16667M8.58333 9.16667H5.08333M8.58333 9.16667C8.58333 9.811 9.10567 10.3333 9.75 10.3333C10.3943 10.3333 10.9167 9.811 10.9167 9.16667M8.58333 9.16667C8.58333 8.52233 9.10567 8 9.75 8C10.3943 8 10.9167 8.52233 10.9167 9.16667M10.9167 9.16667H12.0833C12.238 9.16667 12.3864 9.10521 12.4958 8.99581C12.6052 8.88642 12.6667 8.73804 12.6667 8.58333V6.45417C12.6664 6.32179 12.6212 6.19342 12.5383 6.09017L10.5083 3.55267C10.4538 3.48435 10.3846 3.42916 10.3058 3.3912C10.227 3.35323 10.1408 3.33346 10.0533 3.33333H8"
+                                    />
+                                </svg>
+                            </div>
+                        ) }
+                        { showMoreProductsTab && (
+                            <div className="bg-[#e1d7ff] rounded-full px-1.5 py-0.5">
+                                <svg
+                                    className="w-3.5 h-3.5 text-[#7047eb]"
+                                    fill="none"
+                                    stroke="currentColor"
+                                    viewBox="0 0 12 14"
+                                    strokeWidth="1"
+                                >
+                                    <path
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        d="M1.175 3.91547L6.25 6.83214M6.25 6.83214L11.325 3.91547M6.25 6.83214V12.6655M11.5 4.4988C11.4998 4.29421 11.4458 4.09328 11.3434 3.91615C11.241 3.73902 11.0938 3.59193 10.9167 3.48964L6.83333 1.1563C6.65598 1.05391 6.45479 1 6.25 1C6.04521 1 5.84402 1.05391 5.66667 1.1563L1.58333 3.48964C1.40615 3.59193 1.25899 3.73902 1.1566 3.91615C1.05422 4.09328 1.00021 4.29421 1 4.4988V9.16547C1.00021 9.37006 1.05422 9.571 1.1566 9.74813C1.25899 9.92525 1.40615 10.0723 1.58333 10.1746L5.66667 12.508C5.84402 12.6104 6.04521 12.6643 6.25 12.6643C6.45479 12.6643 6.65598 12.6104 6.83333 12.508L10.9167 10.1746C11.0938 10.0723 11.241 9.92525 11.3434 9.74813C11.4458 9.571 11.4998 9.37006 11.5 9.16547V4.4988Z"
+                                    />
+                                </svg>
+                            </div>
+                        ) }
+                    </div>
+                    <div className="space-y-1.5">
+                        <div className="h-[2.47px] bg-[#bfacf9] rounded-full w-[124px]"></div>
+                        <div className="h-[3px] bg-[#bfacf9] rounded-full w-[90px]"></div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/admin/dashboard/pages/settings/fields/DokanVendorInfoPreview.tsx
+++ b/src/admin/dashboard/pages/settings/fields/DokanVendorInfoPreview.tsx
@@ -1,21 +1,4 @@
 import { __ } from '@wordpress/i18n';
-import {
-    LabeledCheckbox,
-    useSettings,
-    type SettingsElement,
-} from '@wedevs/plugin-ui';
-
-type VendorInfoValue = {
-    store_email?: boolean;
-    store_phone?: boolean;
-    store_address?: boolean;
-};
-
-const DEFAULT_VALUE: VendorInfoValue = {
-    store_email: true,
-    store_phone: true,
-    store_address: true,
-};
 
 type PreviewProps = {
     showEmail: boolean;
@@ -23,11 +6,11 @@ type PreviewProps = {
     showAddress: boolean;
 };
 
-const VendorPreviewImage = ( {
+export default function DokanVendorInfoPreview( {
     showEmail,
     showPhone,
     showAddress,
-}: PreviewProps ) => {
+}: PreviewProps ) {
     return (
         <div className="bg-[#efeaff] rounded p-2 w-[156px] h-[11rem] flex flex-col relative overflow-hidden">
             <div className="flex flex-col items-center mb-4 mt-1">
@@ -105,94 +88,6 @@ const VendorPreviewImage = ( {
                         <div className="h-[3px] bg-[#bfacf9] rounded-full w-[56px]"></div>
                     </div>
                 ) }
-            </div>
-        </div>
-    );
-};
-
-type Props = {
-    element: SettingsElement;
-};
-
-export default function DokanVendorInfoPreview( { element }: Props ) {
-    const { updateValue } = useSettings();
-
-    const value: VendorInfoValue =
-        ( element.value as VendorInfoValue ) ||
-        ( element.default as VendorInfoValue ) ||
-        DEFAULT_VALUE;
-
-    const handleToggle = (
-        key: keyof VendorInfoValue,
-        checked: boolean
-    ): void => {
-        // No guard needed: `id` is always present on field elements.
-        updateValue( element.id, {
-            ...value,
-            [ key ]: checked,
-        } );
-    };
-
-    const showEmail = Boolean( value.store_email );
-    const showPhone = Boolean( value.store_phone );
-    const showAddress = Boolean( value.store_address );
-
-    return (
-        <div className="bg-white p-5">
-            <div className="flex items-start justify-between">
-                <div className="flex-1 max-w-lg">
-                    { ( element.label || element.title ) && (
-                        <div className="text-sm font-semibold text-foreground">
-                            { element.label || element.title }
-                        </div>
-                    ) }
-                    { element.description && (
-                        <div className="text-xs text-muted-foreground leading-relaxed mt-1">
-                            { element.description }
-                        </div>
-                    ) }
-
-                    <div className="mt-4 flex flex-col gap-3">
-                        <LabeledCheckbox
-                            label={ __( 'Email Address', 'dokan-lite' ) }
-                            checked={ showEmail }
-                            onCheckedChange={ ( checked ) =>
-                                handleToggle(
-                                    'store_email',
-                                    Boolean( checked )
-                                )
-                            }
-                        />
-                        <LabeledCheckbox
-                            label={ __( 'Phone Number', 'dokan-lite' ) }
-                            checked={ showPhone }
-                            onCheckedChange={ ( checked ) =>
-                                handleToggle(
-                                    'store_phone',
-                                    Boolean( checked )
-                                )
-                            }
-                        />
-                        <LabeledCheckbox
-                            label={ __( 'Store Address', 'dokan-lite' ) }
-                            checked={ showAddress }
-                            onCheckedChange={ ( checked ) =>
-                                handleToggle(
-                                    'store_address',
-                                    Boolean( checked )
-                                )
-                            }
-                        />
-                    </div>
-                </div>
-
-                <div className="ml-8">
-                    <VendorPreviewImage
-                        showEmail={ showEmail }
-                        showPhone={ showPhone }
-                        showAddress={ showAddress }
-                    />
-                </div>
             </div>
         </div>
     );

--- a/src/admin/dashboard/pages/settings/register-fields.tsx
+++ b/src/admin/dashboard/pages/settings/register-fields.tsx
@@ -18,20 +18,39 @@ import DokanDoubleInput from './fields/DokanDoubleInput';
  * times stacks duplicate handlers — keep callers to a single invocation.
  */
 export function registerSettingsFields(): void {
+    // Inject Dokan-specific SVG previews into plugin-ui's `info_preview` field.
+    // Dispatches by element id so each schema-driven info_preview field can
+    // contribute its own dynamic mock without re-implementing the field.
     addFilter(
-        'dokan_settings_vendor_info_preview_field',
-        'dokan-lite/vendor-info-preview',
-        ( _defaultComponent: React.ReactNode, element: SettingsElement ) => (
-            <DokanVendorInfoPreview element={ element } />
-        )
-    );
-
-    addFilter(
-        'dokan_settings_single_product_preview_field',
-        'dokan-lite/single-product-preview',
-        ( _defaultComponent: React.ReactNode, element: SettingsElement ) => (
-            <DokanSingleProductPreview element={ element } />
-        )
+        'dokan_settings_info_preview_field_preview',
+        'dokan-lite/info-preview',
+        (
+            defaultPreview: React.ReactNode,
+            element: SettingsElement,
+            value: Record< string, boolean >
+        ) => {
+            if ( element.id === 'vendor_info_visibility' ) {
+                return (
+                    <DokanVendorInfoPreview
+                        showEmail={ Boolean( value?.store_email ) }
+                        showPhone={ Boolean( value?.store_phone ) }
+                        showAddress={ Boolean( value?.store_address ) }
+                    />
+                );
+            }
+            if ( element.id === 'single_product_page_appearance' ) {
+                return (
+                    <DokanSingleProductPreview
+                        showVendorInfo={ Boolean( value?.vendor_info ) }
+                        showMoreProductsTab={ Boolean(
+                            value?.more_products_tab
+                        ) }
+                        showShippingTab={ Boolean( value?.shipping_tab ) }
+                    />
+                );
+            }
+            return defaultPreview;
+        }
     );
 
     addFilter(

--- a/tests/php/src/Admin/Settings/Migration/LegacySettingsBridgeTest.php
+++ b/tests/php/src/Admin/Settings/Migration/LegacySettingsBridgeTest.php
@@ -567,7 +567,7 @@ class LegacySettingsBridgeTest extends DokanTestCase {
         $this->assertSame( 'cba', $hydrated['banner_caption'] );
     }
 
-    public function test_callable_transformer_rejects_closure_and_falls_back(): void {
+    public function test_callable_transformer_accepts_closure(): void {
         $fixture = [
             [
                 'id'                 => 'banner_caption',
@@ -596,8 +596,8 @@ class LegacySettingsBridgeTest extends DokanTestCase {
         remove_filter( 'dokan_get_admin_settings_schema', $cb );
         delete_option( 'dokan_appearance' );
 
-        // Closure is rejected by CallableTransformer; bridge falls back to pass-through.
-        $this->assertSame( 'abc', $hydrated['banner_caption'] );
+        // Closures are accepted by CallableTransformer; to_new runs on hydrate.
+        $this->assertSame( 'cba', $hydrated['banner_caption'] );
     }
 
     public function test_callable_transformer_ignored_when_pair_incomplete(): void {
@@ -653,5 +653,149 @@ class LegacySettingsBridgeTest extends DokanTestCase {
         delete_option( 'dokan_general' );
 
         $this->assertSame( 'world', $stored['setup_wizard_message'] );
+    }
+
+    public function test_multi_mapping_hydrates_from_legacy_via_slots(): void {
+        $fixture = [
+            [
+                'id'                 => 'product_page_appearance',
+                'type'               => 'field',
+                'legacy_key'         => [
+                    'vendor_info'   => [ 'option' => 'dokan_appearance', 'field' => 'show_vendor_info' ],
+                    'more_products' => [ 'option' => 'dokan_appearance', 'field' => 'show_more_products' ],
+                    'shipping_tab'  => [ 'option' => 'dokan_appearance', 'field' => 'show_shipping_tab' ],
+                ],
+                'legacy_transformer' => [
+                    'to_new'    => static function ( $slots ) {
+                        return [
+                            'vendor_info'   => ! empty( $slots['vendor_info'] ),
+                            'more_products' => ! empty( $slots['more_products'] ),
+                            'shipping_tab'  => ! empty( $slots['shipping_tab'] ),
+                        ];
+                    },
+                    'to_legacy' => static function ( $new ) {
+                        return [
+                            'vendor_info'   => ! empty( $new['vendor_info'] ) ? 'on' : '',
+                            'more_products' => ! empty( $new['more_products'] ) ? 'on' : '',
+                            'shipping_tab'  => ! empty( $new['shipping_tab'] ) ? 'on' : '',
+                        ];
+                    },
+                ],
+                'default'            => [ 'vendor_info' => false, 'more_products' => false, 'shipping_tab' => false ],
+            ],
+        ];
+        $cb = static function () use ( $fixture ) {
+            return $fixture;
+        };
+        add_filter( 'dokan_get_admin_settings_schema', $cb );
+
+        update_option( 'dokan_appearance', [
+            'show_vendor_info'   => 'on',
+            'show_more_products' => '',
+            'show_shipping_tab'  => 'on',
+        ] );
+
+        $bridge   = new LegacySettingsBridge();
+        $hydrated = $bridge->hydrate_new_from_legacy( [] );
+
+        remove_filter( 'dokan_get_admin_settings_schema', $cb );
+        delete_option( 'dokan_appearance' );
+
+        $this->assertSame(
+            [ 'vendor_info' => true, 'more_products' => false, 'shipping_tab' => true ],
+            $hydrated['product_page_appearance']
+        );
+    }
+
+    public function test_multi_mapping_writes_back_each_slot(): void {
+        $fixture = [
+            [
+                'id'                 => 'product_page_appearance',
+                'type'               => 'field',
+                'legacy_key'         => [
+                    'vendor_info'   => [ 'option' => 'dokan_appearance', 'field' => 'show_vendor_info' ],
+                    'more_products' => [ 'option' => 'dokan_appearance', 'field' => 'show_more_products' ],
+                    'shipping_tab'  => [ 'option' => 'dokan_appearance', 'field' => 'show_shipping_tab' ],
+                ],
+                'legacy_transformer' => [
+                    'to_new'    => static function ( $slots ) {
+                        return $slots;
+                    },
+                    'to_legacy' => static function ( $new ) {
+                        return [
+                            'vendor_info'   => ! empty( $new['vendor_info'] ) ? 'on' : '',
+                            'more_products' => ! empty( $new['more_products'] ) ? 'on' : '',
+                            'shipping_tab'  => ! empty( $new['shipping_tab'] ) ? 'on' : '',
+                        ];
+                    },
+                ],
+                'default'            => [],
+            ],
+        ];
+        $cb = static function () use ( $fixture ) {
+            return $fixture;
+        };
+        add_filter( 'dokan_get_admin_settings_schema', $cb );
+
+        $bridge = new LegacySettingsBridge();
+        $bridge->write_new_to_legacy( [
+            'product_page_appearance' => [
+                'vendor_info'   => true,
+                'more_products' => false,
+                'shipping_tab'  => true,
+            ],
+        ] );
+        $stored = get_option( 'dokan_appearance' );
+
+        remove_filter( 'dokan_get_admin_settings_schema', $cb );
+        delete_option( 'dokan_appearance' );
+
+        $this->assertSame( 'on', $stored['show_vendor_info'] );
+        $this->assertSame( '', $stored['show_more_products'] );
+        $this->assertSame( 'on', $stored['show_shipping_tab'] );
+    }
+
+    public function test_multi_mapping_spans_multiple_legacy_options(): void {
+        $fixture = [
+            [
+                'id'                 => 'cross_option_field',
+                'type'               => 'field',
+                'legacy_key'         => [
+                    'a' => [ 'option' => 'dokan_appearance', 'field' => 'slot_a' ],
+                    'b' => [ 'option' => 'dokan_general', 'field' => 'slot_b' ],
+                ],
+                'legacy_transformer' => [
+                    'to_new'    => static function ( $slots ) {
+                        return $slots;
+                    },
+                    'to_legacy' => static function ( $new ) {
+                        return [ 'a' => $new['a'] ?? '', 'b' => $new['b'] ?? '' ];
+                    },
+                ],
+                'default'            => [],
+            ],
+        ];
+        $cb = static function () use ( $fixture ) {
+            return $fixture;
+        };
+        add_filter( 'dokan_get_admin_settings_schema', $cb );
+
+        update_option( 'dokan_appearance', [ 'slot_a' => 'A' ] );
+        update_option( 'dokan_general', [ 'slot_b' => 'B' ] );
+
+        $bridge   = new LegacySettingsBridge();
+        $hydrated = $bridge->hydrate_new_from_legacy( [] );
+        $this->assertSame( [ 'a' => 'A', 'b' => 'B' ], $hydrated['cross_option_field'] );
+
+        $bridge->write_new_to_legacy( [ 'cross_option_field' => [ 'a' => 'A2', 'b' => 'B2' ] ] );
+        $stored_app = get_option( 'dokan_appearance' );
+        $stored_gen = get_option( 'dokan_general' );
+
+        remove_filter( 'dokan_get_admin_settings_schema', $cb );
+        delete_option( 'dokan_appearance' );
+        delete_option( 'dokan_general' );
+
+        $this->assertSame( 'A2', $stored_app['slot_a'] );
+        $this->assertSame( 'B2', $stored_gen['slot_b'] );
     }
 }

--- a/tests/php/src/Admin/Settings/Migration/Transformer/SingleProductAppearanceTransformerTest.php
+++ b/tests/php/src/Admin/Settings/Migration/Transformer/SingleProductAppearanceTransformerTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace WeDevs\Dokan\Test\Admin\Settings\Migration\Transformer;
+
+use WeDevs\Dokan\Admin\Settings\Migration\Transformer\SingleProductAppearanceTransformer;
+use WP_UnitTestCase;
+
+/**
+ * Locks in the slot semantics for the `single_product_page_appearance` field —
+ * particularly the inverted `shipping_tab` polarity, which is the only slot
+ * that's easy to flip the wrong way during a refactor.
+ *
+ * @covers \WeDevs\Dokan\Admin\Settings\Migration\Transformer\SingleProductAppearanceTransformer
+ */
+class SingleProductAppearanceTransformerTest extends WP_UnitTestCase {
+
+    public function test_to_new_passes_through_direct_slots_and_inverts_shipping_tab(): void {
+        $transformer = new SingleProductAppearanceTransformer();
+
+        $result = $transformer->to_new(
+            [
+				'vendor_info'       => 'on',
+				'more_products_tab' => '',
+				'shipping_tab'      => 'on', // legacy "on" means hidden
+			]
+        );
+
+        $this->assertSame(
+            [
+                'vendor_info'       => true,
+                'more_products_tab' => false,
+                'shipping_tab'      => false, // inverted: legacy "on" → new false
+            ],
+            $result
+        );
+    }
+
+    public function test_to_new_treats_missing_shipping_tab_as_visible(): void {
+        $transformer = new SingleProductAppearanceTransformer();
+
+        $result = $transformer->to_new(
+            [
+				'vendor_info'       => 'on',
+				'more_products_tab' => 'on',
+            // shipping_tab absent from legacy
+			]
+        );
+
+        $this->assertTrue( $result['shipping_tab'] );
+    }
+
+    public function test_to_legacy_inverts_shipping_tab_back_to_disable_flag(): void {
+        $transformer = new SingleProductAppearanceTransformer();
+
+        $result = $transformer->to_legacy(
+            [
+				'vendor_info'       => true,
+				'more_products_tab' => false,
+				'shipping_tab'      => false, // hide in new
+			]
+        );
+
+        $this->assertSame(
+            [
+                'vendor_info'       => 'on',
+                'more_products_tab' => 'off',
+                'shipping_tab'      => 'on', // inverted back: new false → legacy "on" (disabled)
+            ],
+            $result
+        );
+    }
+
+    public function test_round_trip_preserves_visible_shipping_tab(): void {
+        $transformer = new SingleProductAppearanceTransformer();
+
+        // Start from canonical legacy values written by to_legacy.
+        $legacy = [
+            'vendor_info'       => 'on',
+            'more_products_tab' => 'on',
+            'shipping_tab'      => 'off', // not disabled = visible
+        ];
+        $new    = $transformer->to_new( $legacy );
+        $back   = $transformer->to_legacy( $new );
+
+        $this->assertTrue( $new['shipping_tab'] );
+        $this->assertSame( $legacy, $back );
+    }
+
+    public function test_non_array_input_is_treated_as_empty(): void {
+        $transformer = new SingleProductAppearanceTransformer();
+
+        $this->assertSame(
+            [
+                'vendor_info'       => false,
+                'more_products_tab' => false,
+                'shipping_tab'      => true, // no legacy data → tab visible by default
+            ],
+            $transformer->to_new( null )
+        );
+    }
+}

--- a/tests/php/src/Admin/Settings/Migration/Transformer/WithdrawChargeTransformerTest.php
+++ b/tests/php/src/Admin/Settings/Migration/Transformer/WithdrawChargeTransformerTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace WeDevs\Dokan\Test\Admin\Settings\Migration\Transformer;
+
+use WeDevs\Dokan\Admin\Settings\Migration\Transformer\WithdrawChargeTransformer;
+use WP_UnitTestCase;
+
+/**
+ * Locks in the key-flip contract for per-method withdraw charge entries:
+ * legacy [fixed, percentage] ⇔ new [admin_percentage, additional_fee].
+ *
+ * @covers \WeDevs\Dokan\Admin\Settings\Migration\Transformer\WithdrawChargeTransformer
+ */
+class WithdrawChargeTransformerTest extends WP_UnitTestCase {
+
+    public function test_to_new_flips_keys_and_preserves_values(): void {
+        $transformer = new WithdrawChargeTransformer();
+
+        $this->assertSame(
+            [
+                'admin_percentage' => '10.11',
+                'additional_fee'   => '7.89',
+            ],
+            $transformer->to_new(
+                [
+                    'fixed'      => '7.89',
+                    'percentage' => '10.11',
+                ]
+            )
+        );
+    }
+
+    public function test_to_legacy_flips_keys_and_preserves_values(): void {
+        $transformer = new WithdrawChargeTransformer();
+
+        $this->assertSame(
+            [
+                'percentage' => '5.5',
+                'fixed'      => '1.25',
+            ],
+            $transformer->to_legacy(
+                [
+                    'admin_percentage' => '5.5',
+                    'additional_fee'   => '1.25',
+                ]
+            )
+        );
+    }
+
+    public function test_missing_keys_become_empty_strings(): void {
+        $transformer = new WithdrawChargeTransformer();
+
+        $this->assertSame(
+            [
+                'admin_percentage' => '',
+                'additional_fee'   => '',
+            ],
+            $transformer->to_new( [] )
+        );
+
+        $this->assertSame(
+            [
+                'percentage' => '',
+                'fixed'      => '',
+            ],
+            $transformer->to_legacy( [] )
+        );
+    }
+
+    public function test_non_array_input_is_treated_as_empty(): void {
+        $transformer = new WithdrawChargeTransformer();
+
+        $this->assertSame(
+            [
+                'admin_percentage' => '',
+                'additional_fee'   => '',
+            ],
+            $transformer->to_new( null )
+        );
+        $this->assertSame(
+            [
+                'percentage' => '',
+                'fixed'      => '',
+            ],
+            $transformer->to_legacy( 'garbage' )
+        );
+    }
+
+    public function test_round_trip_preserves_legacy_shape(): void {
+        $transformer = new WithdrawChargeTransformer();
+
+        $legacy = [ 'fixed' => '1.23', 'percentage' => '4.56' ];
+        $back   = $transformer->to_legacy( $transformer->to_new( $legacy ) );
+
+        $this->assertSame( $legacy, $back );
+    }
+}

--- a/tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php
+++ b/tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php
@@ -73,7 +73,7 @@ class LegacySettingsRepositoryTest extends DokanTestCase {
     }
 
     public function test_foreign_legacy_write_flushes_only_that_section(): void {
-        update_option( 'dokan_general',    [ 'custom_store_url' => 'shop' ] );
+        update_option( 'dokan_general', [ 'custom_store_url' => 'shop' ] );
         update_option( 'dokan_appearance', [ 'store_banner_width' => 600 ] );
 
         $repo = new LegacySettingsRepository();
@@ -97,7 +97,7 @@ class LegacySettingsRepositoryTest extends DokanTestCase {
     }
 
     public function test_new_flat_option_write_flushes_every_section(): void {
-        update_option( 'dokan_general',    [ 'custom_store_url' => 'shop' ] );
+        update_option( 'dokan_general', [ 'custom_store_url' => 'shop' ] );
         update_option( 'dokan_appearance', [ 'store_banner_width' => 600 ] );
 
         $repo = new LegacySettingsRepository();

--- a/tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php
+++ b/tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php
@@ -125,4 +125,111 @@ class LegacySettingsRepositoryTest extends DokanTestCase {
 
         $this->assertSame( 'cleared', $repo->get( 'dokan_general', 'custom_store_url' ) );
     }
+
+    public function test_update_persists_to_legacy_section_option(): void {
+        update_option( 'dokan_general', [ 'other' => 'preserved' ] );
+        delete_option( 'dokan_admin_settings' );
+
+        $repo    = new LegacySettingsRepository();
+        $changed = $repo->update( 'dokan_general', [ 'custom_store_url' => 'shop' ] );
+
+        $this->assertSame( [ 'custom_store_url' => 'shop' ], $changed );
+        $this->assertSame(
+            [ 'other' => 'preserved', 'custom_store_url' => 'shop' ],
+            get_option( 'dokan_general' )
+        );
+    }
+
+    public function test_update_mirrors_mapped_keys_to_new_flat_option(): void {
+        delete_option( 'dokan_general' );
+        delete_option( 'dokan_admin_settings' );
+
+        $repo = new LegacySettingsRepository();
+        $repo->update( 'dokan_general', [ 'custom_store_url' => 'marketplace' ] );
+
+        $new = get_option( 'dokan_admin_settings' );
+        $this->assertIsArray( $new );
+        // Schema maps vendor_store_url → dokan_general.custom_store_url (SettingsSchema.php:153-165).
+        $this->assertSame( 'marketplace', $new['vendor_store_url'] );
+    }
+
+    public function test_update_with_no_change_is_a_noop(): void {
+        update_option( 'dokan_general', [ 'custom_store_url' => 'shop' ] );
+
+        $repo = new LegacySettingsRepository();
+        // Warm the snapshot first so $current matches the on-disk value.
+        $repo->all( 'dokan_general' );
+
+        $changed = $repo->update( 'dokan_general', [ 'custom_store_url' => 'shop' ] );
+        $this->assertSame( [], $changed );
+    }
+
+    public function test_update_fires_pre_save_filter_and_changed_action(): void {
+        delete_option( 'dokan_general' );
+        delete_option( 'dokan_admin_settings' );
+
+        $filter_received = null;
+        $action_payload  = null;
+
+        add_filter(
+            'dokan_legacy_settings_pre_save',
+            static function ( $slice, $section, $current ) use ( &$filter_received ) {
+                $filter_received = [ 'slice' => $slice, 'section' => $section, 'current' => $current ];
+                return $slice;
+            },
+            10,
+            3
+        );
+
+        add_action(
+            'dokan_legacy_settings_changed',
+            static function ( $section, $changed, $before, $after ) use ( &$action_payload ) {
+                $action_payload = compact( 'section', 'changed', 'before', 'after' );
+            },
+            10,
+            4
+        );
+
+        $repo = new LegacySettingsRepository();
+        $repo->update( 'dokan_general', [ 'custom_store_url' => 'shop' ] );
+
+        $this->assertSame( 'dokan_general', $filter_received['section'] );
+        $this->assertSame( [ 'custom_store_url' => 'shop' ], $filter_received['slice'] );
+        $this->assertSame( 'dokan_general', $action_payload['section'] );
+        $this->assertSame( [ 'custom_store_url' => 'shop' ], $action_payload['changed'] );
+    }
+
+    public function test_pre_save_filter_can_mutate_slice(): void {
+        delete_option( 'dokan_general' );
+
+        add_filter(
+            'dokan_legacy_settings_pre_save',
+            static function ( $slice ) {
+                $slice['custom_store_url'] = 'overridden';
+                return $slice;
+            }
+        );
+
+        $repo = new LegacySettingsRepository();
+        $repo->update( 'dokan_general', [ 'custom_store_url' => 'original' ] );
+
+        $this->assertSame( 'overridden', get_option( 'dokan_general' )['custom_store_url'] );
+    }
+
+    public function test_update_returns_only_changed_entries(): void {
+        update_option( 'dokan_general', [
+            'custom_store_url' => 'shop',
+            'admin_access'     => 'on',
+        ] );
+
+        $repo = new LegacySettingsRepository();
+        $repo->all( 'dokan_general' );
+
+        $changed = $repo->update( 'dokan_general', [
+            'custom_store_url' => 'shop',    // unchanged
+            'admin_access'     => 'off',     // changed
+        ] );
+
+        $this->assertSame( [ 'admin_access' => 'off' ], $changed );
+    }
 }

--- a/tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php
+++ b/tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php
@@ -71,4 +71,58 @@ class LegacySettingsRepositoryTest extends DokanTestCase {
 
         $this->assertSame( 'shop', $repo->get( 'dokan_general', 'custom_store_url' ) );
     }
+
+    public function test_foreign_legacy_write_flushes_only_that_section(): void {
+        update_option( 'dokan_general',    [ 'custom_store_url' => 'shop' ] );
+        update_option( 'dokan_appearance', [ 'store_banner_width' => 600 ] );
+
+        $repo = new LegacySettingsRepository();
+        // Warm both snapshots.
+        $repo->all( 'dokan_general' );
+        $repo->all( 'dokan_appearance' );
+
+        // Foreign write to dokan_general should trigger update_option_dokan_general.
+        update_option( 'dokan_general', [ 'custom_store_url' => 'market' ] );
+
+        $this->assertSame( 'market', $repo->get( 'dokan_general', 'custom_store_url' ) );
+        // The other section's snapshot should remain cached — tamper to verify.
+        global $wpdb;
+        $wpdb->update(
+            $wpdb->options,
+            [ 'option_value' => serialize( [ 'store_banner_width' => 9999 ] ) ],
+            [ 'option_name' => 'dokan_appearance' ]
+        );
+        wp_cache_delete( 'dokan_appearance', 'options' );
+        $this->assertSame( 600, $repo->get( 'dokan_appearance', 'store_banner_width' ) );
+    }
+
+    public function test_new_flat_option_write_flushes_every_section(): void {
+        update_option( 'dokan_general',    [ 'custom_store_url' => 'shop' ] );
+        update_option( 'dokan_appearance', [ 'store_banner_width' => 600 ] );
+
+        $repo = new LegacySettingsRepository();
+        $repo->all( 'dokan_general' );
+        $repo->all( 'dokan_appearance' );
+
+        update_option( 'dokan_admin_settings', [ 'vendor_store_url' => 'marketplace' ] );
+
+        // After flush, the next read should reflect the overlay from the new flat option.
+        $this->assertSame( 'marketplace', $repo->get( 'dokan_general', 'custom_store_url' ) );
+    }
+
+    public function test_flush_cache_null_clears_all_sections(): void {
+        update_option( 'dokan_general', [ 'custom_store_url' => 'shop' ] );
+
+        $repo = new LegacySettingsRepository();
+        $repo->all( 'dokan_general' );
+
+        $repo->flush_cache( null );
+
+        update_option( 'dokan_general', [ 'custom_store_url' => 'cleared' ] );
+        // Bypass the WP hook by re-flushing manually (the hook already flushed once but
+        // we want to assert the public method works independently of the listener).
+        $repo->flush_cache( null );
+
+        $this->assertSame( 'cleared', $repo->get( 'dokan_general', 'custom_store_url' ) );
+    }
 }

--- a/tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php
+++ b/tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php
@@ -267,4 +267,16 @@ class LegacySettingsRepositoryTest extends DokanTestCase {
 
         $this->assertSame( 'marketplace', get_option( 'dokan_admin_settings' )['vendor_store_url'] );
     }
+
+    public function test_dokan_get_option_reads_through_repository(): void {
+        update_option( 'dokan_general', [ 'custom_store_url' => 'shop' ] );
+        update_option( 'dokan_admin_settings', [ 'vendor_store_url' => 'marketplace' ] );
+
+        // Flush repo cache so the next read sees the freshly-set options.
+        dokan_get_container()
+            ->get( LegacySettingsRepository::class )
+            ->flush_cache( null );
+
+        $this->assertSame( 'marketplace', dokan_get_option( 'custom_store_url', 'dokan_general' ) );
+    }
 }

--- a/tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php
+++ b/tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php
@@ -232,4 +232,39 @@ class LegacySettingsRepositoryTest extends DokanTestCase {
 
         $this->assertSame( [ 'admin_access' => 'off' ], $changed );
     }
+
+    public function test_replace_writes_payload_whole(): void {
+        update_option( 'dokan_general', [ 'a' => 1, 'b' => 2 ] );
+        delete_option( 'dokan_admin_settings' );
+
+        $repo = new LegacySettingsRepository();
+        $repo->replace( 'dokan_general', [ 'c' => 3 ] );
+
+        $this->assertSame( [ 'c' => 3 ], get_option( 'dokan_general' ) );
+    }
+
+    public function test_replace_returns_diff_with_removed_keys_as_null(): void {
+        update_option( 'dokan_general', [ 'a' => 1, 'b' => 2 ] );
+
+        $repo = new LegacySettingsRepository();
+        $repo->all( 'dokan_general' );
+
+        $diff = $repo->replace( 'dokan_general', [ 'a' => 1, 'c' => 3 ] );
+
+        // `b` removed, `c` added, `a` unchanged.
+        $this->assertArrayHasKey( 'b', $diff );
+        $this->assertNull( $diff['b'] );
+        $this->assertSame( 3, $diff['c'] );
+        $this->assertArrayNotHasKey( 'a', $diff );
+    }
+
+    public function test_replace_mirrors_mapped_keys_to_new_option(): void {
+        delete_option( 'dokan_general' );
+        delete_option( 'dokan_admin_settings' );
+
+        $repo = new LegacySettingsRepository();
+        $repo->replace( 'dokan_general', [ 'custom_store_url' => 'marketplace' ] );
+
+        $this->assertSame( 'marketplace', get_option( 'dokan_admin_settings' )['vendor_store_url'] );
+    }
 }

--- a/tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php
+++ b/tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace WeDevs\Dokan\Test\Admin\Settings\Repository;
+
+use WeDevs\Dokan\Admin\Settings\Repository\LegacySettingsRepository;
+use WeDevs\Dokan\Admin\Settings\Repository\LegacySettingsRepositoryInterface;
+use WeDevs\Dokan\Test\DokanTestCase;
+
+/**
+ * @group admin-settings
+ */
+class LegacySettingsRepositoryTest extends DokanTestCase {
+
+    public function test_class_implements_interface(): void {
+        $repo = new LegacySettingsRepository();
+        $this->assertInstanceOf( LegacySettingsRepositoryInterface::class, $repo );
+    }
+}

--- a/tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php
+++ b/tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php
@@ -15,4 +15,60 @@ class LegacySettingsRepositoryTest extends DokanTestCase {
         $repo = new LegacySettingsRepository();
         $this->assertInstanceOf( LegacySettingsRepositoryInterface::class, $repo );
     }
+
+    public function test_all_returns_empty_array_when_option_missing(): void {
+        delete_option( 'dokan_general' );
+
+        $repo = new LegacySettingsRepository();
+        $this->assertSame( [], $repo->all( 'dokan_general' ) );
+    }
+
+    public function test_all_returns_raw_section_when_no_overlay(): void {
+        update_option( 'dokan_general', [ 'custom_store_url' => 'shop' ] );
+        delete_option( 'dokan_admin_settings' );
+
+        $repo = new LegacySettingsRepository();
+        $this->assertSame(
+            [ 'custom_store_url' => 'shop' ],
+            $repo->all( 'dokan_general' )
+        );
+    }
+
+    public function test_get_returns_default_when_key_absent(): void {
+        update_option( 'dokan_general', [ 'other' => 'value' ] );
+        delete_option( 'dokan_admin_settings' );
+
+        $repo = new LegacySettingsRepository();
+        $this->assertSame( 'fallback', $repo->get( 'dokan_general', 'custom_store_url', 'fallback' ) );
+    }
+
+    public function test_overlay_from_new_option_wins_over_raw_section(): void {
+        update_option( 'dokan_general', [ 'custom_store_url' => 'shop' ] );
+        update_option( 'dokan_admin_settings', [ 'vendor_store_url' => 'marketplace' ] );
+
+        $repo = new LegacySettingsRepository();
+        $this->assertSame(
+            'marketplace',
+            $repo->get( 'dokan_general', 'custom_store_url' )
+        );
+    }
+
+    public function test_second_read_uses_in_request_cache(): void {
+        update_option( 'dokan_general', [ 'custom_store_url' => 'shop' ] );
+
+        $repo = new LegacySettingsRepository();
+        $this->assertSame( 'shop', $repo->get( 'dokan_general', 'custom_store_url' ) );
+
+        // Tamper with the option directly; repository should still serve the cached snapshot.
+        global $wpdb;
+        $wpdb->update(
+            $wpdb->options,
+            [ 'option_value' => serialize( [ 'custom_store_url' => 'TAMPERED' ] ) ],
+            [ 'option_name' => 'dokan_general' ]
+        );
+        wp_cache_delete( 'dokan_general', 'options' );
+        wp_cache_delete( 'notoptions', 'options' );
+
+        $this->assertSame( 'shop', $repo->get( 'dokan_general', 'custom_store_url' ) );
+    }
 }

--- a/tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php
+++ b/tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php
@@ -4,6 +4,7 @@ namespace WeDevs\Dokan\Test\Admin\Settings\Repository;
 
 use WeDevs\Dokan\Admin\Settings\Repository\LegacySettingsRepository;
 use WeDevs\Dokan\Admin\Settings\Repository\LegacySettingsRepositoryInterface;
+use WeDevs\Dokan\Admin\Settings\Repository\SettingsRepository;
 use WeDevs\Dokan\Test\DokanTestCase;
 
 /**
@@ -277,6 +278,31 @@ class LegacySettingsRepositoryTest extends DokanTestCase {
             ->get( LegacySettingsRepository::class )
             ->flush_cache( null );
 
+        $this->assertSame( 'marketplace', dokan_get_option( 'custom_store_url', 'dokan_general' ) );
+    }
+
+    public function test_integration_round_trip_through_container(): void {
+        // Set both options to a value that differs from what the test will write
+        // so the diff is always non-empty regardless of any prior test's cached state.
+        update_option( 'dokan_general', [ 'custom_store_url' => 'before' ] );
+        update_option( 'dokan_admin_settings', [ 'vendor_store_url' => 'before' ] );
+
+        // Flush every in-request snapshot (container singletons + internal private
+        // repos inside LegacySettingsRepository and LegacySettingsBridge) so the
+        // next read reflects the options we just set.
+        $container = dokan_get_container();
+        $container->get( LegacySettingsRepository::class )->flush_cache( null );
+        $container->get( SettingsRepository::class )->flush_cache();
+
+        $repo = $container->get( LegacySettingsRepository::class );
+
+        $repo->update( 'dokan_general', [ 'custom_store_url' => 'marketplace' ] );
+
+        // Legacy storage updated.
+        $this->assertSame( 'marketplace', get_option( 'dokan_general' )['custom_store_url'] );
+        // New flat storage updated via mirror.
+        $this->assertSame( 'marketplace', get_option( 'dokan_admin_settings' )['vendor_store_url'] );
+        // dokan_get_option() resolves through the repo and sees the overlay.
         $this->assertSame( 'marketplace', dokan_get_option( 'custom_store_url', 'dokan_general' ) );
     }
 }


### PR DESCRIPTION
### All Submissions

* [x] My code follows WordPress' coding standards
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation

### Changes proposed in this Pull Request

Introduces `LegacySettingsRepository` as the single sanctioned read/write seam for the legacy per-section `dokan_*` wp_options (`dokan_general`, `dokan_selling`, `dokan_appearance`, `dokan_pages`, `dokan_privacy`, `dokan_withdraw`, …).

**Design goal:** testability + per-request caching. Not a migration step. Legacy storage is unchanged; the bridge stays in place; behavior of `dokan_get_option()` is preserved.

**What the repository does:**
- Section-aware API: `all($section)`, `get($section, $key, $default)`, `update($section, $slice)`, `replace($section, $payload)`, `flush_cache(?$section)`.
- Per-section in-request snapshot cache with the existing `LegacySettingsBridge` overlay applied on read.
- Writes persist to the legacy section option AND mirror mapped keys to `dokan_admin_settings` via the existing `SettingsRepository::update()` (bridge's `transform_legacy_payload_to_new()` handles the legacy→new translation).
- Cache invalidation listeners bind to `update_option_<section>` / `add_option_<section>` for every section in the bridge mapping, plus `update_option_dokan_admin_settings` / `add_option_dokan_admin_settings` (overlay-source changes flush all snapshots).
- Two new hooks: `dokan_legacy_settings_pre_save` filter, `dokan_legacy_settings_changed` action.

**Call-site changes (small surface):**
- `dokan_get_option()` in `includes/functions.php` now delegates to the repository (container-missing fallback preserved exactly as before).
- Two direct `get_option('dokan_*')` reads in `includes/functions.php` migrated to `->all($section)` — they pick up the overlay for free, fixing a latent inconsistency.
- A 40-line audit of direct `update_option('dokan_*', …)` callers found no migration-eligible writes (all matches are non-settings keys, installers, or one-time activation flows).

### Documents

- Design spec: `docs/superpowers/specs/2026-05-18-legacy-settings-repository-design.md`
- Implementation plan: `docs/superpowers/plans/2026-05-19-legacy-settings-repository.md`

### How to test the changes

1. Run the admin-settings PHPUnit group:
   ```bash
   npm run phpunit -- --group=admin-settings
   ```
   Expected: 244 tests, 2959 assertions, all passing.
2. PHPCS on the new code:
   ```bash
   composer phpcs -- includes/Admin/Settings/Repository
   ```
   Expected: 0 errors, 0 warnings.
3. Manual smoke: change any settings tab in the admin UI and verify `get_option('dokan_general')` and `get_option('dokan_admin_settings')` both reflect the change.

### Changelog entry

*LegacySettingsRepository — single read/write seam for legacy per-section dokan_* options*

Adds `LegacySettingsRepository` for the legacy `dokan_general`, `dokan_selling`, `dokan_appearance`, `dokan_pages`, `dokan_privacy`, `dokan_withdraw` and other per-section settings options. Reads apply the new-flat overlay; writes mirror to `dokan_admin_settings` via the existing repository. `dokan_get_option()` now delegates here. Two direct `get_option('dokan_*')` reads in `includes/functions.php` migrated, fixing a latent inconsistency where those callers bypassed the overlay.

### Before Changes

`dokan_get_option()` inlined the bridge overlay; two direct `get_option('dokan_pages')` / `get_option('dokan_appearance')` reads bypassed it. No central seam to mock in tests or to enforce invariants on legacy reads/writes.

### After Changes

Single repository owns legacy section reads/writes. Per-request snapshot cache backed by WP option hooks. Two new extensibility hooks (`dokan_legacy_settings_pre_save`, `dokan_legacy_settings_changed`).

### PR Self Review Checklist

- [x] Code style follows project conventions
- [x] Naming reflects intent
- [x] KISS — straightforward repository pattern, no premature abstraction
- [x] DRY — reuses bridge's existing legacy↔new mapping; no parallel hardcoded section list
- [x] Inline docblocks present
- [x] No grammar errors in commits/docs

### Implementation notes for reviewers

- The repository's listener registration relies on `LegacySettingsBridge::get_mapping()` for `known_sections()` — a third-party plugin that adds a new legacy section via the `dokan_settings_sections` filter *after* the repo's constructor will not get cache-invalidation listeners. Documented and accepted in the spec.
- Mirror write failures (bridge throws, new repo throws) are caught + logged via `dokan_log`; the legacy write is not rolled back. Best-effort by design.
- The interface `LegacySettingsRepositoryInterface` is registered via the container's `share_with_implements_tags` (consistent with how `SettingsRepository` and `SettingsRepositoryInterface` are bound — concrete-only resolution, interface tagged but not aliased). Callers use the concrete class for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)