### PR TITLE
fix(settings): update data_clear test to match danger_switch variant

### DIFF
--- a/tests/php/src/Admin/Settings/Schema/SettingsSchemaTest.php
+++ b/tests/php/src/Admin/Settings/Schema/SettingsSchemaTest.php
@@ -210,9 +210,12 @@ class SettingsSchemaTest extends DokanTestCase {
         $field = $this->find_element( 'data_clear_on_uninstall', 'field' );
 
         $this->assertNotNull( $field );
-        $this->assertSame( 'switch', $field['variant'] );
-        $this->assertTrue( $field['should_confirm'] );
-        $this->assertSame( 'error', $field['switcher_type'] );
+
+        // The schema uses a `danger_switch` variant that subsumes the old
+        // `switch` + `should_confirm: true` + `switcher_type: 'error'`
+        // combination. The variant alone signals the destructive-action
+        // styling; only the modal copy is still declared inline.
+        $this->assertSame( 'danger_switch', $field['variant'] );
         $this->assertArrayHasKey( 'confirm_modal', $field );
         $this->assertArrayHasKey( 'title', $field['confirm_modal'] );
         $this->assertArrayHasKey( 'confirmText', $field['confirm_modal'] );


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation

### Changes proposed in this Pull Request:

\`SettingsSchemaTest::test_data_clear_field_has_confirm_modal\` was written against the old field shape that combined a \`switch\` variant with separate \`should_confirm: true\` and \`switcher_type: 'error'\` flags. The schema has since consolidated those three signals into a single \`danger_switch\` variant — the variant alone expresses the destructive-action styling, and only the \`confirm_modal\` copy is declared separately.

Test updated to assert against the new shape:
- \`variant === 'danger_switch'\`
- \`confirm_modal\` array still present with \`title\` and \`confirmText\`

Dropped the \`should_confirm\` and \`switcher_type\` assertions since the underlying schema no longer carries those keys — they are implied by the variant.

\`danger_switch\` is registered as a known variant in \`SchemaValidator\` (PR #3220) and renders via the corresponding \`addFilter('dokan_settings_danger_switch_field', ...)\` hook in \`src/admin/dashboard/pages/settings/register-fields.tsx\`.

### Related Pull Request(s)

* Companion polish to PRs #3217, #3218, #3219, #3220, #3221 in the settings-rebuild series.

### How to test the changes in this Pull Request:

\`\`\`bash
npm run phpunit -- --group admin-settings
\`\`\`

**Before:** 256 tests, 2 failures
**After:**  256 tests, 1 failure (the remaining one is the unrelated AI legacy-save payload-pollution test)

### Changelog entry

**Title**

Tests: align data-clear field test with the consolidated \`danger_switch\` variant

**Detailed Description**

- **Before:** Test asserted against a \`switch\` variant plus three separate flags (\`should_confirm\`, \`switcher_type\`) that the schema no longer carries.
- **After:** Test asserts against the consolidated \`danger_switch\` variant. The \`confirm_modal\` array is still validated.

### Before Changes
N/A — test-only update, no UI or runtime surface.

### After Changes
N/A — test-only update, no UI or runtime surface.