### PR TITLE
fix(settings): update reverse-withdrawal dep tests to renamed field ids

### DIFF
--- a/tests/php/src/Admin/Settings/Schema/SettingsSchemaTest.php
+++ b/tests/php/src/Admin/Settings/Schema/SettingsSchemaTest.php
@@ -219,16 +219,16 @@ class SettingsSchemaTest extends DokanTestCase {
     }
 
     public function test_reverse_withdrawal_fields_have_correct_dependencies(): void {
-        $threshold = $this->find_element( 'reverse_balance_threshold', 'field' );
+        $threshold = $this->find_element( 'reverse_withdrawal_balance_threshold', 'field' );
 
         $this->assertNotNull( $threshold );
         $this->assertNotEmpty( $threshold['dependencies'] );
 
-        // Should depend on billing_type.
+        // Should depend on reverse_withdrawal_billing_type.
         $dep_keys = array_column( $threshold['dependencies'], 'key' );
         $this->assertTrue(
-            in_array( 'billing_type', $dep_keys, true ),
-            'reverse_balance_threshold should depend on billing_type (flat-key form).'
+            in_array( 'reverse_withdrawal_billing_type', $dep_keys, true ),
+            'reverse_withdrawal_balance_threshold should depend on reverse_withdrawal_billing_type (flat-key form).'
         );
     }
 

--- a/tests/php/src/Admin/Settings/Schema/ShowIfBehaviorTest.php
+++ b/tests/php/src/Admin/Settings/Schema/ShowIfBehaviorTest.php
@@ -163,7 +163,7 @@ class ShowIfBehaviorTest extends DokanTestCase {
     public function test_reverse_withdrawal_billing_type_dependencies_are_flat(): void {
         $threshold = null;
         foreach ( $this->schema as $element ) {
-            if ( ( $element['id'] ?? '' ) === 'reverse_balance_threshold'
+            if ( ( $element['id'] ?? '' ) === 'reverse_withdrawal_balance_threshold'
                 && ( $element['type'] ?? '' ) === 'field'
             ) {
                 $threshold = $element;
@@ -173,7 +173,7 @@ class ShowIfBehaviorTest extends DokanTestCase {
 
         $this->assertNotNull(
             $threshold,
-            'reverse_balance_threshold field must exist in the schema.'
+            'reverse_withdrawal_balance_threshold field must exist in the schema.'
         );
         $this->assertArrayHasKey( 'dependencies', $threshold );
         $this->assertNotEmpty( $threshold['dependencies'] );
@@ -181,16 +181,16 @@ class ShowIfBehaviorTest extends DokanTestCase {
         $dep_keys = array_column( $threshold['dependencies'], 'key' );
 
         $this->assertContains(
-            'billing_type',
+            'reverse_withdrawal_billing_type',
             $dep_keys,
-            'reverse_balance_threshold should depend on the flat key `billing_type`.'
+            'reverse_withdrawal_balance_threshold should depend on the flat key `reverse_withdrawal_billing_type`.'
         );
 
         foreach ( $dep_keys as $dep_key ) {
             $this->assertStringNotContainsString(
                 '.',
                 (string) $dep_key,
-                "reverse_balance_threshold dependency key '{$dep_key}' must be flat, not dot-path."
+                "reverse_withdrawal_balance_threshold dependency key '{$dep_key}' must be flat, not dot-path."
             );
         }
     }


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation

### Changes proposed in this Pull Request:

Two dependency-integrity tests fell out of sync when PR #3218 renamed the reverse-withdrawal schema field ids:

| Old id | New id |
|---|---|
| \`reverse_balance_threshold\` | \`reverse_withdrawal_balance_threshold\` |
| \`billing_type\` | \`reverse_withdrawal_billing_type\` |

The renames landed in the schema and Playwright e2e files, but two PHPUnit tests still asserted against the old ids:

- \`tests/php/src/Admin/Settings/Schema/SettingsSchemaTest.php::test_reverse_withdrawal_fields_have_correct_dependencies\`
- \`tests/php/src/Admin/Settings/Schema/ShowIfBehaviorTest.php::test_reverse_withdrawal_billing_type_dependencies_are_flat\`

Both updated to reference the new ids. The assertion shape is unchanged — each test continues to verify the field exists, has dependencies, and that dependency keys are flat (no dot-paths).

### Related Pull Request(s)

* Source of the rename: PR #3218 (\`chore(settings): sync SettingsSchema field-id renames from accessor-api\`).

### How to test the changes in this Pull Request:

\`\`\`bash
npm run phpunit -- --group admin-settings
\`\`\`

**Before:** 256 tests, 5 failures
**After:**  256 tests, 3 failures (the three remaining are unrelated pre-existing schema/AI issues — unknown variants, \`danger_switch\` field, AI payload pollution test)

### Changelog entry

**Title**

Tests: align reverse-withdrawal dependency tests with renamed field ids

**Detailed Description**

- **Before:** Two dependency-integrity tests asserted against \`reverse_balance_threshold\` / \`billing_type\` after the schema renamed those ids to the \`reverse_withdrawal_*\` prefix wave.
- **After:** Both tests reference the new ids and pass cleanly.

### Before Changes
N/A — test-only update, no UI or runtime surface.

### After Changes
N/A — test-only update, no UI or runtime surface.