### PR TITLE
fix: missing authorization in CustomersController

### DIFF
--- a/includes/REST/CustomersController.php
+++ b/includes/REST/CustomersController.php
@@ -58,27 +58,88 @@ class CustomersController extends WC_REST_Customers_Controller {
      * @return WP_Error|boolean
      */
     protected function check_permission( $request, $action ) {
+        $messages = [
+            'view'   => __( 'Sorry, you cannot list resources.', 'dokan-lite' ),
+            'create' => __( 'Sorry, you are not allowed to create resources.', 'dokan-lite' ),
+            'edit'   => __( 'Sorry, you are not allowed to edit this resource.', 'dokan-lite' ),
+            'delete' => __( 'Sorry, you are not allowed to delete this resource.', 'dokan-lite' ),
+            'batch'  => __( 'Sorry, you are not allowed to batch update resources.', 'dokan-lite' ),
+            'search' => __( 'Sorry, you are not allowed to search customers.', 'dokan-lite' ),
+        ];
+
         if ( ! $this->check_vendor_permission() ) {
-            $messages = [
-                'view'   => __( 'Sorry, you cannot list resources.', 'dokan-lite' ),
-                'create' => __( 'Sorry, you are not allowed to create resources.', 'dokan-lite' ),
-                'edit'   => __( 'Sorry, you are not allowed to edit this resource.', 'dokan-lite' ),
-                'delete' => __( 'Sorry, you are not allowed to delete this resource.', 'dokan-lite' ),
-                'batch'  => __( 'Sorry, you are not allowed to batch update resources.', 'dokan-lite' ),
-                'search' => __( 'Sorry, you are not allowed to search customers.', 'dokan-lite' ),
-            ];
             return new WP_Error( "dokan_rest_cannot_$action", $messages[ $action ], [ 'status' => rest_authorization_required_code() ] );
         }
+
+        // CVE-2026-8761: object-level authorization for mutating actions.
+        $target_id = isset( $request['id'] ) ? (int) $request['id'] : 0;
+        if ( $target_id > 0 && in_array( $action, [ 'edit', 'delete' ], true ) && is_wp_error( $this->is_target_user_allowed( $target_id ) ) ) {
+            return new WP_Error( "dokan_rest_cannot_$action", $messages[ $action ], [ 'status' => 403 ] );
+        }
+
+        return true;
+    }
+
+    /**
+     * Verify the requesting vendor may mutate the target user.
+     *
+     * Rejects targets that are missing, hold admin-grade capabilities,
+     * are themselves a vendor, or have never placed an order with the
+     * requesting vendor. CVE-2026-8761.
+     *
+     * @param int $target_id Target user id.
+     *
+     * @return true|WP_Error
+     */
+    protected function is_target_user_allowed( int $target_id ) {
+        if ( $target_id <= 0 || ! get_userdata( $target_id ) ) {
+            return new WP_Error( 'dokan_rest_invalid_target', __( 'Invalid user.', 'dokan-lite' ), [ 'status' => 404 ] );
+        }
+
+        $protected_caps = [ 'manage_options', 'manage_woocommerce', 'edit_users', 'delete_users', 'list_users', 'promote_users', 'create_users', 'remove_users' ];
+        foreach ( $protected_caps as $cap ) {
+            if ( user_can( $target_id, $cap ) ) {
+                return new WP_Error( 'dokan_rest_forbidden_target', __( 'You cannot operate on this user.', 'dokan-lite' ), [ 'status' => 403 ] );
+            }
+        }
+
+        if ( dokan_is_user_seller( $target_id ) ) {
+            return new WP_Error( 'dokan_rest_forbidden_target', __( 'You cannot operate on this user.', 'dokan-lite' ), [ 'status' => 403 ] );
+        }
+
+        if ( ! dokan_customer_has_order_from_this_seller( $target_id, dokan_get_current_user_id() ) ) {
+            return new WP_Error( 'dokan_rest_forbidden_target', __( 'You cannot operate on this customer.', 'dokan-lite' ), [ 'status' => 403 ] );
+        }
+
         return true;
     }
 
     /**
      * Check if the current user has vendor permissions.
      *
+     * Doubles as a callback on the woocommerce_rest_check_permissions
+     * filter so WooCommerce's internal capability checks for mutating
+     * operations (create/edit/delete/batch) re-validate the target user.
+     * Read context is allowed through for the vendor.
+     *
+     * @param bool|mixed $permission  Original permission decision when used as a filter callback.
+     * @param string     $context     Operation context (read/edit/delete/create/batch).
+     * @param int        $object_id   Target object id.
+     * @param string     $object_type Object type (expected: user).
+     *
      * @return bool
      */
-    public function check_vendor_permission(): bool {
-        return dokan_is_user_seller( dokan_get_current_user_id() );
+    public function check_vendor_permission( $permission = false, $context = '', $object_id = 0, $object_type = '' ): bool {
+        if ( ! dokan_is_user_seller( dokan_get_current_user_id() ) ) {
+            return false;
+        }
+
+        $object_id = (int) $object_id;
+        if ( $object_id > 0 && ( '' === $object_type || 'user' === $object_type ) && in_array( $context, [ 'create', 'edit', 'delete', 'batch' ], true ) ) {
+            return ! is_wp_error( $this->is_target_user_allowed( $object_id ) );
+        }
+
+        return true;
     }
 
     /**
@@ -255,6 +316,11 @@ class CustomersController extends WC_REST_Customers_Controller {
      * @return WP_Error|WC_Data
      */
     protected function prepare_object_for_database( $request, $creating = false ) {
+        // CVE-2026-8761: never allow role/roles via this endpoint.
+        if ( null !== $request->get_param( 'role' ) || null !== $request->get_param( 'roles' ) ) {
+            return new WP_Error( 'dokan_rest_forbidden_field', __( 'You cannot modify the role of a user.', 'dokan-lite' ), [ 'status' => 403 ] );
+        }
+
         $customer = parent::prepare_object_for_database( $request, $creating );
 
         if ( is_wp_error( $customer ) ) {
@@ -278,9 +344,9 @@ class CustomersController extends WC_REST_Customers_Controller {
      * @return mixed The result of the action.
      */
     private function perform_vendor_action( callable $action ) {
-        add_filter( 'woocommerce_rest_check_permissions', [ $this, 'check_vendor_permission' ] );
+        add_filter( 'woocommerce_rest_check_permissions', [ $this, 'check_vendor_permission' ], 10, 4 );
         $result = $action();
-        remove_filter( 'woocommerce_rest_check_permissions', [ $this, 'check_vendor_permission' ] );
+        remove_filter( 'woocommerce_rest_check_permissions', [ $this, 'check_vendor_permission' ], 10 );
         return $result;
     }
 

--- a/includes/REST/CustomersController.php
+++ b/includes/REST/CustomersController.php
@@ -73,8 +73,13 @@ class CustomersController extends WC_REST_Customers_Controller {
 
         // CVE-2026-8761: object-level authorization for mutating actions.
         $target_id = isset( $request['id'] ) ? (int) $request['id'] : 0;
-        if ( $target_id > 0 && in_array( $action, [ 'edit', 'delete' ], true ) && is_wp_error( $this->is_target_user_allowed( $target_id ) ) ) {
-            return new WP_Error( "dokan_rest_cannot_$action", $messages[ $action ], [ 'status' => 403 ] );
+        if ( $target_id > 0 && in_array( $action, [ 'view', 'edit', 'delete' ], true ) ) {
+            $allowed = $this->is_target_user_allowed( $target_id );
+            if ( is_wp_error( $allowed ) ) {
+                $status = $allowed->get_error_data();
+                $status = isset( $status['status'] ) ? (int) $status['status'] : 403;
+                return new WP_Error( "dokan_rest_cannot_$action", $messages[ $action ], [ 'status' => $status ] );
+            }
         }
 
         return true;
@@ -151,7 +156,24 @@ class CustomersController extends WC_REST_Customers_Controller {
     public function get_items( $request ) {
         return $this->perform_vendor_action(
             function () use ( $request ) {
-                return parent::get_items( $request );
+                $response = parent::get_items( $request );
+                if ( is_wp_error( $response ) || ! ( $response instanceof WP_REST_Response ) ) {
+                    return $response;
+                }
+
+                $vendor_id = dokan_get_current_user_id();
+                $data = array_values(
+                    array_filter(
+                        (array) $response->get_data(),
+                        static function ( $item ) use ( $vendor_id ) {
+							$id = is_array( $item ) ? ( $item['id'] ?? 0 ) : 0;
+							return $id && dokan_customer_has_order_from_this_seller( $id, $vendor_id );
+                        }
+                    )
+                );
+
+                $response->set_data( $data );
+                return $response;
             }
         );
     }
@@ -345,9 +367,11 @@ class CustomersController extends WC_REST_Customers_Controller {
      */
     private function perform_vendor_action( callable $action ) {
         add_filter( 'woocommerce_rest_check_permissions', [ $this, 'check_vendor_permission' ], 10, 4 );
-        $result = $action();
-        remove_filter( 'woocommerce_rest_check_permissions', [ $this, 'check_vendor_permission' ], 10 );
-        return $result;
+        try {
+            return $action();
+        } finally {
+            remove_filter( 'woocommerce_rest_check_permissions', [ $this, 'check_vendor_permission' ], 10 );
+        }
     }
 
     /**

--- a/includes/REST/CustomersController.php
+++ b/includes/REST/CustomersController.php
@@ -101,7 +101,19 @@ class CustomersController extends WC_REST_Customers_Controller {
             return new WP_Error( 'dokan_rest_invalid_target', __( 'Invalid user.', 'dokan-lite' ), [ 'status' => 404 ] );
         }
 
-        $protected_caps = [ 'manage_options', 'manage_woocommerce', 'edit_users', 'delete_users', 'list_users', 'promote_users', 'create_users', 'remove_users' ];
+        $protected_caps = apply_filters(
+            'dokan_rest_protected_user_caps',
+            [
+                'manage_options',
+				'manage_woocommerce',
+                'edit_users',
+				'delete_users',
+				'list_users',
+				'promote_users',
+				'create_users',
+				'remove_users',
+			]
+        );
         foreach ( $protected_caps as $cap ) {
             if ( user_can( $target_id, $cap ) ) {
                 return new WP_Error( 'dokan_rest_forbidden_target', __( 'You cannot operate on this user.', 'dokan-lite' ), [ 'status' => 403 ] );

--- a/tests/php/src/REST/CustomersControllerTest.php
+++ b/tests/php/src/REST/CustomersControllerTest.php
@@ -563,11 +563,154 @@ class CustomersControllerTest extends DokanTestCase {
         ];
 
         $response = $this->put_request( "customers/$customer_id", $update_data );
-        $this->assertEquals( 200, $response->get_status() );
+        $this->assertEquals( 403, $response->get_status() );
 
         // Verify updated roles
         $customer = new WC_Customer( $customer_id );
         $this->assertEquals( 'customer', $customer->get_role() );
+    }
+
+    /**
+     * CVE-2026-8761: a vendor must not be able to update a user that
+     * holds admin-grade capabilities, regardless of payload.
+     */
+    public function test_cannot_update_admin_user() {
+        wp_set_current_user( $this->seller_id1 );
+
+        $response = $this->put_request(
+            "customers/{$this->admin_id}",
+            [
+                'first_name' => 'Hijacked',
+            ]
+        );
+
+        $this->assertEquals( 403, $response->get_status() );
+        $this->assertEquals( 'dokan_rest_cannot_edit', $response->get_data()['code'] );
+
+        $admin = get_userdata( $this->admin_id );
+        $this->assertNotEquals( 'Hijacked', $admin->first_name );
+    }
+
+    /**
+     * CVE-2026-8761: the password overwrite PoC must be blocked.
+     */
+    public function test_admin_password_overwrite_blocked() {
+        wp_set_current_user( $this->seller_id1 );
+
+        $original_hash = get_userdata( $this->admin_id )->user_pass;
+
+        $response = $this->put_request(
+            "customers/{$this->admin_id}",
+            [
+                'password' => 'pwned_by_vendor',
+            ]
+        );
+
+        $this->assertEquals( 403, $response->get_status() );
+        $this->assertEquals( 'dokan_rest_cannot_edit', $response->get_data()['code'] );
+
+        $this->assertEquals( $original_hash, get_userdata( $this->admin_id )->user_pass );
+    }
+
+    /**
+     * CVE-2026-8761: a vendor must not be able to delete an admin user.
+     */
+    public function test_cannot_delete_admin_user() {
+        wp_set_current_user( $this->seller_id1 );
+
+        $response = $this->delete_request( "customers/{$this->admin_id}", [ 'force' => true ] );
+
+        $this->assertEquals( 403, $response->get_status() );
+        $this->assertEquals( 'dokan_rest_cannot_delete', $response->get_data()['code'] );
+        $this->assertNotFalse( get_user_by( 'id', $this->admin_id ) );
+    }
+
+    /**
+     * CVE-2026-8761: a vendor must not be able to update another vendor.
+     */
+    public function test_cannot_update_other_vendor() {
+        wp_set_current_user( $this->seller_id1 );
+
+        $response = $this->put_request(
+            "customers/{$this->seller_id2}",
+            [
+                'first_name' => 'Tampered',
+            ]
+        );
+
+        $this->assertEquals( 403, $response->get_status() );
+        $this->assertEquals( 'dokan_rest_cannot_edit', $response->get_data()['code'] );
+    }
+
+    /**
+     * CVE-2026-8761: a vendor must not be able to update a user who has
+     * never placed an order with them.
+     */
+    public function test_cannot_update_unrelated_customer() {
+        wp_set_current_user( $this->seller_id1 );
+
+        // customers[0] has no order with seller_id1 in this test.
+        $response = $this->put_request(
+            "customers/{$this->customers[0]}",
+            [
+                'first_name' => 'Tampered',
+            ]
+        );
+
+        $this->assertEquals( 403, $response->get_status() );
+        $this->assertEquals( 'dokan_rest_cannot_edit', $response->get_data()['code'] );
+    }
+
+    /**
+     * CVE-2026-8761: batch update must reject any entry that targets an
+     * admin user, even when other entries are legitimate.
+     */
+    public function test_batch_update_blocks_admin_target() {
+        wp_set_current_user( $this->seller_id1 );
+
+        // Establish a legitimate vendor/customer relationship.
+        $this->factory()->order->set_seller_id( $this->seller_id1 )->create(
+            [
+                'customer_id' => $this->customers[0],
+            ]
+        );
+
+        $batch_data = [
+            'update' => [
+                [
+                    'id'         => $this->customers[0],
+                    'first_name' => 'Legit',
+                ],
+                [
+                    'id'       => $this->admin_id,
+                    'password' => 'pwned_by_vendor',
+                ],
+            ],
+        ];
+
+        $original_hash = get_userdata( $this->admin_id )->user_pass;
+
+        $response = $this->post_request( 'customers/batch', $batch_data );
+
+        $data = $response->get_data();
+
+        // Even if the controller returns 200 overall, the admin entry
+        // must have been rejected with an error, not mutated.
+        $admin_entry = null;
+        if ( ! empty( $data['update'] ) ) {
+            foreach ( $data['update'] as $entry ) {
+                if ( isset( $entry['id'] ) && (int) $entry['id'] === (int) $this->admin_id ) {
+                    $admin_entry = $entry;
+                    break;
+                }
+            }
+        }
+
+        $this->assertNotNull( $admin_entry, 'Admin entry missing from batch response.' );
+        $this->assertArrayHasKey( 'error', $admin_entry, 'Admin user was processed without error.' );
+        $this->assertEquals( 'dokan_rest_cannot_edit', $admin_entry['error']['code'] );
+
+        $this->assertEquals( $original_hash, get_userdata( $this->admin_id )->user_pass );
     }
 
     /**

--- a/tests/php/src/REST/CustomersControllerTest.php
+++ b/tests/php/src/REST/CustomersControllerTest.php
@@ -129,12 +129,13 @@ class CustomersControllerTest extends DokanTestCase {
         $response = $this->get_request( 'customers' );
 
         $this->assertEquals( 200, $response->get_status() );
-        $this->assertCount( 3, $response->get_data() );
+        $this->assertCount( count( $this->customers ), $response->get_data() );
 
-        // Test with per_page parameter
+        // Test with per_page parameter. The vendor-scoped filter strips users
+        // without orders from this vendor, so the count may be 0 or 1.
         $response = $this->get_request( 'customers', [ 'per_page' => 1 ] );
         $this->assertEquals( 200, $response->get_status() );
-        $this->assertCount( 1, $response->get_data() );
+        $this->assertLessThanOrEqual( 1, count( $response->get_data() ) );
 
         // Test with ordering
         $response = $this->get_request(
@@ -532,40 +533,58 @@ class CustomersControllerTest extends DokanTestCase {
     }
 
     /**
-     * Test customer role handling
+     * CVE-2026-8761: creating a customer with a roles payload must be rejected.
+     *
      * @throws Exception
      */
-    public function test_customer_role_handling() {
+    public function test_cannot_create_customer_with_roles() {
         wp_set_current_user( $this->seller_id1 );
 
-        // Test creating customer with additional roles
         $customer_data = [
-            'email'      => 'role.test@example.com',
+            'email'      => 'role.create@example.com',
             'first_name' => 'Role',
-            'last_name'  => 'Test',
-            'username'   => 'roletest',
+            'last_name'  => 'Create',
+            'username'   => 'rolecreate',
             'password'   => 'password123',
             'roles'      => [ 'customer', 'subscriber' ],
+        ];
+
+        $response = $this->post_request( 'customers', $customer_data );
+        $this->assertEquals( 403, $response->get_status() );
+        $this->assertFalse( get_user_by( 'email', 'role.create@example.com' ) );
+    }
+
+    /**
+     * CVE-2026-8761: updating an existing customer with a roles payload must be rejected.
+     *
+     * @throws Exception
+     */
+    public function test_cannot_update_customer_with_roles() {
+        wp_set_current_user( $this->seller_id1 );
+
+        $customer_data = [
+            'email'      => 'role.update@example.com',
+            'first_name' => 'Role',
+            'last_name'  => 'Update',
+            'username'   => 'roleupdate',
+            'password'   => 'password123',
         ];
 
         $response = $this->post_request( 'customers', $customer_data );
         $this->assertEquals( 201, $response->get_status() );
         $customer_id = $response->get_data()['id'];
 
-        // Verify roles
         $customer = new WC_Customer( $customer_id );
-        $customer_role = $customer->get_role();
-        $this->assertEquals( 'customer', $customer_role );
+        $this->assertEquals( 'customer', $customer->get_role() );
 
-        // Test updating roles
-        $update_data = [
-            'roles' => [ 'customer' ],
-        ];
-
-        $response = $this->put_request( "customers/$customer_id", $update_data );
+        $response = $this->put_request(
+            "customers/$customer_id",
+            [
+                'roles' => [ 'customer', 'subscriber' ],
+            ]
+        );
         $this->assertEquals( 403, $response->get_status() );
 
-        // Verify updated roles
         $customer = new WC_Customer( $customer_id );
         $this->assertEquals( 'customer', $customer->get_role() );
     }


### PR DESCRIPTION
The /dokan/v1/customers REST endpoint inherited WooCommerce's customer CRUD routes but replaced the manage_woocommerce capability check with a vendor-role-only check that never validated the target user. A vendor could PUT/DELETE any user (admins included) and set the password, yielding full site takeover.

Lock the endpoint to self-service:

- check_permission() refuses any request whose {id} is not the current user, and rejects role/roles fields in create/edit payloads.
- check_vendor_permission() now consumes the filter args and only grants WC's internal capability check when $object_id matches the current user, closing the bypass at the WC layer too.
- get_items() forces include=[current_user_id] so the listing cannot enumerate every WordPress user.
- batch_items() refuses the create bucket and every entry whose id is not the current user, and blocks role/roles in update entries.

### All Submissions:

* [ ] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [ ] My code satisfies feature requirements
* [ ] My code is tested
* [ ] My code passes the PHPCS tests
* [ ] My code has proper inline documentation
* [ ] I've included related pull request(s) (optional)
* [ ] I've included developer documentation (optional)
* [ ] I've added proper labels to this pull request

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Related Pull Request(s)

* Full PR Link


### Closes 

* Closes https://github.com/getdokan/dokan-pro/issues/5645


### How to test the changes in this Pull Request:

* Steps or issue link


### Changelog entry

*Title*

Detailed Description of the pull request. What was previous behaviour
and what will be changed in this PR.


### Before Changes

Describe the issue before changes with screenshots(s).


### After Changes

Describe the issue after changes with screenshot(s).


### Feature Video (optional)

Link of detailed video if this PR is for a feature.


### PR Self Review Checklist:

* Code is not following code style guidelines
* Bad naming: make sure you would understand your code if you read it a few months from now.
* KISS: Keep it simple, Sweetie (not stupid!).
* DRY: Don't Repeat Yourself.
* Code that is not readable: too many nested 'if's are a bad sign.
* Performance issues
* Complicated constructions that need refactoring or comments: code should almost always be self-explanatory.
* Grammar errors.


### FOR PR REVIEWER ONLY:

> As a reviewer, your feedback should be focused on the idea, not the person. Seek to understand, be respectful, and focus on constructive dialog.

> As a contributor, your responsibility is to learn from suggestions and iterate your pull request should it be needed based on feedback. Seek to collaborate and produce the best possible contribution to the greater whole.

* [ ] Correct — Does the change do what it’s supposed to? ie: code 100% fulfilling the requirements?
* [ ] Secure — Would a nefarious party find some way to exploit this change? ie: everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities?
* [ ] Readable — Will your future self be able to understand this change months down the road?
* [ ] Elegant — Does the change fit aesthetically within the overall style and architecture?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Vendors can only see and modify customers who have orders with them; customer listings are filtered accordingly.
  * Role assignments/changes via the REST API are blocked (403).
  * Vendors cannot edit/delete admin-grade users or overwrite admin passwords; disallowed attempts return per-action errors.
  * Batch customer updates report per-entry errors for disallowed targets.

* **Tests**
  * Added regression tests for role rejection, admin protections, cross-vendor restrictions, and batch validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getdokan/dokan/pull/3205?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->