### PR TITLE
Fix untranslated 'Actions' column header on vendor dashboard tables

### DIFF
--- a/src/dashboard/index.tsx
+++ b/src/dashboard/index.tsx
@@ -1,5 +1,7 @@
 import { createRoot } from '@wordpress/element';
 import domReady from '@wordpress/dom-ready';
+import { addFilter } from '@wordpress/hooks';
+import { __ } from '@wordpress/i18n';
 import Layout from '../layout';
 import getRoutes, { withRouter } from '../routing';
 import { createHashRouter, RouterProvider } from 'react-router-dom';
@@ -7,6 +9,22 @@ import { useSelect } from '@wordpress/data';
 import coreStore from '@dokan/stores/core';
 import Skeleton from '@src/layout/Skeleton';
 import { generateColorVariants } from '@dokan/utilities';
+
+// `<DataViews>` (via @wordpress/dataviews) renders its Actions column header
+// against the core 'default' text domain, whose translations don't load on the
+// frontend. Re-route the 'default' "Actions" lookup through 'dokan-lite' so
+// Dokan's translation wins.
+addFilter(
+    'i18n.gettext_default',
+    'dokan-lite/dataviews-actions-label',
+    ( translation: string, text: string ) => {
+        if ( text !== 'Actions' ) {
+            return translation;
+        }
+        const dokanTranslation = __( 'Actions', 'dokan-lite' );
+        return dokanTranslation !== 'Actions' ? dokanTranslation : translation;
+    }
+);
 
 const App = () => {
     const routes = getRoutes();

--- a/src/dashboard/index.tsx
+++ b/src/dashboard/index.tsx
@@ -21,8 +21,7 @@ addFilter(
         if ( text !== 'Actions' ) {
             return translation;
         }
-        const dokanTranslation = __( 'Actions', 'dokan-lite' );
-        return dokanTranslation !== 'Actions' ? dokanTranslation : translation;
+        return __( 'Actions', 'dokan-lite' );
     }
 );
 

--- a/src/dashboard/products/ProductList.tsx
+++ b/src/dashboard/products/ProductList.tsx
@@ -936,6 +936,7 @@ function ProductList() {
                     onReset: onFilterReset,
                 } }
                 search={ true }
+                actionsLabel={ __( 'Actions', 'dokan-lite' ) }
                 actions={ filteredActions }
                 selection={ selection }
                 onChangeSelection={ ( ids: string[] ) => setSelection( ids ) }

--- a/src/dashboard/products/ProductList.tsx
+++ b/src/dashboard/products/ProductList.tsx
@@ -936,7 +936,6 @@ function ProductList() {
                     onReset: onFilterReset,
                 } }
                 search={ true }
-                actionsLabel={ __( 'Actions', 'dokan-lite' ) }
                 actions={ filteredActions }
                 selection={ selection }
                 onChangeSelection={ ( ids: string[] ) => setSelection( ids ) }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fix the untranslated "Actions" column header on the vendor-dashboard product listing page (and any other `<DataViews>` table on the vendor dashboard).

**Root cause** — upstream `@wordpress/dataviews` renders the column header with `__('Actions')` in the WordPress core `'default'` text domain. Core `'default'` translations are only loaded in wp-admin context; on the vendor-dashboard frontend they are not loaded, so the header falls back to English even when Dokan ships a translation for the same string.

**Fix** — register an `i18n.gettext_default` filter at the vendor-dashboard entry point (`src/dashboard/index.tsx`) that re-routes the `'default'`-domain `Actions` lookup through `'dokan-lite'` whenever Dokan has its own translation. The filter is global to the vendor-dashboard bundle, so every `<DataViews>` table on the dashboard benefits, including the skeleton/loading state (which also calls `__('Actions', 'default')` internally and is routed through the same filter).

### Related Pull Request(s)

* getdokan/dokan-pro#5655 — Pro companion PR (Quick Edit / Duplicate / Advertise)

### Closes

* Partial fix for getdokan/dokan-pro#5647 (Pro PR addresses "Quick Edit", "Duplicate", "Advertise")

### How to test the changes in this Pull Request:

1. Switch site language to one where Dokan ships a translated "Actions" string (e.g. Spanish, Bengali). Verify in `dokan-lite.po` that `Actions` has a non-empty `msgstr`.
2. As a vendor, visit **Vendor Dashboard → Products**.
3. Confirm the "Actions" column header renders translated.
4. Confirm during the initial loading skeleton, the placeholder header also reads as the translated string (no English flash).
5. Confirm no other UI text on the page has regressed.

### Changelog entry

*Fix untranslated 'Actions' column header on vendor dashboard tables*

The actions column header rendered by `@wordpress/dataviews` was showing English "Actions" on the vendor-dashboard frontend even when a Dokan translation existed. Route the upstream `__('Actions', 'default')` lookup through Dokan's `'dokan-lite'` text domain via an `i18n.gettext_default` filter.

### Before Changes

Vendor dashboard products page in a translated locale — column header reads English "ACTIONS" while sibling columns are translated.

### After Changes

Same page — column header now reads as the locale-appropriate translation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization & Translation**
  * Improved translation support for action labels in the dashboard, ensuring they are properly localized based on the application's text domain rather than WordPress's default domain.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getdokan/dokan/pull/3204?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->