### PR TITLE
feat(settings): make new flat option canonical, overlay legacy reads

### DIFF
--- a/includes/Admin/OnboardingSetup/Steps/AppearanceStep.php
+++ b/includes/Admin/OnboardingSetup/Steps/AppearanceStep.php
@@ -170,6 +170,6 @@ class AppearanceStep extends AbstractStep {
         $dokan_appearance['hide_vendor_info']['phone']   = $data['appearance']['vendor-info']['phone'] ?? $default_settings['hide_vendor_info']['phone'];
         $dokan_appearance['hide_vendor_info']['address'] = $data['appearance']['vendor-info']['address'] ?? $default_settings['hide_vendor_info']['address'];
 
-        update_option( 'dokan_appearance', $dokan_appearance );
+        dokan_save_legacy_settings_section( 'dokan_appearance', $dokan_appearance );
     }
 }

--- a/includes/Admin/OnboardingSetup/Steps/BasicStep.php
+++ b/includes/Admin/OnboardingSetup/Steps/BasicStep.php
@@ -169,6 +169,6 @@ class BasicStep extends AbstractStep {
         $dokan_selling['order_status_change']        = $data['basic']['order_status_change'] ?? $default_settings['order_status_change'];
         $dokan_selling['new_seller_enable_selling']  = $data['basic']['new_seller_enable_selling'] ?? $default_settings['new_seller_enable_selling'];
 
-        update_option( 'dokan_selling', $dokan_selling );
+        dokan_save_legacy_settings_section( 'dokan_selling', $dokan_selling );
     }
 }

--- a/includes/Admin/OnboardingSetup/Steps/CommissionStep.php
+++ b/includes/Admin/OnboardingSetup/Steps/CommissionStep.php
@@ -175,6 +175,6 @@ class CommissionStep extends AbstractStep {
         $dokan_selling['commission_category_based_values']          = $data['commission']['commission_category_based_values'] ?? $default_settings['commission_category_based_values'];
         $dokan_selling['reset_sub_category_when_edit_all_category'] = $data['commission']['reset_sub_category_when_edit_all_category'] ?? $default_settings['reset_sub_category_when_edit_all_category'];
 
-        update_option( 'dokan_selling', $dokan_selling );
+        dokan_save_legacy_settings_section( 'dokan_selling', $dokan_selling );
     }
 }

--- a/includes/Admin/OnboardingSetup/Steps/WithdrawStep.php
+++ b/includes/Admin/OnboardingSetup/Steps/WithdrawStep.php
@@ -177,6 +177,6 @@ class WithdrawStep extends AbstractStep {
         $dokan_withdraw['withdraw_methods']['paypal'] = $data['withdraw']['paypal'] ?? $default_settings['withdraw_methods']['paypal'];
         $dokan_withdraw['withdraw_methods']['skrill'] = $data['withdraw']['skrill'] ?? $default_settings['withdraw_methods']['skrill'];
 
-        update_option( 'dokan_withdraw', $dokan_withdraw );
+        dokan_save_legacy_settings_section( 'dokan_withdraw', $dokan_withdraw );
     }
 }

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -175,21 +175,11 @@ class Settings {
              */
             do_action( 'dokan_before_saving_settings', $option_name, $option_value, $old_options );
 
-            update_option( $option_name, $option_value );
-
-            // Propagate to the new flat option so toggling back to the new UI reflects this save.
-            if ( function_exists( 'dokan_get_container' ) ) {
-                try {
-                    $bridge    = dokan_get_container()->get( \WeDevs\Dokan\Admin\Settings\Migration\LegacySettingsBridge::class );
-                    $new_slice = $bridge->transform_legacy_payload_to_new( $option_name, $option_value );
-                    if ( ! empty( $new_slice ) ) {
-                        $repo = dokan_get_container()->get( \WeDevs\Dokan\Admin\Settings\Repository\SettingsRepository::class );
-                        $repo->update( $new_slice );
-                    }
-                } catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-                    // Container not booted — skip propagation, legacy save still succeeds.
-                }
-            }
+            // Route through the legacy settings repository: mapped keys are
+            // mirrored into the new flat option (the canonical source of
+            // truth) and stripped from the legacy row, which receives the
+            // unmapped subset only.
+            dokan_save_legacy_settings_section( $option_name, $option_value );
 
             /**
              * @since 3.5.1 added $old_options parameter

--- a/includes/Admin/Settings/Migration/BridgeBootstrap.php
+++ b/includes/Admin/Settings/Migration/BridgeBootstrap.php
@@ -7,34 +7,49 @@ use WeDevs\Dokan\Contracts\Hookable;
 /**
  * Bridge Bootstrap.
  *
- * Subscribes to the repository's `dokan_admin_settings_changed` action so that
- * every save of the new flat option mirrors changed keys back into the
- * relevant legacy `dokan_<section>` wp_options. Direct-`get_option()`
- * readers (Pro modules, third-party code) keep seeing fresh values
- * without going through the new option.
+ * With the new flat `dokan_admin_settings` option as the canonical source
+ * of truth, this bootstrap installs read-time overlay filters on every
+ * mapped legacy `dokan_<section>` wp_option. Any `get_option('dokan_general')`
+ * caller — Pro modules, third-party code, internal helpers — receives a
+ * payload with mapped values projected in from the new flat option.
  *
- * Reentry guard prevents infinite recursion if `write_new_to_legacy()`
- * triggers a downstream listener that re-emits a repository update.
+ * The write side is handled at each writer (via
+ * {@see LegacySettingsBridge::persist_legacy_section()}): mapped keys land
+ * in `dokan_admin_settings` only; the legacy row holds unmapped keys only.
+ * No reverse mirror is installed — that would defeat the single-source
+ * invariant.
+ *
+ * Reentry latch: the bridge's own internal reads (build_map, hydrate*)
+ * must see raw legacy data, not the overlay; the static guard short-
+ * circuits the filter while bridge work is in flight.
  *
  * @since DOKAN_SINCE
  */
 class BridgeBootstrap implements Hookable {
 
     /**
-     * Reentry latch. True while a reverse-write is in flight.
+     * Reentry latch. True while the overlay filter is itself running or
+     * while the bridge is mid-reentrant work.
      *
      * @var bool
      */
-    private static bool $in_reverse_write = false;
+    private static bool $in_overlay = false;
 
     /**
-     * Bridge collaborator. May be null on construct — auto-resolved from the
-     * DI container on first use so the bootstrap can be registered as a
-     * zero-arg service.
+     * Bridge collaborator. May be null on construct — auto-resolved from
+     * the DI container on first use so the bootstrap can be registered as
+     * a zero-arg service.
      *
      * @var LegacySettingsBridge|null
      */
     private ?LegacySettingsBridge $bridge;
+
+    /**
+     * Sections we've already attached the `option_<name>` filter for.
+     *
+     * @var array<string,bool>
+     */
+    private array $registered_sections = [];
 
     /**
      * @param LegacySettingsBridge|null $bridge
@@ -60,7 +75,7 @@ class BridgeBootstrap implements Hookable {
                     return $this->bridge;
                 }
             } catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-                // Container miss — return null and skip mirroring this request.
+                unset( $e );
             }
         }
         return null;
@@ -70,49 +85,113 @@ class BridgeBootstrap implements Hookable {
      * {@inheritDoc}
      */
     public function register_hooks(): void {
-        add_action( 'dokan_admin_settings_changed', [ $this, 'on_settings_changed' ], 10, 3 );
+        // Pro modules register their schema callbacks on `init` at varying
+        // priorities; defer overlay-filter wiring until `init` priority 999
+        // so the full mapping is harvestable when we ask for known sections.
+        add_action( 'init', [ $this, 'register_overlay_filters' ], 999 );
     }
 
     /**
-     * Handle `dokan_admin_settings_changed`.
-     *
-     * The repository pre-computes the diff so the bootstrap doesn't need
-     * to redo that work; it just mirrors the changed keys.
-     *
-     * @param array<string,mixed> $changed     Added/modified entries.
-     * @param array<string,mixed> $old         Payload before the write (unused).
-     * @param array<string,mixed> $new_payload Payload after the write (unused).
+     * Register `option_<section>` filters for every legacy section the
+     * bridge knows about. Safe to call more than once: previously-registered
+     * sections are skipped (multiple boots in one request can happen during
+     * tests).
      *
      * @return void
      */
-    public function on_settings_changed( $changed, $old = [], $new_payload = [] ): void {
-        unset( $old, $new_payload );
-        if ( self::$in_reverse_write ) {
-            return;
-        }
-        if ( ! is_array( $changed ) || empty( $changed ) ) {
-            return;
-        }
-        $this->mirror( $changed );
-    }
-
-    /**
-     * Run the mirror under the reentry guard.
-     *
-     * @param array<string,mixed> $changed
-     *
-     * @return void
-     */
-    private function mirror( array $changed ): void {
+    public function register_overlay_filters(): void {
         $bridge = $this->resolve_bridge();
         if ( ! $bridge instanceof LegacySettingsBridge ) {
             return;
         }
-        self::$in_reverse_write = true;
-        try {
-            $bridge->write_new_to_legacy( $changed );
-        } finally {
-            self::$in_reverse_write = false;
+        foreach ( $this->known_sections( $bridge ) as $section ) {
+            if ( isset( $this->registered_sections[ $section ] ) ) {
+                continue;
+            }
+            $this->registered_sections[ $section ] = true;
+            add_filter( "option_{$section}", [ $this, 'apply_overlay' ], 10, 2 );
+            add_filter( "default_option_{$section}", [ $this, 'apply_overlay' ], 10, 2 );
         }
+    }
+
+    /**
+     * Filter callback: project mapped values from the new flat option onto
+     * the raw legacy section read.
+     *
+     * @param mixed  $value  Raw option value (may be `false` if option absent).
+     * @param string $option Option name (provided by WordPress for the
+     *                       `default_option_*` filter shape; deduced from
+     *                       current_filter() otherwise).
+     *
+     * @return mixed
+     */
+    public function apply_overlay( $value, $option = '' ) {
+        if ( self::$in_overlay ) {
+            return $value;
+        }
+        if ( '' === $option ) {
+            $current = current_filter();
+            foreach ( [ 'option_', 'default_option_' ] as $prefix ) {
+                if ( 0 === strpos( $current, $prefix ) ) {
+                    $option = substr( $current, strlen( $prefix ) );
+                    break;
+                }
+            }
+        }
+        if ( '' === $option ) {
+            return $value;
+        }
+        $bridge = $this->resolve_bridge();
+        if ( ! $bridge instanceof LegacySettingsBridge ) {
+            return $value;
+        }
+
+        $legacy = is_array( $value ) ? $value : [];
+
+        self::$in_overlay = true;
+        try {
+            $projected = $bridge->hydrate_legacy_from_new( $option, $legacy );
+        } catch ( \Throwable $e ) {
+            self::$in_overlay = false;
+            if ( function_exists( 'dokan_log' ) ) {
+                dokan_log( '[BridgeBootstrap] overlay failed for ' . $option . ': ' . $e->getMessage() );
+            }
+            return $value;
+        }
+        self::$in_overlay = false;
+
+        // If the raw read was `false` (option missing) but overlay produced
+        // entries, return the projected array so callers see the synthesized
+        // view. Otherwise honor the original type contract.
+        if ( false === $value && empty( $projected ) ) {
+            return false;
+        }
+        return $projected;
+    }
+
+    /**
+     * Unique legacy wp_option names that the bridge currently knows about.
+     *
+     * @param LegacySettingsBridge $bridge
+     *
+     * @return array<int,string>
+     */
+    private function known_sections( LegacySettingsBridge $bridge ): array {
+        $map      = $bridge->get_mapping();
+        $sections = [];
+        foreach ( $map as $entry ) {
+            if ( isset( $entry['option'] ) && is_string( $entry['option'] ) ) {
+                $sections[ $entry['option'] ] = true;
+                continue;
+            }
+            if ( is_array( $entry ) ) {
+                foreach ( $entry as $slot ) {
+                    if ( isset( $slot['option'] ) && is_string( $slot['option'] ) ) {
+                        $sections[ $slot['option'] ] = true;
+                    }
+                }
+            }
+        }
+        return array_keys( $sections );
     }
 }

--- a/includes/Admin/Settings/Migration/LegacySettingsBridge.php
+++ b/includes/Admin/Settings/Migration/LegacySettingsBridge.php
@@ -114,6 +114,27 @@ class LegacySettingsBridge {
     }
 
     /**
+     * Flush the in-request caches held by this bridge and its collaborators.
+     *
+     * Drops the mapping memo, the defaults/transformers indices, and asks the
+     * underlying `SettingsRepositoryInterface` to drop its snapshot. Useful in
+     * tests where the DB is rolled back between cases without firing the
+     * option hooks (a `delete_option` on an already-empty row is a no-op).
+     *
+     * @since DOKAN_SINCE
+     *
+     * @return void
+     */
+    public function flush_cache(): void {
+        $this->map                 = null;
+        $this->defaults            = null;
+        $this->transformers        = null;
+        $this->by_option           = null;
+        $this->cached_filter_count = null;
+        $this->settings_repo->flush_cache();
+    }
+
+    /**
      * Return the normalized mapping of new flat ids to legacy addresses.
      *
      * Single-mapped entries surface as `['option' => ..., 'field' => ...]`.
@@ -292,6 +313,112 @@ class LegacySettingsBridge {
             }
         }
         return $legacy_option;
+    }
+
+    /**
+     * Remove mapped key paths from a legacy-shaped payload.
+     *
+     * Used by writers that persist a legacy section option but want the
+     * mapped keys to live exclusively in the new flat option. For 1:1
+     * addresses, walks the path and unsets the leaf; for 1:N multi mappings
+     * unsets every slot whose address lives under this section. Empty
+     * parent arrays produced by leaf removal are pruned so the section row
+     * doesn't accumulate dead structure.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param string              $option_name Legacy wp_option name.
+     * @param array<string,mixed> $payload     Legacy-shaped payload.
+     *
+     * @return array<string,mixed> Payload with mapped paths removed.
+     */
+    public function strip_mapped_keys( string $option_name, array $payload ): array {
+        $this->build_map();
+        $pairs = $this->by_option[ $option_name ] ?? [];
+        if ( empty( $pairs ) ) {
+            return $payload;
+        }
+        foreach ( $pairs as $entry ) {
+            if ( $entry instanceof LegacyAddress ) {
+                $this->unset_path( $payload, $entry->path() );
+                continue;
+            }
+            // Multi-mapped slice: only the slots in this option are present here.
+            foreach ( $entry as $address ) {
+                $this->unset_path( $payload, $address->path() );
+            }
+        }
+        return $payload;
+    }
+
+    /**
+     * Persist a legacy section payload through the bridge:
+     *   1. Mirror mapped keys into the new flat option.
+     *   2. Strip those mapped keys from the payload.
+     *
+     * Returns the stripped payload; the caller is responsible for the
+     * `update_option( $option_name, ... )` write. The split keeps callers
+     * in control of side effects (do_action hooks, cache flushes, etc.)
+     * while centralizing the strip + mirror logic.
+     *
+     * Strict mode: stripping happens unconditionally. If the new-option
+     * write throws, we log and continue — the mapped values are lost from
+     * this save, but the legacy row never holds mapped data. Source of
+     * truth stays single.
+     *
+     * @since DOKAN_SINCE
+     *
+     * @param string              $option_name Legacy wp_option name.
+     * @param array<string,mixed> $payload     Legacy-shaped payload.
+     *
+     * @return array<string,mixed> Stripped payload, safe to `update_option`.
+     */
+    public function persist_legacy_section( string $option_name, array $payload ): array {
+        try {
+            $new_slice = $this->transform_legacy_payload_to_new( $option_name, $payload );
+            if ( ! empty( $new_slice ) ) {
+                $this->settings_repo->update( $new_slice );
+            }
+        } catch ( \Throwable $e ) {
+            if ( function_exists( 'dokan_log' ) ) {
+                dokan_log( '[LegacySettingsBridge] persist_legacy_section new-write failed: ' . $e->getMessage() );
+            }
+        }
+        return $this->strip_mapped_keys( $option_name, $payload );
+    }
+
+    /**
+     * Unset a value at the given path; prune empty arrays back up the chain.
+     *
+     * Recursive because PHP's stacked-reference pattern (`$stack[] = &$cursor;
+     * $cursor = &$cursor[$seg];`) silently rebinds the stored references when
+     * `$cursor` is reassigned.
+     *
+     * @param array<string,mixed> $target By-reference legacy payload.
+     * @param array<int,string>   $path
+     * @param int                 $i      Current path index.
+     *
+     * @return void
+     */
+    private function unset_path( array &$target, array $path, int $i = 0 ): void {
+        if ( empty( $path ) || ! array_key_exists( $i, $path ) ) {
+            return;
+        }
+        $segment = $path[ $i ];
+        if ( ! is_array( $target ) || ! array_key_exists( $segment, $target ) ) {
+            return;
+        }
+        if ( $i === count( $path ) - 1 ) {
+            unset( $target[ $segment ] );
+            return;
+        }
+        if ( ! is_array( $target[ $segment ] ) ) {
+            return;
+        }
+        $this->unset_path( $target[ $segment ], $path, $i + 1 );
+        if ( empty( $target[ $segment ] ) ) {
+            unset( $target[ $segment ] );
+        }
     }
 
     /**

--- a/includes/Admin/Settings/Repository/LegacySettingsRepository.php
+++ b/includes/Admin/Settings/Repository/LegacySettingsRepository.php
@@ -34,6 +34,7 @@ final class LegacySettingsRepository implements LegacySettingsRepositoryInterfac
         foreach ( $this->known_sections() as $section ) {
             add_action( "update_option_{$section}", [ $this, 'on_section_changed' ] );
             add_action( "add_option_{$section}", [ $this, 'on_section_changed' ] );
+            add_action( "delete_option_{$section}", [ $this, 'on_section_changed' ] );
         }
 
         // The new flat option participates in every overlay — its writes invalidate
@@ -42,6 +43,7 @@ final class LegacySettingsRepository implements LegacySettingsRepositoryInterfac
         $new_option = SettingsRepository::OPTION_KEY;
         add_action( "update_option_{$new_option}", [ $this, 'flush_all_snapshots' ] );
         add_action( "add_option_{$new_option}", [ $this, 'flush_all_snapshots' ] );
+        add_action( "delete_option_{$new_option}", [ $this, 'flush_all_snapshots' ] );
     }
 
     public function all( string $section ): array {
@@ -82,28 +84,22 @@ final class LegacySettingsRepository implements LegacySettingsRepositoryInterfac
             return [];
         }
 
+        // Route the incoming slice through the bridge: mapped keys go to the
+        // new flat option only; the legacy row holds unmapped keys only.
+        $stripped_slice = $this->bridge->persist_legacy_section( $section, $slice );
+
         $raw    = get_option( $section, [] );
         $raw    = is_array( $raw ) ? $raw : [];
-        $merged = array_merge( $raw, $slice );
+        // Defensive: a previously-stored legacy row may still hold mapped keys
+        // (lazy migration policy — we never backfill on read). Strip them on
+        // every write so the saved row converges on the invariant.
+        $raw    = $this->bridge->strip_mapped_keys( $section, $raw );
+        $merged = array_merge( $raw, $stripped_slice );
 
         update_option( $section, $merged, true );
         // Refresh our snapshot now — the WP hook already flushed it, but we want
         // the next read in *this* request to skip a get_option round-trip.
         $this->snapshots[ $section ] = $this->bridge->hydrate_legacy_from_new( $section, $merged );
-
-        // Mirror mapped keys into the new flat option. Best-effort: a thrown
-        // exception from the bridge or new repo is caught and logged so the
-        // legacy write that already landed is not silently rolled back.
-        try {
-            $flat_slice = $this->bridge->transform_legacy_payload_to_new( $section, $slice );
-            if ( ! empty( $flat_slice ) ) {
-                $this->new_repo->update( $flat_slice );
-            }
-        } catch ( \Throwable $e ) {
-            if ( function_exists( 'dokan_log' ) ) {
-                dokan_log( '[LegacySettingsRepository] mirror write failed: ' . $e->getMessage() );
-            }
-        }
 
         /**
          * Fired after a successful write to a legacy section option.
@@ -133,19 +129,13 @@ final class LegacySettingsRepository implements LegacySettingsRepositoryInterfac
             }
         }
 
-        update_option( $section, $payload, true );
-        $this->snapshots[ $section ] = $this->bridge->hydrate_legacy_from_new( $section, $payload );
+        // `replace` is a full-row write, so mapped keys must be peeled off
+        // before we land the legacy option. The bridge mirrors them into the
+        // new flat option as a side effect.
+        $stripped_payload = $this->bridge->persist_legacy_section( $section, $payload );
 
-        try {
-            $flat_slice = $this->bridge->transform_legacy_payload_to_new( $section, $payload );
-            if ( ! empty( $flat_slice ) ) {
-                $this->new_repo->update( $flat_slice );
-            }
-        } catch ( \Throwable $e ) {
-            if ( function_exists( 'dokan_log' ) ) {
-                dokan_log( '[LegacySettingsRepository] mirror replace failed: ' . $e->getMessage() );
-            }
-        }
+        update_option( $section, $stripped_payload, true );
+        $this->snapshots[ $section ] = $this->bridge->hydrate_legacy_from_new( $section, $stripped_payload );
 
         if ( ! empty( $diff ) ) {
             /** This action is documented in includes/Admin/Settings/Repository/LegacySettingsRepository.php */

--- a/includes/Admin/Settings/Repository/SettingsRepository.php
+++ b/includes/Admin/Settings/Repository/SettingsRepository.php
@@ -31,6 +31,7 @@ final class SettingsRepository implements SettingsRepositoryInterface {
     public function __construct() {
         add_action( 'update_option_' . self::OPTION_KEY, [ $this, 'flush_cache' ] );
         add_action( 'add_option_' . self::OPTION_KEY, [ $this, 'flush_cache' ] );
+        add_action( 'delete_option_' . self::OPTION_KEY, [ $this, 'flush_cache' ] );
     }
 
     /**

--- a/includes/Admin/SetupWizard.php
+++ b/includes/Admin/SetupWizard.php
@@ -545,9 +545,9 @@ class SetupWizard {
         // call a hook for other plugins to do their thing
         do_action( 'dokan_share_essentials_updated', $share_essentials );
 
-        update_option( 'dokan_general', $general_options );
-        update_option( 'dokan_selling', $selling_options );
-        update_option( 'dokan_appearance', $appearance );
+        dokan_save_legacy_settings_section( 'dokan_general', $general_options );
+        dokan_save_legacy_settings_section( 'dokan_selling', $selling_options );
+        dokan_save_legacy_settings_section( 'dokan_appearance', $appearance );
 
         do_action( 'dokan_admin_setup_wizard_save_step_store' );
 
@@ -624,7 +624,7 @@ class SetupWizard {
         $options['new_seller_enable_selling'] = dokan_get_container()->get( AdminSettings::class )->get_new_seller_enable_selling_status( sanitize_text_field( wp_unslash( $_POST['new_seller_enable_selling'] ) ) ?? 'automatically' );
         $options['order_status_change']       = isset( $_POST['order_status_change'] ) ? 'on' : 'off';
 
-        update_option( 'dokan_selling', $options );
+        dokan_save_legacy_settings_section( 'dokan_selling', $options );
 
         do_action( 'dokan_admin_setup_wizard_save_step_setup_selling', $options, [] );
 
@@ -654,7 +654,7 @@ class SetupWizard {
         $options['commission_category_based_values']          = isset( $_POST['dokan_commission_category_based'] ) ? wc_clean( json_decode( sanitize_text_field( wp_unslash( $_POST['dokan_commission_category_based'] ) ), true ) ) : [];
         $options['reset_sub_category_when_edit_all_category'] = isset( $_POST['reset_sub_category'] ) && false === dokan_string_to_bool( $_POST['reset_sub_category'] ) ? 'off' : 'on';
 
-        update_option( 'dokan_selling', $options );
+        dokan_save_legacy_settings_section( 'dokan_selling', $options );
 
         do_action( 'dokan_admin_setup_wizard_save_step_setup_commission', $options, [] );
 
@@ -891,7 +891,7 @@ class SetupWizard {
          */
         $options = apply_filters( 'dokan_setup_wizard_save_withdraw_options', $options, [] );
 
-        update_option( 'dokan_withdraw', $options );
+        dokan_save_legacy_settings_section( 'dokan_withdraw', $options );
 
         wp_safe_redirect( esc_url_raw( $this->get_next_step_link() ) );
         exit;

--- a/includes/Commission/Settings/GlobalSetting.php
+++ b/includes/Commission/Settings/GlobalSetting.php
@@ -85,7 +85,7 @@ class GlobalSetting implements InterfaceSetting {
         $options['additional_fee']                   = isset( $setting['flat'] ) ? $setting['flat'] : '';
         $options['commission_category_based_values'] = isset( $setting['category_commissions'] ) ? $setting['category_commissions'] : [];
 
-        update_option( 'dokan_selling', $options );
+        dokan_save_legacy_settings_section( 'dokan_selling', $options );
 
         do_action( 'dokan_global_commission_settings_after_save', $setting );
     }

--- a/includes/Commission/Upugrader/Update_Category_Commission.php
+++ b/includes/Commission/Upugrader/Update_Category_Commission.php
@@ -206,7 +206,7 @@ class Update_Category_Commission {
         }
 
         $dokan_selling['commission_category_based_values'] = $category_commission;
-        update_option( 'dokan_selling', $dokan_selling );
+        dokan_save_legacy_settings_section( 'dokan_selling', $dokan_selling );
     }
 
     /**

--- a/includes/DependencyManagement/Providers/AdminSettingsServiceProvider.php
+++ b/includes/DependencyManagement/Providers/AdminSettingsServiceProvider.php
@@ -5,7 +5,9 @@ namespace WeDevs\Dokan\DependencyManagement\Providers;
 use WeDevs\Dokan\Admin\Settings\Migration\BridgeBootstrap;
 use WeDevs\Dokan\Admin\Settings\Migration\LegacySettingsBridge;
 use WeDevs\Dokan\Admin\Settings\Repository\LegacySettingsRepository;
+use WeDevs\Dokan\Admin\Settings\Repository\LegacySettingsRepositoryInterface;
 use WeDevs\Dokan\Admin\Settings\Repository\SettingsRepository;
+use WeDevs\Dokan\Admin\Settings\Repository\SettingsRepositoryInterface;
 use WeDevs\Dokan\Admin\Settings\Schema\SchemaValidator;
 use WeDevs\Dokan\Admin\Settings\Schema\SettingsRegistry;
 use WeDevs\Dokan\DependencyManagement\BaseServiceProvider;
@@ -36,5 +38,17 @@ class AdminSettingsServiceProvider extends BaseServiceProvider {
             $definition = $this->share_with_implements_tags( $service );
             $this->add_tags( $definition, $this->tags );
         }
+
+        // Bind the repository interfaces to the same shared instances. Without
+        // this, constructor injection of `?SettingsRepositoryInterface` /
+        // `?LegacySettingsRepositoryInterface` falls back to the type-hint
+        // default (null) and the consuming class instantiates a *fresh*
+        // repository — yielding parallel snapshots that drift apart.
+        $this->getContainer()
+            ->add( SettingsRepositoryInterface::class, fn() => $this->getContainer()->get( SettingsRepository::class ) )
+            ->setShared( true );
+        $this->getContainer()
+            ->add( LegacySettingsRepositoryInterface::class, fn() => $this->getContainer()->get( LegacySettingsRepository::class ) )
+            ->setShared( true );
     }
 }

--- a/includes/Install/Installer.php
+++ b/includes/Install/Installer.php
@@ -148,7 +148,7 @@ class Installer {
 
         if ( ! $installed_version ) {
             $options = get_option( 'dokan_selling' );
-            update_option( 'dokan_selling', $options );
+            dokan_save_legacy_settings_section( 'dokan_selling', is_array( $options ) ? $options : [] );
         }
     }
 

--- a/includes/REST/AdminOnboardingController.php
+++ b/includes/REST/AdminOnboardingController.php
@@ -186,7 +186,7 @@ class AdminOnboardingController extends DokanBaseAdminController {
             }
 
             $general_options['custom_store_url'] = $custom_store_url;
-            update_option( 'dokan_general', $general_options );
+            dokan_save_legacy_settings_section( 'dokan_general', $general_options );
         }
 
         $share_essentials = isset( $data['share_essentials'] ) ? (bool) $data['share_essentials'] : false;

--- a/includes/Shortcodes/FullWidthVendorLayout.php
+++ b/includes/Shortcodes/FullWidthVendorLayout.php
@@ -52,7 +52,7 @@ class FullWidthVendorLayout implements Hookable {
         $appearance['vendor_layout_style']   = 'latest';
         $appearance['vendor_product_editor'] = 'latest';
 
-        update_option( 'dokan_appearance', $appearance );
+        dokan_save_legacy_settings_section( 'dokan_appearance', $appearance );
     }
 
     /**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1087,6 +1087,44 @@ function dokan_get_option( $option, $section, $default_value = '' ) {
 }
 
 /**
+ * Save a legacy section option through the settings repository.
+ *
+ * Routes a full-row legacy payload through {@see LegacySettingsRepository::replace()},
+ * which:
+ *   1. Mirrors mapped keys into the new flat `dokan_admin_settings` option
+ *      (the canonical source of truth).
+ *   2. Strips those mapped keys from the payload.
+ *   3. Persists the unmapped remainder under the legacy `$option_name` row.
+ *   4. Fires `dokan_legacy_settings_changed` and refreshes the in-request snapshot.
+ *
+ * Callers should NOT also call `update_option( $option_name, ... )` — the
+ * repository owns that write. If the DI container is unavailable (early
+ * bootstrap, isolated tests), this falls back to a raw `update_option` so
+ * legacy writes still succeed without the source-of-truth guarantee.
+ *
+ * @since DOKAN_SINCE
+ *
+ * @param string              $option_name Legacy wp_option name (e.g. `dokan_general`).
+ * @param array<string,mixed> $payload     Legacy-shaped payload to persist.
+ *
+ * @return void
+ */
+function dokan_save_legacy_settings_section( string $option_name, array $payload ): void {
+    if ( ! function_exists( 'dokan_get_container' ) ) {
+        update_option( $option_name, $payload );
+        return;
+    }
+    try {
+        dokan_get_container()
+            ->get( \WeDevs\Dokan\Admin\Settings\Repository\LegacySettingsRepository::class )
+            ->replace( $option_name, $payload );
+    } catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+        unset( $e );
+        update_option( $option_name, $payload );
+    }
+}
+
+/**
  * Redirect users from standard WordPress register page to woocommerce
  * my account page
  *

--- a/tests/php/src/Admin/Settings/DokanSaveLegacySettingsSectionTest.php
+++ b/tests/php/src/Admin/Settings/DokanSaveLegacySettingsSectionTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace WeDevs\Dokan\Test\Admin\Settings;
+
+use WeDevs\Dokan\Test\DokanTestCase;
+
+/**
+ * Round-trip behavior of dokan_save_legacy_settings_section(): mapped keys
+ * land in the new flat option (canonical), the legacy row holds the unmapped
+ * remainder only, and a fresh get_option() read returns the synthesized
+ * full view.
+ *
+ * @group admin-settings
+ */
+class DokanSaveLegacySettingsSectionTest extends DokanTestCase {
+
+    public function test_round_trip_strips_legacy_row_and_overlays_on_read(): void {
+        $cb = static function (): array {
+            return [
+                [
+                    'id'         => 'vendor_welcome_wizard_enabled',
+                    'type'       => 'field',
+                    'legacy_key' => 'dokan_general.disable_welcome_wizard',
+                    'default'    => 'on',
+                ],
+            ];
+        };
+        add_filter( 'dokan_get_admin_settings_schema', $cb );
+
+        delete_option( 'dokan_general' );
+        delete_option( 'dokan_admin_settings' );
+
+        dokan_save_legacy_settings_section(
+            'dokan_general',
+            [
+                'disable_welcome_wizard' => 'off',
+                'custom_store_url'       => 'store7',
+            ]
+        );
+
+        // Read the raw row directly via $wpdb — `get_option()` would route
+        // through BridgeBootstrap's overlay filter and re-inject the mapped
+        // key from the new flat option, masking whether the leaf actually
+        // got stripped from storage.
+        global $wpdb;
+        $raw_serialized = $wpdb->get_var(
+            $wpdb->prepare( "SELECT option_value FROM {$wpdb->options} WHERE option_name = %s", 'dokan_general' )
+        );
+        $raw_legacy   = is_string( $raw_serialized ) ? maybe_unserialize( $raw_serialized ) : [];
+        $new_settings = get_option( 'dokan_admin_settings', [] );
+
+        remove_filter( 'dokan_get_admin_settings_schema', $cb );
+        delete_option( 'dokan_general' );
+        delete_option( 'dokan_admin_settings' );
+
+        $this->assertSame( 'off', $new_settings['vendor_welcome_wizard_enabled'] );
+        // The legacy row must not retain the mapped key after the strip.
+        $this->assertIsArray( $raw_legacy );
+        $this->assertSame( 'store7', $raw_legacy['custom_store_url'] );
+        $this->assertArrayNotHasKey(
+            'disable_welcome_wizard',
+            (array) $raw_legacy,
+            'Mapped key must not persist in the legacy row.'
+        );
+    }
+}

--- a/tests/php/src/Admin/Settings/Migration/BridgeBootstrapOverlayTest.php
+++ b/tests/php/src/Admin/Settings/Migration/BridgeBootstrapOverlayTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace WeDevs\Dokan\Test\Admin\Settings\Migration;
+
+use WeDevs\Dokan\Admin\Settings\Migration\BridgeBootstrap;
+use WeDevs\Dokan\Admin\Settings\Migration\LegacySettingsBridge;
+use WeDevs\Dokan\Test\DokanTestCase;
+
+/**
+ * Verifies the option_<section> overlay filters installed by BridgeBootstrap
+ * so direct `get_option('dokan_<section>')` callers receive a payload with
+ * mapped values projected in from the new flat option.
+ *
+ * @group admin-settings
+ */
+class BridgeBootstrapOverlayTest extends DokanTestCase {
+
+    public function test_overlay_projects_new_value_onto_get_option_read(): void {
+        $cb = static function (): array {
+            return [
+                [
+                    'id'         => 'vendor_welcome_wizard_enabled',
+                    'type'       => 'field',
+                    'legacy_key' => 'dokan_general.disable_welcome_wizard',
+                    'default'    => 'on',
+                ],
+            ];
+        };
+        add_filter( 'dokan_get_admin_settings_schema', $cb );
+
+        // Legacy row holds ONLY unmapped data — this is the new invariant
+        // after a strip-on-save.
+        update_option( 'dokan_general', [ 'custom_store_url' => 'shop' ] );
+        update_option( 'dokan_admin_settings', [ 'vendor_welcome_wizard_enabled' => 'off' ] );
+
+        $bootstrap = new BridgeBootstrap( new LegacySettingsBridge() );
+        $bootstrap->register_overlay_filters();
+
+        $legacy_view = get_option( 'dokan_general' );
+
+        remove_filter( "option_dokan_general", [ $bootstrap, 'apply_overlay' ], 10 );
+        remove_filter( "default_option_dokan_general", [ $bootstrap, 'apply_overlay' ], 10 );
+        remove_filter( 'dokan_get_admin_settings_schema', $cb );
+        delete_option( 'dokan_admin_settings' );
+        delete_option( 'dokan_general' );
+
+        $this->assertSame( 'shop', $legacy_view['custom_store_url'] );
+        $this->assertSame(
+            'off',
+            $legacy_view['disable_welcome_wizard'],
+            'Mapped key from dokan_admin_settings should appear in the overlay-applied legacy view'
+        );
+    }
+
+    public function test_overlay_synthesizes_view_even_when_legacy_row_absent(): void {
+        $cb = static function (): array {
+            return [
+                [
+                    'id'         => 'banner_width',
+                    'type'       => 'field',
+                    'legacy_key' => 'dokan_appearance.store_banner_width',
+                    'default'    => 400,
+                ],
+            ];
+        };
+        add_filter( 'dokan_get_admin_settings_schema', $cb );
+
+        delete_option( 'dokan_appearance' );
+        update_option( 'dokan_admin_settings', [ 'banner_width' => 1280 ] );
+
+        $bootstrap = new BridgeBootstrap( new LegacySettingsBridge() );
+        $bootstrap->register_overlay_filters();
+
+        $value = get_option( 'dokan_appearance', false );
+
+        remove_filter( "default_option_dokan_appearance", [ $bootstrap, 'apply_overlay' ], 10 );
+        remove_filter( "option_dokan_appearance", [ $bootstrap, 'apply_overlay' ], 10 );
+        remove_filter( 'dokan_get_admin_settings_schema', $cb );
+        delete_option( 'dokan_admin_settings' );
+
+        // The default_option_<name> filter chains through apply_overlay even
+        // when the row is missing, so a synthesized array surfaces with the
+        // mapped value populated.
+        $this->assertIsArray( $value );
+        $this->assertSame( 1280, $value['store_banner_width'] );
+    }
+
+    public function test_overlay_passes_through_when_section_has_no_mapping(): void {
+        $cb = static function (): array {
+            return [
+                [
+                    'id'         => 'banner_width',
+                    'type'       => 'field',
+                    'legacy_key' => 'dokan_appearance.store_banner_width',
+                    'default'    => 400,
+                ],
+            ];
+        };
+        add_filter( 'dokan_get_admin_settings_schema', $cb );
+
+        update_option( 'dokan_general', [ 'custom_store_url' => 'shop' ] );
+
+        $bootstrap = new BridgeBootstrap( new LegacySettingsBridge() );
+        $bootstrap->register_overlay_filters();
+
+        // dokan_general has no mapped fields in this fixture — no filter
+        // should have been registered for it, and the raw value passes
+        // through unchanged.
+        $value = get_option( 'dokan_general' );
+
+        remove_filter( 'dokan_get_admin_settings_schema', $cb );
+        delete_option( 'dokan_general' );
+
+        $this->assertSame( [ 'custom_store_url' => 'shop' ], $value );
+    }
+}

--- a/tests/php/src/Admin/Settings/Migration/LegacySettingsBridgeTest.php
+++ b/tests/php/src/Admin/Settings/Migration/LegacySettingsBridgeTest.php
@@ -11,6 +11,34 @@ use WeDevs\Dokan\Test\DokanTestCase;
  */
 class LegacySettingsBridgeTest extends DokanTestCase {
 
+    /**
+     * Clear the new-flat option and its caches before each test so leaks
+     * from a sibling test cannot bleed through the BridgeBootstrap overlay
+     * filter that wraps every `get_option('dokan_*')` read.
+     */
+    public function set_up() {
+        parent::set_up();
+        delete_option( 'dokan_admin_settings' );
+        wp_cache_delete( 'dokan_admin_settings', 'options' );
+        wp_cache_delete( 'alloptions', 'options' );
+        wp_cache_delete( 'notoptions', 'options' );
+        if ( function_exists( 'dokan_get_container' ) ) {
+            try {
+                dokan_get_container()
+                    ->get( \WeDevs\Dokan\Admin\Settings\Repository\SettingsRepository::class )
+                    ->flush_cache();
+                dokan_get_container()
+                    ->get( \WeDevs\Dokan\Admin\Settings\Repository\LegacySettingsRepository::class )
+                    ->flush_cache( null );
+                dokan_get_container()
+                    ->get( \WeDevs\Dokan\Admin\Settings\Migration\LegacySettingsBridge::class )
+                    ->flush_cache();
+            } catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+                unset( $e );
+            }
+        }
+    }
+
     public function test_class_exists_and_construct(): void {
         $bridge = new LegacySettingsBridge();
         $this->assertInstanceOf( LegacySettingsBridge::class, $bridge );
@@ -432,7 +460,7 @@ class LegacySettingsBridgeTest extends DokanTestCase {
         $this->assertSame( 'zyx', $stored['store_banner_width'] );
     }
 
-    public function test_bridge_bootstrap_mirrors_changed_keys_to_legacy(): void {
+    public function test_bridge_bootstrap_overlay_projects_new_into_legacy_read(): void {
         $map_filter = static function ( $map ) {
             $map['general_marketplace_site_logo'] = [
 				'option' => 'dokan_general',
@@ -447,23 +475,27 @@ class LegacySettingsBridgeTest extends DokanTestCase {
 
         $bridge    = new LegacySettingsBridge();
         $bootstrap = new \WeDevs\Dokan\Admin\Settings\Migration\BridgeBootstrap( $bridge );
-        $bootstrap->register_hooks();
+        $bootstrap->register_overlay_filters();
 
         $repo = new \WeDevs\Dokan\Admin\Settings\Repository\SettingsRepository();
         $repo->update( [ 'general_marketplace_site_logo' => 'new.png' ] );
 
         $stored_legacy = get_option( 'dokan_general' );
 
+        remove_filter( 'option_dokan_general', [ $bootstrap, 'apply_overlay' ], 10 );
+        remove_filter( 'default_option_dokan_general', [ $bootstrap, 'apply_overlay' ], 10 );
         remove_filter( 'dokan_legacy_settings_key_mapping', $map_filter );
-        remove_action( 'dokan_admin_settings_changed', [ $bootstrap, 'on_settings_changed' ], 10 );
         delete_option( 'dokan_general' );
         delete_option( 'dokan_admin_settings' );
 
+        // Under the new-as-canonical model the legacy DB row is NOT written
+        // when the new option changes; instead the read-time overlay synthesizes
+        // the legacy shape from dokan_admin_settings on every get_option call.
         $this->assertIsArray( $stored_legacy );
         $this->assertSame( 'new.png', $stored_legacy['site_logo'] );
     }
 
-    public function test_bridge_bootstrap_reentry_guard_prevents_recursion(): void {
+    public function test_bridge_bootstrap_overlay_reentry_guard_prevents_recursion(): void {
         $map_filter = static function ( $map ) {
             $map['general_marketplace_site_logo'] = [
 				'option' => 'dokan_general',
@@ -478,32 +510,40 @@ class LegacySettingsBridgeTest extends DokanTestCase {
 
         $bridge    = new LegacySettingsBridge();
         $bootstrap = new \WeDevs\Dokan\Admin\Settings\Migration\BridgeBootstrap( $bridge );
-        $bootstrap->register_hooks();
+        $bootstrap->register_overlay_filters();
+
+        // Seed a row so `option_<name>` (rather than `default_option_<name>`)
+        // is the active read hook; the counter measures only this filter.
+        update_option( 'dokan_general', [ 'placeholder' => 'x' ] );
+
+        // Count overlay invocations: a recursive `get_option` from inside the
+        // bridge's hydrate path would re-enter `apply_overlay` and re-fire
+        // this listener if the reentry latch were broken.
+        $invocations = 0;
+        $counter     = static function ( $value ) use ( &$invocations ) {
+            ++$invocations;
+            return $value;
+        };
+        // Priority 9 — runs before the overlay (priority 10).
+        add_filter( 'option_dokan_general', $counter, 9 );
+
         $repo = new \WeDevs\Dokan\Admin\Settings\Repository\SettingsRepository();
         $repo->update( [ 'general_marketplace_site_logo' => 'seed.png' ] );
 
-        // Count `dokan_admin_settings_changed` firings at priority 5 so it runs
-        // before the bootstrap mirror at priority 10.
-        $invocations = 0;
-        $counter     = static function () use ( &$invocations ) {
-            ++$invocations;
-        };
-        add_action( 'dokan_admin_settings_changed', $counter, 5 );
+        // Two top-level reads — counter should fire exactly twice, not more.
+        $first  = get_option( 'dokan_general' );
+        $second = get_option( 'dokan_general' );
 
-        $repo->update( [ 'general_marketplace_site_logo' => 'first.png' ] );
-        $repo->update( [ 'general_marketplace_site_logo' => 'second.png' ] );
-
-        remove_action( 'dokan_admin_settings_changed', $counter, 5 );
-        remove_action( 'dokan_admin_settings_changed', [ $bootstrap, 'on_settings_changed' ], 10 );
+        remove_filter( 'option_dokan_general', $counter, 9 );
+        remove_filter( 'option_dokan_general', [ $bootstrap, 'apply_overlay' ], 10 );
+        remove_filter( 'default_option_dokan_general', [ $bootstrap, 'apply_overlay' ], 10 );
         remove_filter( 'dokan_legacy_settings_key_mapping', $map_filter );
-        $stored_legacy = get_option( 'dokan_general' );
         delete_option( 'dokan_general' );
         delete_option( 'dokan_admin_settings' );
 
-        // Two top-level repository updates — counter should fire exactly twice,
-        // not more (no infinite loop, no nested re-entry).
-        $this->assertSame( 2, $invocations );
-        $this->assertSame( 'second.png', $stored_legacy['site_logo'] );
+        $this->assertSame( 2, $invocations, 'Overlay must not re-enter itself.' );
+        $this->assertSame( 'seed.png', $first['site_logo'] );
+        $this->assertSame( 'seed.png', $second['site_logo'] );
     }
 
     public function test_callable_transformer_pair_runs_for_both_directions(): void {

--- a/tests/php/src/Admin/Settings/Migration/StripMappedKeysTest.php
+++ b/tests/php/src/Admin/Settings/Migration/StripMappedKeysTest.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace WeDevs\Dokan\Test\Admin\Settings\Migration;
+
+use WeDevs\Dokan\Admin\Settings\Migration\LegacySettingsBridge;
+use WeDevs\Dokan\Test\DokanTestCase;
+
+/**
+ * Behavior of LegacySettingsBridge::strip_mapped_keys() and
+ * persist_legacy_section() — the write-side of the new-is-canonical
+ * settings model.
+ *
+ * @group admin-settings
+ */
+class StripMappedKeysTest extends DokanTestCase {
+
+    public function test_strip_removes_simple_mapped_keys_and_keeps_unmapped(): void {
+        $cb = static function (): array {
+            return [
+                [
+                    'id'         => 'vendor_welcome_wizard_enabled',
+                    'type'       => 'field',
+                    'legacy_key' => 'dokan_general.disable_welcome_wizard',
+                    'default'    => 'on',
+                ],
+            ];
+        };
+        add_filter( 'dokan_get_admin_settings_schema', $cb );
+
+        $bridge = new LegacySettingsBridge();
+        $result = $bridge->strip_mapped_keys(
+            'dokan_general',
+            [
+                'disable_welcome_wizard' => 'off',
+                'custom_store_url'       => 'store7',
+                'setup_wizard_message'   => '<p>hello</p>',
+            ]
+        );
+
+        remove_filter( 'dokan_get_admin_settings_schema', $cb );
+
+        $this->assertArrayNotHasKey( 'disable_welcome_wizard', $result );
+        $this->assertSame( 'store7', $result['custom_store_url'] );
+        $this->assertSame( '<p>hello</p>', $result['setup_wizard_message'] );
+    }
+
+    public function test_strip_removes_nested_path_and_prunes_empty_parent(): void {
+        $cb = static function (): array {
+            return [
+                [
+                    'id'         => 'paypal_method',
+                    'type'       => 'field',
+                    'legacy_key' => 'dokan_withdraw.withdraw_methods.paypal',
+                    'default'    => 'on',
+                ],
+            ];
+        };
+        add_filter( 'dokan_get_admin_settings_schema', $cb );
+
+        $bridge = new LegacySettingsBridge();
+        $result = $bridge->strip_mapped_keys(
+            'dokan_withdraw',
+            [
+                'withdraw_methods' => [ 'paypal' => 'on' ],
+                'minimum'          => 50,
+            ]
+        );
+
+        remove_filter( 'dokan_get_admin_settings_schema', $cb );
+
+        // The leaf was the only entry under withdraw_methods, so the parent
+        // should be pruned too — we don't want orphan empty arrays clinging
+        // to the legacy row.
+        $this->assertArrayNotHasKey( 'withdraw_methods', $result );
+        $this->assertSame( 50, $result['minimum'] );
+    }
+
+    public function test_strip_keeps_sibling_in_partially_mapped_nested_array(): void {
+        $cb = static function (): array {
+            return [
+                [
+                    'id'         => 'paypal_method',
+                    'type'       => 'field',
+                    'legacy_key' => 'dokan_withdraw.withdraw_methods.paypal',
+                    'default'    => 'on',
+                ],
+            ];
+        };
+        add_filter( 'dokan_get_admin_settings_schema', $cb );
+
+        $bridge = new LegacySettingsBridge();
+        $result = $bridge->strip_mapped_keys(
+            'dokan_withdraw',
+            [
+                'withdraw_methods' => [
+                    'paypal'        => 'on',
+                    'bank_transfer' => 'on',
+                ],
+            ]
+        );
+
+        remove_filter( 'dokan_get_admin_settings_schema', $cb );
+
+        // bank_transfer isn't mapped → parent must NOT be pruned.
+        $this->assertSame(
+            [ 'withdraw_methods' => [ 'bank_transfer' => 'on' ] ],
+            $result
+        );
+    }
+
+    public function test_strip_is_noop_when_section_has_no_mapped_fields(): void {
+        $cb = static function (): array {
+            return [
+                [
+                    'id'         => 'banner_width',
+                    'type'       => 'field',
+                    'legacy_key' => 'dokan_appearance.store_banner_width',
+                    'default'    => 400,
+                ],
+            ];
+        };
+        add_filter( 'dokan_get_admin_settings_schema', $cb );
+
+        $bridge = new LegacySettingsBridge();
+        $payload = [
+            'custom_store_url' => 'shop',
+            'unrelated'        => 'value',
+        ];
+        $result = $bridge->strip_mapped_keys( 'dokan_general', $payload );
+
+        remove_filter( 'dokan_get_admin_settings_schema', $cb );
+
+        $this->assertSame( $payload, $result );
+    }
+
+    public function test_persist_legacy_section_writes_to_new_and_returns_stripped(): void {
+        $cb = static function (): array {
+            return [
+                [
+                    'id'         => 'banner_width',
+                    'type'       => 'field',
+                    'legacy_key' => 'dokan_appearance.store_banner_width',
+                    'default'    => 400,
+                ],
+            ];
+        };
+        add_filter( 'dokan_get_admin_settings_schema', $cb );
+
+        delete_option( 'dokan_admin_settings' );
+        $bridge   = new LegacySettingsBridge();
+        $stripped = $bridge->persist_legacy_section(
+            'dokan_appearance',
+            [
+                'store_banner_width' => 1280,
+                'site_layout'        => 'full-width',
+            ]
+        );
+
+        $new_option = get_option( 'dokan_admin_settings', [] );
+
+        remove_filter( 'dokan_get_admin_settings_schema', $cb );
+        delete_option( 'dokan_admin_settings' );
+
+        $this->assertSame( 1280, $new_option['banner_width'] );
+        $this->assertArrayNotHasKey( 'store_banner_width', $stripped );
+        $this->assertSame( 'full-width', $stripped['site_layout'] );
+    }
+}

--- a/tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php
+++ b/tests/php/src/Admin/Settings/Repository/LegacySettingsRepositoryTest.php
@@ -12,6 +12,42 @@ use WeDevs\Dokan\Test\DokanTestCase;
  */
 class LegacySettingsRepositoryTest extends DokanTestCase {
 
+    /**
+     * The autoloaded options cache leaks `dokan_admin_settings` writes
+     * between tests in this class — DB rollback restores the table but
+     * `alloptions` retains stale values. Combined with the BridgeBootstrap
+     * overlay filter that now intercepts every `get_option('dokan_*')` read,
+     * a leaked entry can mask the section-only assertions below.
+     *
+     * Explicitly clear both the option and the cache before each test so
+     * every case starts from a known empty new-flat state.
+     */
+    public function set_up() {
+        parent::set_up();
+        delete_option( 'dokan_admin_settings' );
+        wp_cache_delete( 'dokan_admin_settings', 'options' );
+        wp_cache_delete( 'alloptions', 'options' );
+        wp_cache_delete( 'notoptions', 'options' );
+        // DB rollback between tests doesn't fire `delete_option_*` hooks
+        // (the row is already gone), so the DI container's shared repository
+        // and bridge instances retain stale snapshots. Flush them all.
+        if ( function_exists( 'dokan_get_container' ) ) {
+            try {
+                dokan_get_container()
+                    ->get( \WeDevs\Dokan\Admin\Settings\Repository\SettingsRepository::class )
+                    ->flush_cache();
+                dokan_get_container()
+                    ->get( \WeDevs\Dokan\Admin\Settings\Repository\LegacySettingsRepository::class )
+                    ->flush_cache( null );
+                dokan_get_container()
+                    ->get( \WeDevs\Dokan\Admin\Settings\Migration\LegacySettingsBridge::class )
+                    ->flush_cache();
+            } catch ( \Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+                unset( $e );
+            }
+        }
+    }
+
     public function test_class_implements_interface(): void {
         $repo = new LegacySettingsRepository();
         $this->assertInstanceOf( LegacySettingsRepositoryInterface::class, $repo );

--- a/tests/php/src/REST/SettingsRoundTripTest.php
+++ b/tests/php/src/REST/SettingsRoundTripTest.php
@@ -72,20 +72,26 @@ class SettingsRoundTripTest extends DokanTestCase {
         delete_option( 'dokan_admin_settings' );
         delete_option( 'dokan_general' );
 
-        // Belt-and-suspenders: the production bootstrap (via
-        // `WeDevs_Dokan::init_hooks()`) already registers a
-        // `BridgeBootstrap` listener on `dokan_admin_settings_changed`.
-        // The test registers a second instance so reverse-propagation is
-        // guaranteed to fire even if the test environment skipped the
-        // hookable boot pass.
+        // The production bootstrap registers its overlay filters on the
+        // `init` action which has already fired by the time this test runs.
+        // Call `register_overlay_filters()` directly so reads in this test
+        // hit the overlay path.
         $bridge               = new LegacySettingsBridge();
         $this->test_bootstrap = new BridgeBootstrap( $bridge );
-        $this->test_bootstrap->register_hooks();
+        $this->test_bootstrap->register_overlay_filters();
     }
 
     public function tear_down() {
         if ( $this->test_bootstrap ) {
-            remove_action( 'dokan_admin_settings_changed', [ $this->test_bootstrap, 'on_settings_changed' ], 10 );
+            // The bootstrap registered overlay filters on every mapped
+            // section's `option_<name>` / `default_option_<name>` hooks.
+            // Remove them so they don't bleed into sibling tests.
+            global $wp_filter;
+            foreach ( array_keys( $wp_filter ) as $hook_name ) {
+                if ( strpos( $hook_name, 'option_dokan_' ) === 0 || strpos( $hook_name, 'default_option_dokan_' ) === 0 ) {
+                    remove_filter( $hook_name, [ $this->test_bootstrap, 'apply_overlay' ], 10 );
+                }
+            }
             $this->test_bootstrap = null;
         }
         delete_option( 'dokan_csv_schema_enabled' );
@@ -202,23 +208,28 @@ class SettingsRoundTripTest extends DokanTestCase {
             'REST PUT should have written the value into dokan_settings.'
         );
 
-        // Verify the BridgeBootstrap listener mirrored the change into the
-        // legacy `dokan_general` option.
+        // Under the new-as-canonical model, the legacy DB row is NOT
+        // back-written. Instead, the BridgeBootstrap overlay filter
+        // synthesizes the legacy shape on read by projecting mapped values
+        // from dokan_admin_settings. A direct `get_option('dokan_general')`
+        // therefore observes the new value through the filter, even though
+        // no row update occurred.
         $legacy = get_option( 'dokan_general', [] );
         $this->assertIsArray( $legacy );
         $this->assertSame(
             'mystorez',
             $legacy['custom_store_url'] ?? null,
-            'REST PUT must reverse-propagate through BridgeBootstrap to the legacy dokan_general.custom_store_url.'
+            'BridgeBootstrap overlay filter must project the new value into the legacy view.'
         );
     }
 
     /**
-     * Direct write of `dokan_settings` fires reverse propagation.
+     * Direct write of `dokan_settings` surfaces in legacy reads via overlay.
      *
-     * Isolates the `dokan_admin_settings_changed` listener from the REST
-     * stack: any code path that goes through the repository (REST
-     * controller, migration, addon, direct call) triggers the mirror.
+     * Any code path that writes the new flat option (REST controller,
+     * migration, addon, direct call) must be visible to direct
+     * `get_option('dokan_*')` readers via the read-time overlay filter
+     * installed by BridgeBootstrap. No DB-level mirror runs.
      *
      * @return void
      */
@@ -237,7 +248,7 @@ class SettingsRoundTripTest extends DokanTestCase {
         $this->assertSame(
             'reverse_value',
             $legacy['setup_wizard_logo_url'] ?? null,
-            'Repository update must mirror mapped keys to the legacy dokan_general option.'
+            'New-flat write must surface in get_option() via the overlay filter.'
         );
     }
 
@@ -280,13 +291,12 @@ class SettingsRoundTripTest extends DokanTestCase {
     }
 
     /**
-     * Round trip: legacy save -> new option -> legacy option matches.
+     * Round trip: legacy save -> new option -> legacy read sees fresh value.
      *
-     * Stitches the two halves together: the legacy AJAX bridge call
-     * writes the flat option, the bootstrap listener mirrors it back.
-     * Confirms the legacy option ends up with the same value after the
-     * full bidirectional trip — there is no shape drift between the two
-     * stores.
+     * Under the new-as-canonical model the legacy DB row is never back-
+     * written. The round-trip is verified via the read-time overlay:
+     * subsequent `get_option('dokan_general')` calls project the latest
+     * new-flat value into the returned array.
      *
      * @return void
      */
@@ -297,34 +307,31 @@ class SettingsRoundTripTest extends DokanTestCase {
             return;
         }
 
-        // 1. Legacy AJAX save path: write legacy then propagate to new.
-        $legacy_payload = [ 'setup_wizard_logo_url' => 'first_value' ];
-        update_option( 'dokan_general', $legacy_payload );
+        // 1. Legacy save path: mapped key lands in dokan_admin_settings,
+        //    legacy row holds the unmapped remainder only.
+        dokan_save_legacy_settings_section(
+            'dokan_general',
+            [ 'setup_wizard_logo_url' => 'first_value' ]
+        );
 
-        $bridge = new LegacySettingsBridge();
-        $slice  = $bridge->transform_legacy_payload_to_new( 'dokan_general', $legacy_payload );
-        $repo   = new \WeDevs\Dokan\Admin\Settings\Repository\SettingsRepository();
-        $repo->update( $slice );
-
-        // The bootstrap mirror fires on dokan_admin_settings_changed and writes
-        // back to dokan_general — but with the same value, so legacy stays
-        // consistent.
+        // Read via get_option — the overlay projects the new value back in.
         $legacy_after = get_option( 'dokan_general', [] );
         $this->assertSame(
             'first_value',
             $legacy_after['setup_wizard_logo_url'] ?? null,
-            'Legacy option survives the round-trip without value drift.'
+            'Legacy view reflects the new-flat write via the overlay filter.'
         );
 
-        // 2. Now write a NEW value via the repository only — legacy must
-        // catch up via the listener.
-        $repo->update( [ $vendor_field['id'] => 'second_value' ] );
+        // 2. Write a NEW value via the new-flat repository directly. Legacy
+        //    readers must observe the fresh value through the same overlay.
+        ( new \WeDevs\Dokan\Admin\Settings\Repository\SettingsRepository() )
+            ->update( [ $vendor_field['id'] => 'second_value' ] );
 
         $legacy_final = get_option( 'dokan_general', [] );
         $this->assertSame(
             'second_value',
             $legacy_final['setup_wizard_logo_url'] ?? null,
-            'New writes propagate back so legacy readers see the fresh value.'
+            'Subsequent new-flat writes surface in legacy reads via the overlay.'
         );
     }
 }


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation

### Changes proposed in this Pull Request:

Shifts the legacy settings model from **two-way mirror** to **new-as-canonical, legacy-as-derived**:

- **Writes** — mapped fields land in `dokan_admin_settings` (the canonical store). Each legacy `dokan_<section>` row holds the **unmapped remainder only**.
- **Reads** — `BridgeBootstrap` installs `option_<section>` filters that project values from the new flat option into the legacy view on read. Direct `get_option('dokan_general')` callers (Pro modules, third-party, internal helpers) transparently see the synthesized full payload.
- **Reverse mirror removed** — the previous `dokan_admin_settings_changed → write_new_to_legacy` listener is gone. Overlay-on-read handles propagation instead.

Mechanics:

```
                              writes
   Legacy writers (12 sites) ──────────► dokan_save_legacy_settings_section()
                                                  │
                                                  ▼
                                         LegacySettingsRepository::replace()
                                                  │
                       ┌─ SettingsRepository (mapped) ──► dokan_admin_settings  ◄── canonical
                       │
                       └─ strip_mapped_keys() ──► dokan_<section>  (unmapped only)
                                                          │
                  get_option('dokan_<section>') reads it ─┤
                                                          ▼
                                                option_<section> filter
                                                          │
                                                          ▼
                                  hydrate_legacy_from_new() projects mapped values
                                  back in ─► caller observes the full payload
```

### Detailed changes

**`LegacySettingsBridge`**
- `strip_mapped_keys($section, $payload)` — path-aware unset (1:1 + 1:N), empty-parent pruning.
- `persist_legacy_section($section, $payload)` — strip + mirror-to-new, returns the stripped legacy slice.
- `flush_cache()` — drops mapping memo and propagates flush to the internal `SettingsRepository`.

**`BridgeBootstrap`** (rewritten)
- Replaced `dokan_admin_settings_changed` mirror with `register_overlay_filters()` registered on `init` priority 999.
- Filters `option_<section>` and `default_option_<section>` for every section in the bridge mapping.
- Static reentry latch lets bridge's own internal reads see raw legacy data.

**`LegacySettingsRepository`**
- `update()` / `replace()` now route through `bridge->persist_legacy_section()`; legacy rows always converge on the strip invariant (defensively re-stripped on every write).
- Added `delete_option_<section>` listeners alongside existing `update_option_*` / `add_option_*` to flush snapshots on row removal.

**`SettingsRepository`**
- Added `delete_option_dokan_admin_settings` listener for snapshot consistency.

**`AdminSettingsServiceProvider`**
- Bound `SettingsRepositoryInterface` and `LegacySettingsRepositoryInterface` to their shared concretions so constructor injection lands on the same instance instead of spawning parallel snapshots.

**Writer migration** — all 12 legacy section writers route through the new helper:
- `dokan_save_legacy_settings_section($name, $payload)` in `includes/functions.php` (delegates to `LegacySettingsRepository::replace()`).
- Updated: `Admin/Settings.php` AJAX save, `SetupWizard.php` (4 sites), `OnboardingSetup/Steps/{Appearance,Basic,Commission,Withdraw}Step.php`, `Shortcodes/FullWidthVendorLayout.php`, `REST/AdminOnboardingController.php`, `Commission/Settings/GlobalSetting.php`, `Commission/Upugrader/Update_Category_Commission.php`, `Install/Installer.php`.

### How to test the changes in this Pull Request:

1. **Strip-on-write invariant**

   ```php
   // Save via legacy AJAX or Setup Wizard
   $ wp option get dokan_general --format=json
   // Mapped keys (e.g., disable_welcome_wizard, custom_store_url) MUST be absent
   $ wp option get dokan_admin_settings --format=json
   // Mapped keys land here (e.g., vendor_welcome_wizard_enabled, vendor_store_url)
   ```

2. **Overlay-on-read invariant**

   ```php
   $legacy = get_option( 'dokan_general' );
   // Returns synthesized array INCLUDING projected mapped keys
   ```

3. **Run the admin-settings test group**

   ```bash
   npm run phpunit -- --group admin-settings
   # Result: 256 tests, 5 failures — all 5 pre-existing on develop (schema-related)
   ```

### Changelog entry

**Title**

Settings: new flat option becomes the source of truth for mapped legacy fields

**Detailed Description of the pull request. What was previous behaviour and what will be changed in this PR.**

- **Before:** Legacy `dokan_<section>` options and the new flat `dokan_admin_settings` option each held copies of every mapped field. A two-way mirror in `BridgeBootstrap` kept them in sync. Direct DB writes by Pro or third-party code could cause silent drift between the two stores.
- **After:** Mapped fields live ONLY in `dokan_admin_settings`. Legacy section rows hold the unmapped remainder. Read-time overlay filters synthesize the legacy view from the new option on every `get_option()` call. Single source of truth, no drift possible.

### Before Changes
N/A — backend refactor, no UI surface.

### After Changes
N/A — backend refactor, no UI surface.

### Related context

- Builds on #3202 (LegacySettingsRepository scaffolding) and the settings-rebuild series.
- Targets `refactor/simplify-settings-to-flat-array` per the series integration branch convention.