### PR TITLE
fix(settings): isolate AI bridge drift test from schema overlaps

### DIFF
--- a/tests/php/src/Admin/Settings/Schema/Tab/AiAssistSchemaTest.php
+++ b/tests/php/src/Admin/Settings/Schema/Tab/AiAssistSchemaTest.php
@@ -199,9 +199,13 @@ class AiAssistSchemaTest extends DokanTestCase {
 
         $first = $tab_fields[0];
 
-        $map_filter = function ( $map ) use ( $first ) {
-            $map[ $first['id'] ] = $first['legacy_key'];
-            return $map;
+        // Replace the entire mapping (rather than amend) so the bridge sees
+        // exactly one declared mapping. The hand-authored schema declares
+        // `ai_product_info_engine` against the same legacy address as the
+        // CSV-derived field we're testing, which would otherwise inflate
+        // the slice. Test isolation requires owning the full map here.
+        $map_filter = function () use ( $first ) {
+            return [ $first['id'] => $first['legacy_key'] ];
         };
         add_filter( 'dokan_legacy_settings_key_mapping', $map_filter );
 
@@ -212,8 +216,7 @@ class AiAssistSchemaTest extends DokanTestCase {
             // payload includes both a real declared field AND an attacker
             // drift key. The bridge MUST filter to declared mappings only,
             // protecting `dokan_settings` from inheriting the historical
-            // `dokan_ai_chatgpt_*` schema drift documented in the trace
-            // report (lines 401-402).
+            // `dokan_ai_chatgpt_*` schema drift.
             $payload = [
                 $first['legacy_key']['field']     => 'real-value',
                 '__attacker_drift_legacy_field__' => 'drift-value',
@@ -228,6 +231,9 @@ class AiAssistSchemaTest extends DokanTestCase {
                 $slice,
                 'Unknown legacy keys must not pollute the new-option slice; expected exactly one declared field.'
             );
+            // Drift key uses the legacy field name; the new-option slice is
+            // keyed by new flat ids, so this assertion is a belt-and-braces
+            // check that no garbage propagated under either naming.
             $this->assertArrayNotHasKey(
                 '__attacker_drift_legacy_field__',
                 $slice,


### PR DESCRIPTION
### All Submissions:

* [x] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [x] My code satisfies feature requirements
* [x] My code is tested
* [x] My code passes the PHPCS tests
* [x] My code has proper inline documentation

### Changes proposed in this Pull Request:

\`test_unknown_payload_key_in_legacy_save_does_not_pollute_new_option\` was failing because the hand-authored schema declares \`ai_product_info_engine\` against the same legacy address (\`dokan_ai.dokan_ai_engine\`) as the CSV-derived field the test seeds. With both mappings live, the bridge correctly emitted the value for both new ids, inflating the slice to size 2 and tripping the size-1 assertion.

The test's intent — verify the bridge filters legacy payloads to declared mappings, blocking attacker-drift keys from polluting the new option — is still valuable. The fix is to make the test **isolate** its view of the map: the filter now returns a SINGLE-entry map (replacing the schema-derived one) so the assertions hold regardless of how many other declared mappings exist against the same legacy address.

### Latent schema concern (flagged, out of scope here)

Multiple \`legacy_key\` declarations pointing at the same legacy address is structurally ambiguous:
- A legacy write becomes ambiguous (which new id "owns" the canonical value?).
- A new-UI write to one mapping leaves the other stale.

This manifests today only when \`dokan_csv_schema_enabled\` is ON (which production has OFF by default), so it's not an active bug. Worth catching in \`SchemaValidator\` as a future hardening — emit a warning when two fields declare the same \`legacy_key\`.

### Related Pull Request(s)

* Last entry in the pre-existing-test-failure cleanup series: PR #3219 (rename), PR #3220 (variants), PR #3222 (danger_switch).
* Source of the audit: \`/.planning/settings-inventory.md\`.

### How to test the changes in this Pull Request:

\`\`\`bash
npm run phpunit -- --group admin-settings
\`\`\`

**Before:** 256 tests, 1 failure
**After:**  256 tests, 0 failures — **full green** on the admin-settings group.

### Changelog entry

**Title**

Tests: isolate the AI bridge drift test from unrelated schema overlaps

**Detailed Description**

- **Before:** Test failed when the hand-authored schema declared a duplicate \`legacy_key\` against the same legacy address as the test's seeded CSV field, inflating the bridge slice.
- **After:** The test's filter replaces the bridge mapping with its single entry, isolating the assertion from schema co-declarations and restoring the security intent (drift keys must not leak into the new-option slice).

### Before Changes
N/A — test-only update, no UI or runtime surface.

### After Changes
N/A — test-only update, no UI or runtime surface.