### PR TITLE
fix(settings): route Installer fresh-install page seed through helper

### DIFF
--- a/includes/Install/Installer.php
+++ b/includes/Install/Installer.php
@@ -284,7 +284,7 @@ class Installer {
             }
         }
 
-        update_option( 'dokan_pages', $dokan_page_settings );
+        dokan_save_legacy_settings_section( 'dokan_pages', $dokan_page_settings );
         update_option( 'dokan_pages_created', true );
     }
 


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation

### Changes proposed in this Pull Request:

\`Installer::create_dokan_pages()\` writes the seeded page-id map directly via \`update_option('dokan_pages', \$dokan_page_settings)\`. Because \`dokan_pages\` has multiple \`legacy_key\` declarations (\`dashboard\`, \`my_orders\`, \`store_listing\`, etc.), this raw write bypasses the strip-on-write invariant set up by the new settings model: mapped page ids land back in the legacy row after the install completes, defeating the source-of-truth guarantee.

Routes the call through \`dokan_save_legacy_settings_section()\` so:
- Mapped fields mirror into \`dokan_admin_settings\` (canonical).
- The legacy \`dokan_pages\` row holds only unmapped fields after the seed completes.

The sibling write at \`Installer.php:151\` already uses the helper; this catches the parallel call in \`create_dokan_pages()\` at line 287.

### Related Pull Request(s)

* Follow-up to PR #3217 (strip-on-write / overlay-on-read) and PR #5669 (Pro writer routing).
* Surfaced by the settings-access inventory (\`/.planning/settings-inventory.md\`) as an active-leak site.

### How to test the changes in this Pull Request:

\`\`\`bash
npm run phpunit -- --group admin-settings
\`\`\`

Result: 256 tests, 2 failures — baseline unchanged (the 2 remaining are unrelated pre-existing schema/AI issues).

For manual verification: on a fresh install, observe that \`wp option get dokan_pages --format=json\` contains only unmapped keys after the installer runs, while \`wp option get dokan_admin_settings --format=json\` carries the mapped page ids (\`dashboard\`, \`my_orders\`, \`store_listing\`, etc.).

### Changelog entry

**Title**

Settings: route fresh-install \`dokan_pages\` seed through the new settings helper

**Detailed Description**

- **Before:** Fresh install raw-wrote \`dokan_pages\` after seeding pages, leaving mapped fields in both the legacy row AND the new flat option.
- **After:** Mapped fields are stripped from the legacy row at install time; canonical storage stays in \`dokan_admin_settings\`.

### Before Changes
N/A — backend, no UI surface.

### After Changes
N/A — backend, no UI surface.