### PR TITLE
fix(settings): inject SettingsRegistry into SettingsAccessor DI binding

### DIFF
--- a/includes/DependencyManagement/Providers/AdminSettingsServiceProvider.php
+++ b/includes/DependencyManagement/Providers/AdminSettingsServiceProvider.php
@@ -35,7 +35,15 @@ class AdminSettingsServiceProvider extends BaseServiceProvider {
      */
 	public function register(): void {
         foreach ( $this->services as $service ) {
-            $definition = $this->share_with_implements_tags( $service );
+            if ( SettingsAccessor::class === $service ) {
+                // SettingsAccessor requires SettingsRegistry; League's
+                // reflection-based auto-resolve cannot satisfy a non-nullable
+                // typed parameter without an explicit binding, so the
+                // dependency is wired here.
+                $definition = $this->share_with_implements_tags( $service )->addArgument( SettingsRegistry::class );
+            } else {
+                $definition = $this->share_with_implements_tags( $service );
+            }
             $this->add_tags( $definition, $this->tags );
         }
     }


### PR DESCRIPTION
## Summary

`dokan()->settings` fatals during plugin activation/bootstrap because `AdminSettingsServiceProvider` registers `SettingsAccessor::class` via the auto-resolve path, but `SettingsAccessor::__construct(SettingsRegistry $registry)` requires its dependency. League Container's reflection-based resolver cannot satisfy a non-nullable typed parameter without an explicit binding.

```
ArgumentCountError: Too few arguments to function
WeDevs\Dokan\Admin\Settings\SettingsAccessor::__construct(),
0 passed and exactly 1 expected
```

Previously masked because `SettingsAccessor`'s own PHPUnit tests instantiate the class manually. PR #3210 migrated `Rewrites::__construct()` to call `dokan()->settings`, which now exercises the binding during plugin bootstrap and surfaces the fatal at install/activation time.

## Fix

Special-case `SettingsAccessor` in the `register()` loop and supply `SettingsRegistry` via `->addArgument()`, matching the existing pattern in `AdminDashboardServiceProvider` for services with required constructor deps. Other services in this provider use `?Type = null` parameters, which is why they auto-resolved without an explicit binding.

## Test plan

- [x] `wp plugin activate woocommerce dokan-lite` succeeds in wp-env (previously fataled)
- [x] PHPUnit bootstrap completes (previously crashed during `WC_Install::install()`)
- [x] All existing settings-related tests continue to run

## Out-of-scope follow-ups surfaced by the now-bootable test suite

These existed before this fix but were hidden by the activation crash:

1. `SettingsAccessorTest::test_has_stored_returns_false_when_registered_but_unset` — `hydrate_new_from_legacy()` always fills schema defaults for mapped keys; `is_stored()` then treats those as "stored." Semantic bug in `is_stored`, not in this DI fix.
2. `SettingsSchemaTest::test_schema_passes_validator_with_no_warnings` — schema warnings about unknown variants (`info_preview`, `danger_switch`, `wp_media_upload`).
3. `SettingsSchemaTest::test_data_clear_field_has_confirm_modal` — modal copy drift.
4. `SettingsSchemaTest::test_reverse_withdrawal_fields_have_correct_dependencies` — dependency array shape drift.

## Why this targets `refactor/settings-accessor-api`, not `develop`

The settings-accessor migration is a multi-PR series staged on the `refactor/settings-accessor-api` integration branch. Sub-PRs land there, then the whole series merges to `develop` once complete (per the design spec). This hotfix unblocks the next sub-PR in the series.